### PR TITLE
Refine scroll momentum handoff for synchronized card pulses

### DIFF
--- a/1-index.html
+++ b/1-index.html
@@ -1164,5 +1164,7 @@
             });
         });
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/10-pr-4.html
+++ b/10-pr-4.html
@@ -346,5 +346,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/11-pr-5.html
+++ b/11-pr-5.html
@@ -443,5 +443,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
-  </body>
+  
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
+</body>
 </html>

--- a/12-pr-6.html
+++ b/12-pr-6.html
@@ -386,5 +386,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/13-pr-7.html
+++ b/13-pr-7.html
@@ -2110,5 +2110,7 @@
         });
         
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/14-pr-8.html
+++ b/14-pr-8.html
@@ -381,5 +381,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/15-pr-9.html
+++ b/15-pr-9.html
@@ -361,5 +361,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/16-pr-10.html
+++ b/16-pr-10.html
@@ -334,5 +334,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/17-pr-11.html
+++ b/17-pr-11.html
@@ -338,5 +338,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/18-pr-12.html
+++ b/18-pr-12.html
@@ -157,5 +157,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/19-pr-13.html
+++ b/19-pr-13.html
@@ -344,5 +344,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/2-index-optimized.html
+++ b/2-index-optimized.html
@@ -645,5 +645,7 @@
     });
   </script>
 
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/20-pr-14.html
+++ b/20-pr-14.html
@@ -185,5 +185,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/21-pr-15.html
+++ b/21-pr-15.html
@@ -767,5 +767,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/22-pr-16.html
+++ b/22-pr-16.html
@@ -319,5 +319,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/23-pr-17.html
+++ b/23-pr-17.html
@@ -298,5 +298,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/24-pr-18.html
+++ b/24-pr-18.html
@@ -310,5 +310,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/25-orthogonal-depth-progression.html
+++ b/25-orthogonal-depth-progression.html
@@ -388,5 +388,7 @@
         });
     </script>
 
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/25-pr-19.html
+++ b/25-pr-19.html
@@ -299,5 +299,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/26-pr-20.html
+++ b/26-pr-20.html
@@ -662,5 +662,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/27-pr-21.html
+++ b/27-pr-21.html
@@ -561,5 +561,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/28-pr-22.html
+++ b/28-pr-22.html
@@ -859,5 +859,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/29-pr-23.html
+++ b/29-pr-23.html
@@ -846,5 +846,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/3-index-fixed.html
+++ b/3-index-fixed.html
@@ -201,5 +201,7 @@
         
         console.log('🔥 Clear Seas FIXED System - Preset lab removed, proper VIB34D URLs');
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/30-pr-24.html
+++ b/30-pr-24.html
@@ -861,5 +861,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/4-index-unified.html
+++ b/4-index-unified.html
@@ -223,5 +223,7 @@
         
         console.log('🧪 Clear Seas Unified System - Test page loaded');
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/5-index-vib34d-integrated.html
+++ b/5-index-vib34d-integrated.html
@@ -379,5 +379,7 @@
             }
         })();
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/6-index-totalistic.html
+++ b/6-index-totalistic.html
@@ -961,5 +961,7 @@
             }
         });
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html><!-- GitHub Pages deployment trigger Thu Sep  4 11:46:16 EDT 2025 -->

--- a/7-pr-1.html
+++ b/7-pr-1.html
@@ -267,5 +267,7 @@
     </footer>
 
     <script src="scripts/clear-seas-home.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/8-pr-2.html
+++ b/8-pr-2.html
@@ -240,5 +240,7 @@
     </div>
 
     <script src="scripts/orbital-field.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/9-pr-3.html
+++ b/9-pr-3.html
@@ -262,5 +262,7 @@
             }
         });
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/ULTIMATE-clear-seas-holistic-system.html
+++ b/ULTIMATE-clear-seas-holistic-system.html
@@ -872,5 +872,7 @@
         });
     </script>
 
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/docs/html-version-groups.md
+++ b/docs/html-version-groups.md
@@ -1,0 +1,46 @@
+# HTML Version Collections
+
+This manifest groups every published HTML experience by the layout framework, shared stylesheets, and JavaScript orchestration they rely on. Use it as a quick map when deciding which builds to compare or extend together.
+
+## Core System Foundation (1–6)
+These flagship builds establish the production-ready stack, moving from the launch deck through unified and totalistic orchestration layers.
+
+- **`1-index.html` – AI Innovation Portfolio**  
+  *Stack:* `scripts/vib34d-contained-card-system.js`.  
+  *Focus:* Flagship trading-card portfolio with the contained VIB34D card system.
+- **`2-index-optimized.html` – Performance Enhanced Core**  
+  *Stack:* `styles/consolidated-styles.css` + `scripts/enhanced-master-conductor.js`, `scripts/main.js`, `scripts/mobile-navigation-injector.js`, `scripts/unified-experience-engine.js`, `scripts/vib34d-contained-card-system.js`, `scripts/zone-visualizers.js`.  
+  *Focus:* Speed-tuned navigation with synchronized canvas zones.
+- **`3-index-fixed.html` – Stabilized System**  
+  *Stack:* `styles/consolidated-styles.css` + `scripts/polytopal-reactivity-json.js`.  
+  *Focus:* Hardens the fixed-layout controls and reactivity JSON pipeline.
+- **`4-index-unified.html` – Unified Architecture**  
+  *Stack:* `styles/consolidated-styles.css` + `scripts/polytopal-reactivity-json.js`, `scripts/preset-laboratory.js`.  
+  *Focus:* Brings disparate modules under a single preset lab configuration.
+- **`5-index-vib34d-integrated.html` – Advanced VIB34D Integration**  
+  *Stack:* layered base/animations/reactivity styles with `js/audio/audio-engine.js`, `js/controls/ui-handlers.js`, `js/core/url-params.js`, `js/gallery/gallery-manager.js`, `js/interactions/device-tilt.js`.  
+  *Focus:* Full VIB34D integration with audio, gallery, and tilt controls.
+- **`6-index-totalistic.html` – Totalistic Experience**  
+  *Stack:* `styles/consolidated-styles.css` + `scripts/core-engine.js`, `scripts/polytopal-reactivity-json.js`, `scripts/unified-experience-engine.js`, `scripts/vib34d-contained-card-system.js`.  
+  *Focus:* Total-system choreography that threads every engine together.
+
+## Immersive AI Command Deck Collection (PR #4–#24)
+All of these prototypes load `styles/clear-seas-ai.css` and `scripts/clear-seas-ai.js`, delivering the mission-axis navigation, translucent orb canvases, and scroll-synced scene choreography used across the modern marketing journey. Iterate within this collection to explore copy, choreography, and module density without changing the underlying framework.
+
+- **Launch Arc (PR #4–#6):** `10-pr-4.html`, `11-pr-5.html`, `12-pr-6.html`.
+- **Experience Refinements (PR #8–#14):** `14-pr-8.html`, `15-pr-9.html`, `16-pr-10.html`, `17-pr-11.html`, `18-pr-12.html`, `19-pr-13.html`, `20-pr-14.html`.
+- **Blueprint & Deck Explorations (PR #15–#18):** `21-pr-15.html`, `22-pr-16.html`, `23-pr-17.html`, `24-pr-18.html`.
+- **Holographic Depth Studies (PR #19–#24):** `25-pr-19.html`, `26-pr-20.html`, `27-pr-21.html`, `28-pr-22.html`, `29-pr-23.html`, `30-pr-24.html` (adds `scripts/immersive-experience-actualizer.js` for amplified choreography).
+
+## Concept Labs & Special Studies
+These builds experiment with alternative canvases, typography systems, or research tooling outside of the shared AI stack.
+
+- **`7-pr-1.html` – Polytopal Home Experience:** Combines `styles/clear-seas-home.css` & `styles/main.css` with `scripts/clear-seas-home.js` to keep the original particle field and narrative-led navigation.
+- **`8-pr-2.html` – Avant-garde AI Landing:** Uses `styles/avant-garde.css` with `scripts/orbital-field.js` for a cinematic orbiting hero.
+- **`9-pr-3.html` – Clear Seas Intelligence Homepage:** Blends `styles/clear-seas-ai.css` with `styles/main.css` for a hybrid presentation that bridges the home and mission-axis directions.
+- **`13-pr-7.html` – Visual Codex Gallery:** Inline neon codex with 4D polytopal backgrounds and crystalline gallery narration.
+- **`25-orthogonal-depth-progression.html` – Orthogonal Depth Lab:** Couples `scripts/orthogonal-depth-progression.js` with `scripts/vib34d-geometric-tilt-system.js` to map scroll to holographic tilt.
+- **`ULTIMATE-clear-seas-holistic-system.html` – Ultimate Holistic System:** Runs the `scripts/ultimate-holistic-vib34d-system.js` choreography for a maximal VIB34D showcase.
+
+## Meta
+- **`index.html`** now surfaces these collections with descriptive section copy, meta chips, and lab highlights so teams can jump directly into comparable builds.

--- a/index.html
+++ b/index.html
@@ -61,6 +61,34 @@
             margin-bottom: 40px;
         }
 
+        .section-header {
+            margin-bottom: 25px;
+        }
+
+        .section-intro {
+            margin-top: 12px;
+            font-size: 0.95rem;
+            line-height: 1.7;
+            color: rgba(255, 255, 255, 0.85);
+        }
+
+        .section-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 18px;
+        }
+
+        .meta-chip {
+            padding: 6px 14px;
+            border-radius: 999px;
+            font-size: 0.72rem;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            background: rgba(255, 255, 255, 0.12);
+            border: 1px solid rgba(255, 255, 255, 0.24);
+        }
+
         .section-title {
             font-size: 1.4rem;
             font-weight: bold;
@@ -153,6 +181,12 @@
             color: #93c5fd;
         }
 
+        .lab-version .status-badge {
+            background: rgba(236, 72, 153, 0.18);
+            border: 1px solid rgba(244, 114, 182, 0.35);
+            color: #f9a8d4;
+        }
+
         .footer {
             text-align: center;
             margin-top: 40px;
@@ -178,13 +212,16 @@
         <div class="header">
             <div class="logo">🌊 Clear Seas Solutions</div>
             <div class="subtitle">Complete Multi-Version Deployment System</div>
-            <div class="count">30 Total Versions • 6 Main + 24 PR Branches</div>
+            <div class="count">32 Total Experiences • 6 Core + 24 PR Branches + 2 Labs</div>
             <p>Explore different iterations and compare approaches side-by-side</p>
         </div>
 
         <!-- MAIN HTML VERSIONS (1-6) -->
         <div class="section">
-            <div class="section-title">Core HTML Versions (1-6)</div>
+            <div class="section-header">
+                <div class="section-title">Core HTML Versions (1-6)</div>
+                <p class="section-intro">Flagship builds that establish the production architecture, performance tuning, unified layouts, VIB34D integration, and the fully orchestrated totalistic experience.</p>
+            </div>
             <div class="version-grid">
                 <div class="version-card main-version">
                     <div class="version-number">01</div>
@@ -248,30 +285,18 @@
             </div>
         </div>
 
-        <!-- PR BRANCH VERSIONS (8-30) -->
+        <!-- IMMERSIVE AI COMMAND DECK COLLECTION -->
         <div class="section">
-            <div class="section-title">PR Branch Versions (8-30)</div>
+            <div class="section-header">
+                <div class="section-title">Immersive AI Command Deck Collection (PR 4–24)</div>
+                <p class="section-intro">Interlinked prototypes that share the Clear Seas AI mission-axis layout, translucent orb fields, and synchronized scroll choreography. Use this collection to compare how narrative emphasis, staging density, and conversion flows evolve while the underlying CSS and JS stack stays consistent.</p>
+                <div class="section-meta">
+                    <span class="meta-chip">Shared CSS: styles/clear-seas-ai.css</span>
+                    <span class="meta-chip">Shared JS: scripts/clear-seas-ai.js</span>
+                    <span class="meta-chip">PR Variants: #4 – #24 (excludes special labs)</span>
+                </div>
+            </div>
             <div class="version-grid">
-                <div class="version-card pr-version">
-                    <div class="version-number">08</div>
-                    <div class="status-badge">PR #2</div>
-                    <div class="version-title">Avant-garde AI Landing Page</div>
-                    <div class="version-description">
-                        Create avant-garde AI consulting landing page with intelligent design and sophisticated interactions.
-                    </div>
-                    <a href="./8-pr-2.html" class="version-link">Launch Version</a>
-                </div>
-
-                <div class="version-card pr-version">
-                    <div class="version-number">09</div>
-                    <div class="status-badge">PR #3</div>
-                    <div class="version-title">Clear Seas Intelligence Homepage</div>
-                    <div class="version-description">
-                        Design new Clear Seas Intelligence AI consulting homepage with advanced geometric cognition features.
-                    </div>
-                    <a href="./9-pr-3.html" class="version-link">Launch Version</a>
-                </div>
-
                 <div class="version-card pr-version">
                     <div class="version-number">10</div>
                     <div class="status-badge">PR #4</div>
@@ -300,16 +325,6 @@
                         Create immersive Clear Seas AI experience with advanced geometric processing and holographic elements.
                     </div>
                     <a href="./12-pr-6.html" class="version-link">Launch Version</a>
-                </div>
-
-                <div class="version-card pr-version">
-                    <div class="version-number">13</div>
-                    <div class="status-badge">PR #7</div>
-                    <div class="version-title">Clear Seas AI Consulting</div>
-                    <div class="version-description">
-                        Create Clear Seas AI consulting experience with refined visual codex and navigation systems.
-                    </div>
-                    <a href="./13-pr-7.html" class="version-link">Launch Version</a>
                 </div>
 
                 <div class="version-card pr-version">
@@ -351,7 +366,6 @@
                     </div>
                     <a href="./17-pr-11.html" class="version-link">Launch Version</a>
                 </div>
-
 
                 <div class="version-card pr-version">
                     <div class="version-number">18</div>
@@ -485,11 +499,85 @@
             </div>
         </div>
 
+        <!-- DISTINCT CONCEPT LABS & SPECIAL STUDIES -->
+        <div class="section">
+            <div class="section-header">
+                <div class="section-title">Concept Labs &amp; Special Studies</div>
+                <p class="section-intro">Exploratory builds that diverge from the mission-axis system to investigate alternate visual systems, stacked canvases, and high-energy holographic research environments.</p>
+                <div class="section-meta">
+                    <span class="meta-chip">Unique frameworks outside the shared AI stack</span>
+                </div>
+            </div>
+            <div class="version-grid">
+                <div class="version-card pr-version lab-version">
+                    <div class="version-number">07</div>
+                    <div class="status-badge">PR #1</div>
+                    <div class="version-title">Polytopal Home Experience</div>
+                    <div class="version-description">
+                        Canvas-driven homepage that pairs clear narrative lanes with the original polytopal particle field and responsive navigation.
+                    </div>
+                    <a href="./7-pr-1.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card pr-version lab-version">
+                    <div class="version-number">08</div>
+                    <div class="status-badge">PR #2</div>
+                    <div class="version-title">Avant-garde AI Landing Page</div>
+                    <div class="version-description">
+                        Create avant-garde AI consulting landing page with intelligent design and sophisticated interactions.
+                    </div>
+                    <a href="./8-pr-2.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card pr-version lab-version">
+                    <div class="version-number">09</div>
+                    <div class="status-badge">PR #3</div>
+                    <div class="version-title">Clear Seas Intelligence Homepage</div>
+                    <div class="version-description">
+                        Design new Clear Seas Intelligence AI consulting homepage with advanced geometric cognition features.
+                    </div>
+                    <a href="./9-pr-3.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card pr-version lab-version">
+                    <div class="version-number">13</div>
+                    <div class="status-badge">PR #7</div>
+                    <div class="version-title">Visual Codex Gallery</div>
+                    <div class="version-description">
+                        Fixed-layout neon codex that experiments with 4D polytopal backgrounds, crystalline palettes, and gallery-style narration.
+                    </div>
+                    <a href="./13-pr-7.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card lab-version">
+                    <div class="version-number">L1</div>
+                    <div class="status-badge">LAB</div>
+                    <div class="version-title">Orthogonal Depth Progression</div>
+                    <div class="version-description">
+                        Experimental camera lab that maps orthogonal scroll momentum into layered holographic tilt systems.
+                    </div>
+                    <a href="./25-orthogonal-depth-progression.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card lab-version">
+                    <div class="version-number">L2</div>
+                    <div class="status-badge">LAB</div>
+                    <div class="version-title">Ultimate Holistic System</div>
+                    <div class="version-description">
+                        Unified VIB34D showcase that activates the ultimate holistic choreography script across canvases and overlays.
+                    </div>
+                    <a href="./ULTIMATE-clear-seas-holistic-system.html" class="version-link">Launch Version</a>
+                </div>
+            </div>
+        </div>
+
         <div class="footer">
             <p><strong>Clear Seas Solutions Multi-Version Deployment</strong></p>
             <p>Compare approaches • Test interactions • Evaluate different design directions</p>
             <p style="margin-top: 15px; opacity: 0.5;">© 2025 Paul Phillips - Clear Seas Solutions LLC</p>
         </div>
     </div>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/scripts/card-specific-vib34d-visualizer.js
+++ b/scripts/card-specific-vib34d-visualizer.js
@@ -512,13 +512,31 @@ class CardSpecificVIB34DVisualizer {
       const rect = this.cardElement.getBoundingClientRect();
       const x = (e.clientX - rect.left) / rect.width;
       const y = (e.clientY - rect.top) / rect.height;
-      
-      this.updateInteraction(x, y, 0.5);
-      
+
+      const tiltX = (0.5 - y) * 2;
+      const tiltY = (x - 0.5) * 2;
+      const pointerMagnitude = Math.min(1.2, Math.hypot(tiltX, tiltY));
+      const bendStrength = Math.min(1, 0.18 + pointerMagnitude * 0.6);
+      const bendTiltX = -tiltX * 12 * bendStrength;
+      const bendTiltY = tiltY * 14 * bendStrength;
+      const bendSkewX = -tiltY * 6 * bendStrength;
+      const bendSkewY = tiltX * 5 * bendStrength;
+      const bendTwist = tiltX * tiltY * 16 * bendStrength;
+      const bendDepth = bendStrength * 28;
+
+      this.updateInteraction(x, y, bendStrength);
+
       // Update CSS custom properties for card transforms
       this.cardElement.style.setProperty('--mouse-x', (x * 100) + '%');
       this.cardElement.style.setProperty('--mouse-y', (y * 100) + '%');
-      this.cardElement.style.setProperty('--bend-intensity', this.mouseIntensity);
+      this.cardElement.style.setProperty('--bend-intensity', bendStrength.toFixed(3));
+      this.cardElement.style.setProperty('--bend-tilt-x-deg', `${bendTiltX.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-tilt-y-deg', `${bendTiltY.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-skew-x-deg', `${bendSkewX.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-skew-y-deg', `${bendSkewY.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-twist-deg', `${bendTwist.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-depth', `${bendDepth.toFixed(3)}px`);
+      this.cardElement.style.setProperty('--visualizer-bend-depth', `${(bendDepth * 0.6).toFixed(3)}px`);
     });
     
     // Click interactions
@@ -540,11 +558,18 @@ class CardSpecificVIB34DVisualizer {
       this.cardElement.classList.remove('visualizer-active');
       this.reactivity = 1.0;
       this.mouseIntensity *= 0.8; // Gradual fade
-      
+
       // Reset CSS transforms
       this.cardElement.style.setProperty('--mouse-x', '50%');
       this.cardElement.style.setProperty('--mouse-y', '50%');
       this.cardElement.style.setProperty('--bend-intensity', '0');
+      this.cardElement.style.setProperty('--bend-tilt-x-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-tilt-y-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-skew-x-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-skew-y-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-twist-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-depth', '0px');
+      this.cardElement.style.setProperty('--visualizer-bend-depth', '0px');
     });
   }
   

--- a/scripts/card-system-initializer.js
+++ b/scripts/card-system-initializer.js
@@ -41,7 +41,40 @@ class CardSystemController {
         colorScheme: 'portfolio'
       }
     };
-    
+
+    this.brandAssets = {
+      images: [
+        'assets/Screenshot_20250430-141821.png',
+        'assets/Screenshot_20241012-073718.png',
+        'assets/Screenshot_20250430-142024~2.png',
+        'assets/Screenshot_20250430-142002~2.png',
+        'assets/Screenshot_20250430-142032~2.png',
+        'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+        'assets/file_0000000054a06230817873012865d150.png',
+        'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+        'assets/image_8 (1).png'
+      ],
+      videos: [
+        '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+        '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+        '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+        '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+        '1746496560073.mp4',
+        '1746500614769.mp4',
+        '1746576068221.mp4'
+      ]
+    };
+
+    this.brandAssignmentIndex = 0;
+    this.scrollTilt = 0;
+    this.scrollTiltTarget = 0;
+    this.scrollTiltRaf = null;
+    this.scrollMomentum = 0;
+
+    this.ensureBrandStyles();
+    this.setupScrollTiltSync();
+    this.applyScrollTiltToCards(this.scrollTilt);
+
     console.log('🎨 Card System Controller initialized');
   }
   
@@ -80,7 +113,24 @@ class CardSystemController {
       element: cardElement,
       config: config,
       visualizers: new Map(),
-      active: false
+      active: false,
+      focusIntensity: 0,
+      clickPulse: 0,
+      pointer: {
+        rawX: 0.5,
+        rawY: 0.5,
+        smoothX: 0.5,
+        smoothY: 0.5,
+        bendTarget: 0.12,
+        bendSmooth: 0.12,
+        twistTarget: 0,
+        twistSmooth: 0
+      },
+      layers: {
+        overlay: null,
+        video: null
+      },
+      reactiveElements: []
     };
     
     // Create visualizers for each role
@@ -108,8 +158,12 @@ class CardSystemController {
     
     // Setup card-specific interactions
     this.setupCardInteractions(cardElement, cardData);
-    
+    this.decorateCard(cardElement, cardData);
+    this.registerReactiveElements(cardData);
+    this.startCardSynergyLoop(cardData);
+
     this.cards.set(cardId, cardData);
+    this.applyScrollTiltToCards(this.scrollTilt);
   }
   
   applyCardConfiguration(visualizer, config, role) {
@@ -149,6 +203,545 @@ class CardSystemController {
       visualizer.roleParams.intensity *= roleIntensityMods[role];
     }
   }
+
+  decorateCard(cardElement, cardData) {
+    if (!cardElement || cardElement.dataset.brandDecorated === 'true') return;
+
+    cardElement.dataset.brandDecorated = 'true';
+    cardElement.classList.add('card-brand-enhanced');
+    cardElement.dataset.focusState = cardElement.dataset.focusState || 'idle';
+    cardElement.style.setProperty('--scroll-tilt', this.scrollTilt.toFixed(4));
+    cardElement.style.setProperty('--visualizer-scroll-tilt', this.scrollTilt.toFixed(4));
+    cardElement.style.setProperty('--scroll-tilt-deg', `${(this.scrollTilt * 12).toFixed(2)}deg`);
+    cardElement.style.setProperty('--scroll-momentum', this.scrollMomentum.toFixed(4));
+
+    const targetContainer =
+      cardElement.querySelector('.visualization-container') ||
+      cardElement.querySelector('.card-preview') ||
+      cardElement.querySelector('.card-visual') ||
+      cardElement;
+
+    if (targetContainer && !['relative', 'absolute', 'fixed'].includes(getComputedStyle(targetContainer).position)) {
+      targetContainer.style.position = 'relative';
+    }
+
+    this.expandCanvasBounds(targetContainer);
+    this.insertBrandOverlay(targetContainer, cardData);
+
+    const observer = new MutationObserver(() => {
+      this.expandCanvasBounds(targetContainer);
+      this.insertBrandOverlay(targetContainer, cardData);
+      this.registerReactiveElements(cardData);
+    });
+
+    observer.observe(targetContainer, { childList: true, subtree: true });
+
+    const previousCleanup = cardData.cleanup;
+    cardData.cleanup = () => {
+      observer.disconnect();
+      if (typeof previousCleanup === 'function') {
+        previousCleanup();
+      }
+    };
+
+    this.registerReactiveElements(cardData);
+  }
+
+  expandCanvasBounds(container) {
+    if (!container) return;
+    const canvases = container.querySelectorAll('canvas');
+    canvases.forEach(canvas => this.styleVisualizerCanvas(canvas));
+  }
+
+  styleVisualizerCanvas(canvas) {
+    if (!canvas || canvas.dataset.brandExpanded === 'true') return;
+
+    canvas.dataset.brandExpanded = 'true';
+    canvas.dataset.focusReactive = 'true';
+    canvas.style.position = 'absolute';
+    canvas.style.top = '50%';
+    canvas.style.left = '50%';
+    canvas.style.width = '135%';
+    canvas.style.height = '135%';
+    canvas.style.transform = 'translate(-50%, -50%) scale(1.05)';
+    canvas.style.transformOrigin = 'center';
+    canvas.style.pointerEvents = 'none';
+    canvas.style.borderRadius = '20px';
+    canvas.style.willChange = 'transform, filter';
+  }
+
+  insertBrandOverlay(container, cardData) {
+    if (!container) return;
+
+    const hasOverlay = container.querySelector('.card-brand-overlay');
+    const hasVideo = container.querySelector('.card-brand-video');
+
+    if (hasOverlay && hasVideo) {
+      return;
+    }
+
+    const assetIndex = this.brandAssignmentIndex;
+    const imageSrc = hasOverlay ? null : this.selectAsset(this.brandAssets.images, assetIndex);
+    const videoSrc = hasVideo ? null : this.selectAsset(this.brandAssets.videos, assetIndex);
+    let assetApplied = false;
+
+    if (!hasOverlay && imageSrc) {
+      const overlay = document.createElement('div');
+      overlay.className = 'card-brand-overlay';
+      overlay.style.setProperty('--brand-rotation', `${(Math.random() * 12 - 6).toFixed(2)}deg`);
+      overlay.style.backgroundImage = `url('${this.getMediaPath(imageSrc)}')`;
+      overlay.setAttribute('aria-hidden', 'true');
+      overlay.dataset.focusReactive = 'true';
+      container.appendChild(overlay);
+      if (cardData) {
+        cardData.layers.overlay = overlay;
+      }
+      assetApplied = true;
+    }
+
+    if (!hasVideo && videoSrc) {
+      const video = document.createElement('video');
+      video.className = 'card-brand-video';
+      video.muted = true;
+      video.loop = true;
+      video.autoplay = true;
+      video.playsInline = true;
+      video.preload = 'metadata';
+      video.src = this.getMediaPath(videoSrc);
+      video.style.setProperty('--brand-rotation', `${(Math.random() * 10 - 5).toFixed(2)}deg`);
+      video.setAttribute('aria-hidden', 'true');
+      video.dataset.focusReactive = 'true';
+      video.addEventListener('error', () => {
+        if (video.parentElement) {
+          video.remove();
+        }
+        if (cardData) {
+          cardData.layers.video = null;
+          if (cardData.brandVideo === video) {
+            delete cardData.brandVideo;
+          }
+          this.registerReactiveElements(cardData);
+        }
+      });
+      video.addEventListener('loadeddata', () => {
+        video.play().catch(() => {});
+        if (cardData) {
+          this.registerReactiveElements(cardData);
+        }
+      });
+      container.appendChild(video);
+
+      if (cardData) {
+        cardData.brandVideo = video;
+        cardData.layers.video = video;
+      }
+      assetApplied = true;
+    }
+
+    if (assetApplied) {
+      this.brandAssignmentIndex++;
+      if (cardData) {
+        this.registerReactiveElements(cardData);
+      }
+    }
+  }
+
+  registerReactiveElements(cardData) {
+    if (!cardData?.element) return;
+
+    const selectors = [
+      '.card-frame',
+      '.card-shell',
+      '.card-wrapper',
+      '.card-content',
+      '.card-foreground',
+      '.card-background',
+      '.card-visual',
+      '.visualization-container',
+      '.card-preview',
+      '.card-title',
+      '.card-subtitle',
+      '.card-description',
+      '.card-meta',
+      'img',
+      'video',
+      'canvas'
+    ];
+
+    const reactiveSet = new Set(cardData.reactiveElements || []);
+
+    selectors.forEach(selector => {
+      cardData.element.querySelectorAll(selector).forEach(el => {
+        if (el !== cardData.element) {
+          reactiveSet.add(el);
+        }
+      });
+    });
+
+    if (cardData.layers.overlay) {
+      reactiveSet.add(cardData.layers.overlay);
+    }
+    if (cardData.layers.video) {
+      reactiveSet.add(cardData.layers.video);
+    }
+
+    const reactiveElements = Array.from(reactiveSet).filter(el => el && el.isConnected);
+    reactiveElements.forEach(el => {
+      el.dataset.focusReactive = 'true';
+    });
+
+    cardData.reactiveElements = reactiveElements;
+  }
+
+  startCardSynergyLoop(cardData) {
+    if (!cardData?.element) return;
+
+    const animate = () => {
+      const targetFocus = cardData.active ? 1 : 0;
+      cardData.focusIntensity += (targetFocus - cardData.focusIntensity) * 0.12;
+
+      if (cardData.clickPulse > 0.001) {
+        cardData.clickPulse *= 0.92;
+      } else {
+        cardData.clickPulse = 0;
+      }
+
+      const pointer = cardData.pointer;
+      pointer.smoothX += (pointer.rawX - pointer.smoothX) * 0.18;
+      pointer.smoothY += (pointer.rawY - pointer.smoothY) * 0.18;
+      pointer.bendSmooth += ((pointer.bendTarget ?? 0.12) - (pointer.bendSmooth ?? 0.12)) * 0.16;
+      pointer.twistSmooth += ((pointer.twistTarget ?? 0) - (pointer.twistSmooth ?? 0)) * 0.2;
+
+      const tiltX = (pointer.smoothY - 0.5) * 2;
+      const tiltY = (pointer.smoothX - 0.5) * 2;
+
+      cardData.currentTilt = { x: tiltX, y: tiltY };
+
+      this.applyCardSynergy(cardData, tiltX, tiltY);
+
+      cardData.synergyRaf = requestAnimationFrame(animate);
+    };
+
+    animate();
+
+    const previousCleanup = cardData.cleanup;
+    cardData.cleanup = () => {
+      if (cardData.synergyRaf) {
+        cancelAnimationFrame(cardData.synergyRaf);
+        cardData.synergyRaf = null;
+      }
+      if (typeof previousCleanup === 'function') {
+        previousCleanup();
+      }
+    };
+  }
+
+  applyCardSynergy(cardData, tiltX, tiltY) {
+    if (!cardData?.element) return;
+
+    const focus = Math.max(0, Math.min(1, cardData.focusIntensity));
+    const momentum = this.scrollMomentum || 0;
+
+    const parallaxStrength = 26 + focus * 24;
+    const parallaxX = tiltY * parallaxStrength;
+    const parallaxY = tiltX * -parallaxStrength;
+    const depthBase = focus * 60 + Math.abs(momentum) * 80;
+
+    cardData.element.style.setProperty('--focus-intensity', focus.toFixed(4));
+    cardData.element.style.setProperty('--focus-tilt-x-deg', `${(-tiltX * 14).toFixed(2)}deg`);
+    cardData.element.style.setProperty('--focus-tilt-y-deg', `${(tiltY * 18).toFixed(2)}deg`);
+    cardData.element.style.setProperty('--focus-parallax-x', `${parallaxX.toFixed(3)}px`);
+    cardData.element.style.setProperty('--focus-parallax-y', `${parallaxY.toFixed(3)}px`);
+    cardData.element.style.setProperty('--focus-depth', `${depthBase.toFixed(2)}px`);
+    cardData.element.style.setProperty('--focus-pulse', cardData.clickPulse.toFixed(3));
+
+    const overlay = cardData.layers.overlay;
+    if (overlay) {
+      overlay.style.opacity = '';
+    }
+
+    if (cardData.brandVideo) {
+      const playbackRate = 0.85 + focus * 0.5 + Math.abs(momentum) * 0.25;
+      cardData.brandVideo.playbackRate = Math.max(0.75, Math.min(1.8, playbackRate));
+    }
+
+    const sharedTiltTarget = this.scrollTilt + tiltY * 0.45;
+    cardData.visualizers.forEach(visualizer => {
+      if (!visualizer) return;
+      const baseXW = visualizer.variantParams?.rot4dXW || 0;
+      const baseYW = visualizer.variantParams?.rot4dYW || 0;
+      const baseZW = visualizer.variantParams?.rot4dZW || 0;
+      const focusEnergy = focus * 0.6;
+
+      if (visualizer.externalRotations) {
+        visualizer.externalRotations.xw = baseXW + (-tiltX * 0.55 + momentum * 0.4) * focusEnergy;
+        visualizer.externalRotations.yw = baseYW + (tiltY * 0.65 + momentum * -0.35) * focusEnergy;
+        visualizer.externalRotations.zw = baseZW + (tiltX * 0.35 + tiltY * 0.25) * focusEnergy;
+      }
+
+      if (typeof visualizer.scrollTiltTarget === 'number') {
+        visualizer.scrollTiltTarget = sharedTiltTarget;
+      }
+    });
+
+    const pointerState = cardData.pointer || {};
+    const bendProgress = Math.max(0, Math.min(1, pointerState.bendSmooth ?? 0.12));
+    const pointerMagnitude = Math.min(1.25, Math.hypot(tiltX, tiltY));
+    const focusBoost = focus * 0.35;
+    const momentumBoost = Math.min(0.4, Math.abs(momentum) * 0.22);
+    const bendIntensity = Math.min(0.88, 0.08 + bendProgress * 0.75 + pointerMagnitude * 0.28 + focusBoost + momentumBoost);
+    const bendTiltX = -tiltX * 12 * bendIntensity;
+    const bendTiltY = tiltY * 14 * bendIntensity;
+    const bendSkewX = -tiltY * 6 * bendIntensity;
+    const bendSkewY = tiltX * 5 * bendIntensity;
+    const bendTwist = (pointerState.twistSmooth ?? 0) * 18 * bendIntensity;
+    const bendDepth = bendIntensity * 28 + focus * 18 + Math.abs(momentum) * 16;
+    const visualizerDepth = bendDepth * 0.6 + bendIntensity * 12;
+
+    cardData.element.style.setProperty('--bend-intensity', bendIntensity.toFixed(3));
+    cardData.element.style.setProperty('--bend-tilt-x-deg', `${bendTiltX.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-tilt-y-deg', `${bendTiltY.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-skew-x-deg', `${bendSkewX.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-skew-y-deg', `${bendSkewY.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-twist-deg', `${bendTwist.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-depth', `${bendDepth.toFixed(3)}px`);
+    cardData.element.style.setProperty('--visualizer-bend-depth', `${visualizerDepth.toFixed(3)}px`);
+
+    cardData.reactiveElements?.forEach(el => {
+      if (!el.isConnected) return;
+      el.style.setProperty('--focus-intensity', focus.toFixed(4));
+    });
+  }
+
+  selectAsset(list, index) {
+    if (!Array.isArray(list) || list.length === 0) return null;
+    return list[index % list.length];
+  }
+
+  getMediaPath(assetPath) {
+    if (!assetPath) return '';
+    const trimmed = assetPath.trim();
+    if (trimmed.startsWith('http')) {
+      return trimmed;
+    }
+    if (trimmed.startsWith('assets/')) {
+      return encodeURI(trimmed);
+    }
+    return encodeURI(`./${trimmed}`);
+  }
+
+  ensureBrandStyles() {
+    if (document.getElementById('card-brand-enhancements')) return;
+
+    const style = document.createElement('style');
+    style.id = 'card-brand-enhancements';
+    style.textContent = `
+      .card-brand-enhanced {
+        position: relative;
+        --scroll-tilt: 0;
+        --visualizer-scroll-tilt: 0;
+        --scroll-momentum: 0;
+        --focus-intensity: 0;
+        --focus-tilt-x-deg: 0deg;
+        --focus-tilt-y-deg: 0deg;
+        --focus-parallax-x: 0px;
+        --focus-parallax-y: 0px;
+        --focus-depth: 0px;
+        --focus-pulse: 0;
+      }
+
+      .card-brand-enhanced .visualization-container,
+      .card-brand-enhanced .card-preview,
+      .card-brand-enhanced .card-visual {
+        overflow: visible !important;
+        transform-style: preserve-3d;
+      }
+
+      .card-brand-enhanced [data-focus-reactive="true"] {
+        position: relative;
+        transition:
+          transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+          filter 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+          opacity 0.6s ease,
+          box-shadow 0.6s ease;
+        transform:
+          perspective(1400px)
+          rotateX(var(--focus-tilt-x-deg))
+          rotateY(var(--focus-tilt-y-deg))
+          translate3d(
+            calc(var(--focus-parallax-x) * 0.45),
+            calc(var(--focus-parallax-y) * 0.45),
+            var(--focus-depth)
+          );
+        filter:
+          saturate(calc(1 + var(--focus-intensity) * 0.2))
+          brightness(calc(1 + var(--focus-intensity) * 0.15));
+        will-change: transform, filter, opacity;
+      }
+
+      .card-brand-enhanced[data-focus-state="active"] [data-focus-reactive="true"],
+      .card-brand-enhanced[data-focus-state="selected"] [data-focus-reactive="true"] {
+        box-shadow:
+          0 0 calc(18px + 22px * var(--focus-intensity)) rgba(0, 255, 255, 0.25),
+          0 0 calc(28px + 24px * var(--focus-intensity)) rgba(255, 0, 255, 0.22);
+      }
+
+      .card-brand-enhanced canvas,
+      .card-brand-enhanced .visualizer-canvas {
+        will-change: transform, filter;
+      }
+
+      .card-brand-enhanced canvas.card-visualizer-canvas,
+      .card-brand-enhanced canvas.visualizer-canvas,
+      .card-brand-enhanced canvas[data-visualizer],
+      .card-brand-enhanced canvas[data-webgl] {
+        position: absolute !important;
+        top: 50% !important;
+        left: 50% !important;
+        width: 135% !important;
+        height: 135% !important;
+        transform: translate(-50%, -50%) scale(1.12)
+          rotateX(calc(var(--visualizer-scroll-tilt, 0) * -6deg + var(--focus-tilt-x-deg)))
+          rotateY(calc(var(--visualizer-scroll-tilt, 0) * 3deg + var(--focus-tilt-y-deg)))
+          translateZ(calc(var(--focus-depth, 0px) * 0.32 + var(--scroll-momentum) * 22px));
+        transform-origin: center;
+        pointer-events: none;
+        border-radius: 20px;
+        filter: saturate(calc(1.08 + var(--focus-intensity) * 0.18))
+          brightness(calc(1.04 + var(--focus-intensity) * 0.22));
+        box-shadow:
+          0 0 calc(45px + 35px * var(--focus-intensity)) rgba(0, 255, 255, 0.22),
+          0 0 calc(85px + 35px * var(--focus-intensity)) rgba(255, 0, 255, 0.18);
+      }
+
+      .card-brand-overlay {
+        position: absolute;
+        inset: -25%;
+        background-position: center;
+        background-size: contain;
+        background-repeat: no-repeat;
+        opacity: calc(0.24 + var(--focus-intensity) * 0.28 + var(--focus-pulse) * 0.18);
+        mix-blend-mode: screen;
+        pointer-events: none;
+        transform:
+          rotate(var(--brand-rotation, 0deg))
+          translate3d(
+            calc(var(--focus-parallax-x) * -0.35 + var(--scroll-momentum) * -14px),
+            calc(var(--focus-parallax-y) * 0.35 + var(--scroll-momentum) * 18px),
+            calc(var(--focus-depth, 0px) * 0.45 + var(--scroll-momentum) * 28px)
+          )
+          scale(calc(1.04 + var(--focus-intensity) * 0.08 + var(--focus-pulse) * 0.04));
+        animation: cardBrandFloat 18s ease-in-out infinite alternate;
+        filter:
+          saturate(calc(1.2 + var(--focus-intensity) * 0.25))
+          drop-shadow(0 0 calc(25px + 25px * var(--focus-intensity)) rgba(0, 255, 255, 0.25));
+      }
+
+      .card-brand-video {
+        position: absolute;
+        inset: -30%;
+        object-fit: cover;
+        opacity: calc(0.22 + var(--focus-intensity) * 0.35 + var(--focus-pulse) * 0.22);
+        mix-blend-mode: lighten;
+        pointer-events: none;
+        border-radius: 28px;
+        transform:
+          rotate(var(--brand-rotation, 0deg))
+          translate3d(
+            calc(var(--focus-parallax-x) * -0.28 + var(--scroll-momentum) * -10px),
+            calc(var(--focus-parallax-y) * 0.28 + var(--scroll-momentum) * 20px),
+            calc(var(--focus-depth, 0px) * 0.65 + var(--scroll-momentum) * 36px)
+          )
+          scale(calc(1.05 + var(--focus-intensity) * 0.08));
+        filter:
+          saturate(calc(1.2 + var(--focus-intensity) * 0.3))
+          contrast(calc(1.05 + var(--focus-intensity) * 0.2))
+          blur(0.2px);
+        animation: cardBrandDrift 24s ease-in-out infinite;
+      }
+
+      @keyframes cardBrandFloat {
+        0% { transform: rotate(var(--brand-rotation, 0deg)) translate3d(-5%, -5%, 0); }
+        50% { transform: rotate(calc(var(--brand-rotation, 0deg) + 4deg)) translate3d(6%, 4%, 10px); }
+        100% { transform: rotate(calc(var(--brand-rotation, 0deg) - 3deg)) translate3d(-4%, 6%, -6px); }
+      }
+
+      @keyframes cardBrandDrift {
+        0% { transform: rotate(var(--brand-rotation, 0deg)) scale(1.02); opacity: 0.18; }
+        50% { transform: rotate(calc(var(--brand-rotation, 0deg) + 2deg)) scale(1.08); opacity: 0.33; }
+        100% { transform: rotate(calc(var(--brand-rotation, 0deg) - 2deg)) scale(1.04); opacity: 0.22; }
+      }
+    `;
+
+    document.head.appendChild(style);
+  }
+
+  setupScrollTiltSync() {
+    const wheelHandler = (event) => {
+      const delta = Math.max(-200, Math.min(200, event.deltaY || 0));
+      const normalized = delta / 160;
+      this.scrollTiltTarget += normalized;
+      this.scrollTiltTarget = Math.max(-3, Math.min(3, this.scrollTiltTarget));
+
+      if (!this.scrollTiltRaf) {
+        this.scrollTiltRaf = requestAnimationFrame(() => this.updateScrollTiltAnimation());
+      }
+    };
+
+    window.addEventListener('wheel', wheelHandler, { passive: true });
+
+    window.addEventListener('scroll', () => {
+      if (!this.scrollTiltRaf) {
+        this.scrollTiltRaf = requestAnimationFrame(() => this.updateScrollTiltAnimation());
+      }
+    }, { passive: true });
+  }
+
+  updateScrollTiltAnimation() {
+    this.scrollTilt += (this.scrollTiltTarget - this.scrollTilt) * 0.2;
+    this.scrollTiltTarget *= 0.88;
+    const momentumDelta = this.scrollTiltTarget - this.scrollTilt;
+    this.scrollMomentum = this.scrollMomentum * 0.82 + momentumDelta * 0.35;
+
+    if (Math.abs(this.scrollTilt) < 0.0005) {
+      this.scrollTilt = 0;
+    }
+
+    this.applyScrollTiltToCards(this.scrollTilt);
+
+    if (Math.abs(this.scrollTilt) > 0.001 || Math.abs(this.scrollTiltTarget) > 0.001) {
+      this.scrollTiltRaf = requestAnimationFrame(() => this.updateScrollTiltAnimation());
+    } else {
+      this.scrollTiltRaf = null;
+      this.scrollTilt = 0;
+      this.scrollTiltTarget = 0;
+      this.scrollMomentum = 0;
+      this.applyScrollTiltToCards(this.scrollTilt);
+    }
+  }
+
+  applyScrollTiltToCards(tiltValue) {
+    const clamped = Math.max(-2, Math.min(2, tiltValue));
+    const tiltString = clamped.toFixed(4);
+
+    document.documentElement.style.setProperty('--scroll-tilt', tiltString);
+    document.documentElement.style.setProperty('--visualizer-scroll-tilt', tiltString);
+    document.documentElement.style.setProperty('--scroll-tilt-deg', `${(clamped * 12).toFixed(2)}deg`);
+    document.documentElement.style.setProperty('--scroll-momentum', this.scrollMomentum.toFixed(4));
+
+    this.cards.forEach(cardData => {
+      if (cardData?.element) {
+        cardData.element.style.setProperty('--scroll-tilt', tiltString);
+        cardData.element.style.setProperty('--visualizer-scroll-tilt', tiltString);
+        cardData.element.style.setProperty('--scroll-tilt-deg', `${(clamped * 12).toFixed(2)}deg`);
+        cardData.element.style.setProperty('--scroll-momentum', this.scrollMomentum.toFixed(4));
+      }
+    });
+
+    window.dispatchEvent(new CustomEvent('visualizer-scroll-tilt', {
+      detail: { tilt: clamped }
+    }));
+  }
   
   setupCardInteractions(cardElement, cardData) {
     let isHovered = false;
@@ -157,27 +750,46 @@ class CardSystemController {
     // Enhanced mouse tracking
     const handleMouseMove = (e) => {
       if (!isHovered) return;
-      
+
       const rect = cardElement.getBoundingClientRect();
       mouseX = (e.clientX - rect.left) / rect.width;
       mouseY = (e.clientY - rect.top) / rect.height;
-      
-      // Update all visualizers for this card
+      mouseX = Math.max(0, Math.min(1, mouseX));
+      mouseY = Math.max(0, Math.min(1, mouseY));
+
+      const offsetX = mouseX - 0.5;
+      const offsetY = 0.5 - mouseY;
+      const pointerDistance = Math.min(Math.hypot(offsetX, offsetY) * 1.35, 1.1);
+      const dynamicMomentum = Math.abs(this.scrollMomentum || 0);
+      const bendTarget = Math.min(1, 0.18 + pointerDistance * 1.1 + dynamicMomentum * 0.28);
+      const twistTarget = offsetX * offsetY * 1.2;
+
+      // Update all visualizers for this card with bend-aware intensity
       for (const visualizer of cardData.visualizers.values()) {
-        visualizer.updateInteraction(mouseX, mouseY, 1.0);
+        visualizer.updateInteraction(mouseX, mouseY, bendTarget);
       }
-      
+
       // Update CSS custom properties for card transforms
       cardElement.style.setProperty('--mouse-x', (mouseX * 100) + '%');
       cardElement.style.setProperty('--mouse-y', (mouseY * 100) + '%');
-      cardElement.style.setProperty('--bend-intensity', '1');
+      cardElement.style.setProperty('--bend-intensity', bendTarget.toFixed(3));
+
+      cardData.pointer.rawX = mouseX;
+      cardData.pointer.rawY = mouseY;
+      cardData.pointer.bendTarget = bendTarget;
+      cardData.pointer.twistTarget = twistTarget;
     };
-    
+
     const handleMouseEnter = () => {
       isHovered = true;
       cardData.active = true;
       cardElement.classList.add('visualizer-active');
-      
+      cardElement.dataset.focusState = 'active';
+
+      cardData.pointer.bendTarget = Math.max(cardData.pointer.bendTarget || 0, 0.24);
+      cardData.pointer.twistTarget = cardData.pointer.twistTarget || 0;
+      cardElement.style.setProperty('--bend-intensity', cardData.pointer.bendTarget.toFixed(3));
+
       // Boost reactivity for all visualizers
       for (const visualizer of cardData.visualizers.values()) {
         visualizer.reactivity = 1.5;
@@ -190,32 +802,51 @@ class CardSystemController {
       isHovered = false;
       cardData.active = false;
       cardElement.classList.remove('visualizer-active');
-      
+      cardElement.dataset.focusState = 'idle';
+
       // Reset visualizers
       for (const visualizer of cardData.visualizers.values()) {
         visualizer.reactivity = 1.0;
         visualizer.mouseIntensity *= 0.8;
       }
-      
+
       // Reset CSS transforms
       cardElement.style.setProperty('--mouse-x', '50%');
       cardElement.style.setProperty('--mouse-y', '50%');
       cardElement.style.setProperty('--bend-intensity', '0');
+      cardElement.style.setProperty('--bend-tilt-x-deg', '0deg');
+      cardElement.style.setProperty('--bend-tilt-y-deg', '0deg');
+      cardElement.style.setProperty('--bend-skew-x-deg', '0deg');
+      cardElement.style.setProperty('--bend-skew-y-deg', '0deg');
+      cardElement.style.setProperty('--bend-twist-deg', '0deg');
+      cardElement.style.setProperty('--bend-depth', '0px');
+      cardElement.style.setProperty('--visualizer-bend-depth', '0px');
+
+      cardData.pointer.rawX = 0.5;
+      cardData.pointer.rawY = 0.5;
+      cardData.pointer.bendTarget = 0.12;
+      cardData.pointer.twistTarget = 0;
     };
-    
+
     const handleClick = (e) => {
       const rect = cardElement.getBoundingClientRect();
       const clickX = (e.clientX - rect.left) / rect.width;
       const clickY = (e.clientY - rect.top) / rect.height;
-      
+
       // Trigger click effect on all visualizers
       for (const visualizer of cardData.visualizers.values()) {
         visualizer.triggerClick(clickX, clickY);
       }
-      
+
+      cardData.clickPulse = 1;
+      cardElement.dataset.focusState = 'selected';
+      setTimeout(() => {
+        cardElement.dataset.focusState = cardData.active ? 'active' : 'idle';
+      }, 420);
+
       console.log(`💥 Card clicked: ${cardElement.id}`);
     };
-    
+
     // Add event listeners
     cardElement.addEventListener('mousemove', handleMouseMove, { passive: true });
     cardElement.addEventListener('mouseenter', handleMouseEnter);
@@ -223,11 +854,15 @@ class CardSystemController {
     cardElement.addEventListener('click', handleClick);
     
     // Store cleanup functions
+    const previousCleanup = cardData.cleanup;
     cardData.cleanup = () => {
       cardElement.removeEventListener('mousemove', handleMouseMove);
       cardElement.removeEventListener('mouseenter', handleMouseEnter);
       cardElement.removeEventListener('mouseleave', handleMouseLeave);
       cardElement.removeEventListener('click', handleClick);
+      if (typeof previousCleanup === 'function') {
+        previousCleanup();
+      }
     };
   }
   
@@ -349,7 +984,15 @@ class CardSystemController {
     if (cardData.cleanup) {
       cardData.cleanup();
     }
-    
+
+    if (cardData.brandVideo?.parentElement) {
+      cardData.brandVideo.remove();
+    }
+    const overlay = cardData.element?.querySelector('.card-brand-overlay');
+    if (overlay) {
+      overlay.remove();
+    }
+
     this.cards.delete(cardId);
     console.log(`🗑️ Card destroyed: ${cardId}`);
   }
@@ -378,22 +1021,44 @@ class CardSystemController {
 
 // Global card system instance
 window.cardSystemController = null;
+window.cardSystemStatusInterval = null;
 
-// Initialize when DOM is loaded
-document.addEventListener('DOMContentLoaded', async () => {
+async function bootCardSystem() {
+  if (window.cardSystemController) {
+    return window.cardSystemController;
+  }
+
   // Wait a bit for other scripts to load
-  await new Promise(resolve => setTimeout(resolve, 500));
-  
+  await new Promise(resolve => setTimeout(resolve, 200));
+
   window.cardSystemController = new CardSystemController();
   await window.cardSystemController.initialize();
-  
-  // Debug status logging
-  setInterval(() => {
-    if (window.cardSystemController) {
-      const status = window.cardSystemController.getCardStatus();
-      console.log('🎨 Card System Status:', status);
-    }
-  }, 10000); // Log every 10 seconds
-});
+
+  if (!window.cardSystemStatusInterval) {
+    window.cardSystemStatusInterval = setInterval(() => {
+      if (window.cardSystemController) {
+        const status = window.cardSystemController.getCardStatus();
+        console.log('🎨 Card System Status:', status);
+      }
+    }, 10000); // Log every 10 seconds
+  }
+
+  return window.cardSystemController;
+}
+
+window.bootCardSystem = bootCardSystem;
+
+const handleReady = () => {
+  bootCardSystem().catch(error => {
+    console.error('❌ Failed to boot card system:', error);
+  });
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', handleReady);
+} else {
+  handleReady();
+}
 
 console.log('🎨 Card System Initializer loaded');
+

--- a/scripts/clear-seas-ai.js
+++ b/scripts/clear-seas-ai.js
@@ -1033,6 +1033,89 @@ class BackgroundFieldController {
     }
 }
 
+const BRAND_LIBRARY_DEFAULTS = {
+    overlays: [
+        'assets/Screenshot_20250430-141821.png',
+        'assets/Screenshot_20250430-142002~2.png',
+        'assets/Screenshot_20250430-142024~2.png',
+        'assets/Screenshot_20250430-142032~2.png',
+        'assets/Screenshot_20241012-073718.png',
+        'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+        'assets/file_0000000054a06230817873012865d150.png',
+        'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+        'assets/image_8 (1).png'
+    ],
+    videos: [
+        '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+        '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+        '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+        '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+        '1746496560073.mp4',
+        '1746500614769.mp4',
+        '1746576068221.mp4'
+    ],
+    logos: [
+        'assets/clear-seas-logo-aurora.svg',
+        'assets/clear-seas-monogram.svg'
+    ]
+};
+
+function ensureSharedBrandLibrary() {
+    const mergeUnique = (target, source) => {
+        if (!Array.isArray(source)) {
+            return target;
+        }
+        source.forEach((item) => {
+            if (typeof item === 'string' && !target.includes(item)) {
+                target.push(item);
+            }
+        });
+        return target;
+    };
+
+    const existing = window.ClearSeasBrandLibrary || { overlays: [], videos: [], logos: [], cursor: 0 };
+    mergeUnique(existing.overlays, BRAND_LIBRARY_DEFAULTS.overlays);
+    mergeUnique(existing.videos, BRAND_LIBRARY_DEFAULTS.videos);
+    mergeUnique(existing.logos, BRAND_LIBRARY_DEFAULTS.logos);
+
+    if (!Number.isFinite(existing.cursor)) {
+        existing.cursor = 0;
+    }
+
+    const getPool = (preference) => {
+        const pref = (preference || '').toLowerCase();
+        if (pref.startsWith('video')) {
+            return existing.videos;
+        }
+        if (pref.startsWith('logo')) {
+            return existing.logos.length ? existing.logos : existing.overlays;
+        }
+        if (pref.startsWith('overlay') || pref.startsWith('image') || pref.startsWith('brand')) {
+            return existing.overlays.length ? existing.overlays : existing.logos;
+        }
+        return [...existing.videos, ...existing.overlays, ...existing.logos];
+    };
+
+    const acquire = (preference) => {
+        const pool = getPool(preference);
+        if (!pool.length) {
+            return null;
+        }
+        const index = Math.abs(existing.cursor) % pool.length;
+        existing.cursor += 1;
+        const src = pool[index];
+        const type = typeof src === 'string' && src.toLowerCase().endsWith('.mp4') ? 'video' : 'image';
+        return { src, type };
+    };
+
+    existing.acquire = acquire;
+    window.ClearSeasBrandLibrary = existing;
+    window.clearSeasAcquireBrandAsset = acquire;
+    return existing;
+}
+
+ensureSharedBrandLibrary();
+
 function easeOutCubic(x) {
     return 1 - Math.pow(1 - x, 3);
 }
@@ -1279,26 +1362,79 @@ function initialiseSectionTracking() {
 
 function createTiltController(elements, options = {}) {
     const targets = Array.from(elements);
+    if (!targets.length) {
+        return { enable() {}, disable() {} };
+    }
+
     const defaultStrength = options.strength || 6;
     const handlers = new WeakMap();
+    const scrollState = {
+        y: window.scrollY,
+        velocity: 0,
+        raf: null,
+        pending: false
+    };
+
+    const applyScroll = () => {
+        scrollState.pending = false;
+        const currentY = window.scrollY;
+        const delta = currentY - scrollState.y;
+        scrollState.y = currentY;
+        const normalizedVelocity = (window.innerHeight || 1) > 0 ? delta / window.innerHeight : 0;
+        scrollState.velocity = scrollState.velocity * 0.82 + normalizedVelocity * 0.18;
+
+        const scrollRotation = Math.max(Math.min(scrollState.velocity * (options.scrollStrength || 18), 18), -18);
+        const parallax = Math.max(Math.min(scrollState.velocity * (options.parallaxStrength || 320), 320), -320);
+        const rotXW = scrollRotation * 2.6;
+        const rotYW = scrollRotation * -1.8;
+        const rotZW = scrollRotation * 1.2;
+
+        targets.forEach((element) => {
+            element.style.setProperty('--tilt-scroll', `${scrollRotation.toFixed(3)}deg`);
+            element.style.setProperty('--visualizer-parallax', `${parallax.toFixed(3)}px`);
+            element.style.setProperty('--visualizer-rot-xw', `${rotXW.toFixed(3)}deg`);
+            element.style.setProperty('--visualizer-rot-yw', `${rotYW.toFixed(3)}deg`);
+            element.style.setProperty('--visualizer-rot-zw', `${rotZW.toFixed(3)}deg`);
+            element.style.setProperty('--scroll-velocity', scrollState.velocity.toFixed(4));
+        });
+
+        window.dispatchEvent(new CustomEvent('clear-seas-scroll-tilt', {
+            detail: {
+                rotation: scrollRotation,
+                velocity: scrollState.velocity
+            }
+        }));
+    };
+
+    const scheduleScroll = () => {
+        if (scrollState.pending) {
+            return;
+        }
+        scrollState.pending = true;
+        scrollState.raf = requestAnimationFrame(applyScroll);
+    };
 
     const enable = () => {
         targets.forEach((element) => {
             const strength = Number(element.dataset.tiltStrength || defaultStrength);
             const onMove = (event) => {
                 const rect = element.getBoundingClientRect();
-                const x = (event.clientX - rect.left) / rect.width;
-                const y = (event.clientY - rect.top) / rect.height;
+                const x = rect.width ? (event.clientX - rect.left) / rect.width : 0.5;
+                const y = rect.height ? (event.clientY - rect.top) / rect.height : 0.5;
                 const clampedX = Math.min(Math.max(x, 0), 1);
                 const clampedY = Math.min(Math.max(y, 0), 1);
                 const rotateX = (0.5 - clampedY) * strength;
                 const rotateY = (clampedX - 0.5) * strength;
                 element.style.setProperty('--tilt-x', `${rotateX.toFixed(2)}deg`);
                 element.style.setProperty('--tilt-y', `${rotateY.toFixed(2)}deg`);
+                element.style.setProperty('--tilt-x-value', rotateX.toFixed(4));
+                element.style.setProperty('--tilt-y-value', rotateY.toFixed(4));
             };
             const onLeave = () => {
                 element.style.setProperty('--tilt-x', '0deg');
                 element.style.setProperty('--tilt-y', '0deg');
+                element.style.setProperty('--tilt-x-value', '0');
+                element.style.setProperty('--tilt-y-value', '0');
             };
 
             element.addEventListener('pointermove', onMove);
@@ -1306,6 +1442,9 @@ function createTiltController(elements, options = {}) {
             element.addEventListener('pointerup', onLeave);
             handlers.set(element, { onMove, onLeave });
         });
+
+        window.addEventListener('scroll', scheduleScroll, { passive: true });
+        scheduleScroll();
     };
 
     const disable = () => {
@@ -1319,8 +1458,24 @@ function createTiltController(elements, options = {}) {
             element.removeEventListener('pointerup', entry.onLeave);
             element.style.setProperty('--tilt-x', '0deg');
             element.style.setProperty('--tilt-y', '0deg');
+            element.style.setProperty('--tilt-x-value', '0');
+            element.style.setProperty('--tilt-y-value', '0');
+            element.style.setProperty('--tilt-scroll', '0deg');
+            element.style.setProperty('--visualizer-parallax', '0px');
+            element.style.setProperty('--visualizer-rot-xw', '0deg');
+            element.style.setProperty('--visualizer-rot-yw', '0deg');
+            element.style.setProperty('--visualizer-rot-zw', '0deg');
+            element.style.setProperty('--scroll-velocity', '0');
             handlers.delete(element);
         });
+
+        window.removeEventListener('scroll', scheduleScroll);
+        if (scrollState.raf) {
+            cancelAnimationFrame(scrollState.raf);
+        }
+        scrollState.pending = false;
+        scrollState.raf = null;
+        scrollState.velocity = 0;
     };
 
     return { enable, disable };
@@ -1869,6 +2024,291 @@ function initialiseTimelines() {
     });
 }
 
+function initialiseCardVisualizers() {
+    const selectors = [
+        '.canvas-card',
+        '.stacked-card',
+        '.hero__module',
+        '.flow-step',
+        '.flow-thread',
+        '.system-card',
+        '.variant-card',
+        '.signal-card',
+        '.signal-node',
+        '.resource-card',
+        '.micro-card',
+        '.metric'
+    ];
+
+    const candidates = new Set();
+    selectors.forEach((selector) => {
+        document.querySelectorAll(selector).forEach((element) => candidates.add(element));
+    });
+
+    const cards = Array.from(candidates).filter((card) => card && !card.dataset.visualizerAttached);
+    if (!cards.length) {
+        return;
+    }
+
+    const acquireAsset = typeof window.clearSeasAcquireBrandAsset === 'function'
+        ? window.clearSeasAcquireBrandAsset
+        : () => null;
+
+    const instances = new WeakMap();
+    const observer = 'IntersectionObserver' in window
+        ? new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                const state = instances.get(entry.target);
+                if (!state) {
+                    return;
+                }
+                state.visible = entry.isIntersecting;
+                if (entry.isIntersecting) {
+                    state.startField();
+                    state.targetFocus = Math.max(state.targetFocus, 0.42);
+                } else if (!state.hover) {
+                    state.stopField();
+                    state.targetFocus = Math.min(state.targetFocus, 0.2);
+                }
+            });
+        }, { threshold: 0.25, rootMargin: '-12% 0px -12% 0px' })
+        : null;
+
+    cards.forEach((card, index) => {
+        card.dataset.visualizerAttached = 'true';
+        card.classList.add('visualizer-host');
+
+        const weight = Number(card.dataset.visualizerWeight || card.dataset.visualizerScale || '1.12');
+        const bleed = Number.isFinite(weight) ? Math.max(1.18, weight + 0.22) : 1.28;
+        const scale = bleed + 0.16;
+        card.style.setProperty('--visualizer-bleed', bleed.toFixed(3));
+        card.style.setProperty('--visualizer-scale', scale.toFixed(3));
+        if (!card.style.getPropertyValue('--brand-rotation')) {
+            card.style.setProperty('--brand-rotation', `${(Math.random() * 38 - 19).toFixed(2)}deg`);
+        }
+
+        const shell = document.createElement('div');
+        shell.className = 'visualizer-shell';
+        shell.setAttribute('aria-hidden', 'true');
+
+        const canvas = document.createElement('canvas');
+        canvas.className = 'visualizer-shell__canvas';
+        shell.appendChild(canvas);
+
+        const assetPreference = card.dataset.visualizerAsset || card.dataset.element || (index % 3 === 0 ? 'video' : 'overlay');
+        const asset = acquireAsset(assetPreference);
+
+        let brandHost = null;
+        let brandMedia = null;
+
+        if (asset && asset.src) {
+            brandHost = document.createElement('div');
+            brandHost.className = 'visualizer-shell__brand';
+            brandHost.dataset.brandType = asset.type;
+
+            if (asset.type === 'video') {
+                brandHost.classList.add('visualizer-shell__brand--video');
+                const video = document.createElement('video');
+                video.className = 'visualizer-shell__brand-media';
+                video.src = asset.src;
+                video.muted = true;
+                video.autoplay = true;
+                video.loop = true;
+                video.playsInline = true;
+                video.setAttribute('muted', '');
+                video.setAttribute('playsinline', '');
+                video.addEventListener('loadeddata', () => {
+                    video.play().catch(() => {});
+                }, { once: true });
+                brandHost.appendChild(video);
+                brandMedia = video;
+            } else {
+                brandHost.classList.add('visualizer-shell__brand--image');
+                brandHost.style.setProperty('--brand-image', `url(${asset.src})`);
+            }
+
+            shell.appendChild(brandHost);
+        }
+
+        card.insertBefore(shell, card.firstChild);
+
+        const state = {
+            card,
+            canvas,
+            shell,
+            brandHost,
+            brandMedia,
+            hover: false,
+            visible: false,
+            started: false,
+            focus: 0.18,
+            targetFocus: 0.24,
+            pulse: 0,
+            pointerX: 0.5,
+            pointerY: 0.5,
+            raf: null,
+            fieldController: null,
+            resizeObserver: null
+        };
+
+        const hologram = ReactiveHologramField.create(canvas);
+        if (hologram) {
+            state.fieldController = {
+                start() {
+                    hologram.start();
+                },
+                stop() {
+                    hologram.stop();
+                },
+                update(focusX, focusY, intensity) {
+                    hologram.setPointer(focusX, focusY);
+                    hologram.setFocus(focusX, focusY, intensity);
+                    hologram.setMode(intensity > 0.75 ? 'active' : 'holographic');
+                },
+                destroy() {
+                    hologram.stop();
+                }
+            };
+        } else {
+            const fallback = new OrbitalField(canvas);
+            state.fieldController = {
+                start() {
+                    fallback.start();
+                },
+                stop() {
+                    fallback.stop();
+                },
+                update(_focusX, _focusY, intensity) {
+                    fallback.setIntensity(0.52 + intensity * 0.45);
+                },
+                destroy() {
+                    fallback.stop();
+                }
+            };
+        }
+
+        const updateCanvasResolution = () => {
+            const rect = card.getBoundingClientRect();
+            if (!rect.width || !rect.height) {
+                return;
+            }
+            const dpr = Math.min(window.devicePixelRatio || 1, 2.5);
+            const bleedFactor = Number(card.style.getPropertyValue('--visualizer-bleed')) || bleed;
+            const resolutionScale = bleedFactor + 0.42;
+            const width = Math.max(1, Math.round(rect.width * resolutionScale * dpr));
+            const height = Math.max(1, Math.round(rect.height * resolutionScale * dpr));
+            if (canvas.width !== width) {
+                canvas.width = width;
+            }
+            if (canvas.height !== height) {
+                canvas.height = height;
+            }
+        };
+
+        updateCanvasResolution();
+        state.resizeObserver = new ResizeObserver(updateCanvasResolution);
+        state.resizeObserver.observe(card);
+
+        const startField = () => {
+            if (state.started || !state.fieldController) {
+                return;
+            }
+            state.fieldController.start();
+            state.started = true;
+        };
+
+        const stopField = () => {
+            if (!state.started || !state.fieldController) {
+                return;
+            }
+            state.fieldController.stop();
+            state.started = false;
+        };
+
+        state.startField = startField;
+        state.stopField = stopField;
+
+        const setPointer = (event) => {
+            const rect = card.getBoundingClientRect();
+            const x = rect.width ? (event.clientX - rect.left) / rect.width : 0.5;
+            const y = rect.height ? (event.clientY - rect.top) / rect.height : 0.5;
+            state.pointerX = Math.min(Math.max(x, 0), 1);
+            state.pointerY = Math.min(Math.max(y, 0), 1);
+        };
+
+        const handleMove = (event) => {
+            setPointer(event);
+            state.targetFocus = Math.max(state.targetFocus, 0.92);
+        };
+
+        const handleEnter = () => {
+            state.hover = true;
+            state.targetFocus = Math.max(state.targetFocus, 1.05);
+            startField();
+        };
+
+        const handleLeave = () => {
+            state.hover = false;
+            state.targetFocus = Math.max(0.22, state.visible ? 0.4 : 0.18);
+            if (!state.visible) {
+                stopField();
+            }
+        };
+
+        const handleDown = () => {
+            state.pulse = 1;
+            state.targetFocus = Math.max(state.targetFocus, 1.12);
+            if (state.brandMedia) {
+                state.brandMedia.play().catch(() => {});
+            }
+        };
+
+        card.addEventListener('pointermove', handleMove);
+        card.addEventListener('pointerenter', handleEnter);
+        card.addEventListener('pointerleave', handleLeave);
+        card.addEventListener('pointerdown', handleDown);
+        card.addEventListener('focusin', handleEnter);
+        card.addEventListener('focusout', handleLeave);
+
+        const animate = () => {
+            const baseTarget = state.hover ? 1.05 : state.visible ? 0.45 : 0.2;
+            state.targetFocus += (baseTarget - state.targetFocus) * 0.08;
+            state.focus += (state.targetFocus - state.focus) * 0.14;
+            state.pulse *= 0.9;
+
+            const focusValue = Math.max(0, state.focus);
+            card.style.setProperty('--focus-intensity', focusValue.toFixed(3));
+            card.style.setProperty('--focus-pulse', state.pulse.toFixed(3));
+            card.style.setProperty('--focus-pointer-x', state.pointerX.toFixed(3));
+            card.style.setProperty('--focus-pointer-y', state.pointerY.toFixed(3));
+
+            if (state.fieldController) {
+                state.fieldController.update(state.pointerX, state.pointerY, Math.min(1.4, focusValue + 0.45));
+            }
+
+            if (state.brandMedia && state.brandMedia instanceof HTMLVideoElement) {
+                const scrollVelocity = Number(card.style.getPropertyValue('--scroll-velocity') || 0);
+                const playbackRate = 0.85 + focusValue * 0.45 + Math.abs(scrollVelocity) * 0.2;
+                state.brandMedia.playbackRate = Math.min(1.8, Math.max(0.7, playbackRate));
+            }
+
+            state.raf = requestAnimationFrame(animate);
+        };
+
+        state.raf = requestAnimationFrame(animate);
+
+        instances.set(card, state);
+
+        if (observer) {
+            observer.observe(card);
+        } else {
+            state.visible = true;
+            startField();
+            state.targetFocus = Math.max(state.targetFocus, 0.4);
+        }
+    });
+}
+
 function updateFooterYear() {
     const target = document.querySelector('[data-year]');
     if (target) {
@@ -1896,6 +2336,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    initialiseCardVisualizers();
     initialiseStackedShowcase();
     initialiseParallaxGroups();
     initialiseSparkInteractions();

--- a/scripts/global-page-orchestrator.js
+++ b/scripts/global-page-orchestrator.js
@@ -1,0 +1,762 @@
+const brandAssets = window.__CLEAR_SEAS_BRAND_ASSETS || (window.__CLEAR_SEAS_BRAND_ASSETS = {
+  images: [
+    'assets/Screenshot_20250430-141821.png',
+    'assets/Screenshot_20241012-073718.png',
+    'assets/Screenshot_20250430-142024~2.png',
+    'assets/Screenshot_20250430-142002~2.png',
+    'assets/Screenshot_20250430-142032~2.png',
+    'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+    'assets/file_0000000054a06230817873012865d150.png',
+    'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+    'assets/image_8 (1).png'
+  ],
+  videos: [
+    '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+    '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+    '1746496560073.mp4',
+    '1746500614769.mp4',
+    '1746576068221.mp4'
+  ]
+});
+
+const stylesLoaded = new Set();
+const scriptsLoaded = new Map();
+const cardStates = new Map();
+const groupStates = new Map();
+let activeCardState = null;
+let rafId = null;
+
+const globalState = {
+  scroll: { current: 0, target: 0, lastY: window.scrollY || 0, lastTime: performance.now() },
+  synergy: { current: 0, target: 0 }
+};
+
+function ensureStylesheet(href, key) {
+  if (stylesLoaded.has(key)) {
+    return;
+  }
+  if (document.querySelector(`link[data-global-style="${key}"]`)) {
+    stylesLoaded.add(key);
+    return;
+  }
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  link.dataset.globalStyle = key;
+  document.head.appendChild(link);
+  stylesLoaded.add(key);
+}
+
+function ensureScript(src) {
+  if (scriptsLoaded.has(src)) {
+    return scriptsLoaded.get(src);
+  }
+  const existing = Array.from(document.scripts).find(script => script.src && script.src.includes(src));
+  if (existing) {
+    if (existing.dataset.loaded === 'true') {
+      const resolved = Promise.resolve();
+      scriptsLoaded.set(src, resolved);
+      return resolved;
+    }
+    const promise = new Promise((resolve) => {
+      existing.addEventListener('load', () => {
+        existing.dataset.loaded = 'true';
+        resolve();
+      }, { once: true });
+      existing.addEventListener('error', () => resolve(), { once: true });
+    });
+    scriptsLoaded.set(src, promise);
+    return promise;
+  }
+  const promise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = false;
+    script.dataset.globalInjected = 'true';
+    script.addEventListener('load', () => {
+      script.dataset.loaded = 'true';
+      resolve();
+    });
+    script.addEventListener('error', (error) => {
+      console.warn(`⚠️ Failed to load script: ${src}`, error);
+      resolve();
+    });
+    document.head.appendChild(script);
+  });
+  scriptsLoaded.set(src, promise);
+  return promise;
+}
+
+async function ensureCardSystem() {
+  await ensureScript('scripts/card-specific-vib34d-visualizer.js');
+  await ensureScript('scripts/card-system-initializer.js');
+  if (typeof window.bootCardSystem === 'function') {
+    try {
+      await window.bootCardSystem();
+    } catch (error) {
+      console.warn('⚠️ Card system boot failed but continuing with synergy orchestrator.', error);
+    }
+  }
+}
+
+function normalise(value, min, max) {
+  if (max - min === 0) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, (value - min) / (max - min)));
+}
+
+function shouldRegister(element) {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+  if (element.dataset.globalCardSynergy === 'applied') {
+    return false;
+  }
+  if (element.closest('[data-global-card-synergy="applied"]') && element.closest('[data-global-card-synergy="applied"]') !== element) {
+    return false;
+  }
+  if (element.dataset.globalCardIgnore === 'true') {
+    return false;
+  }
+  const rect = element.getBoundingClientRect();
+  if (rect.width < 120 || rect.height < 120) {
+    return false;
+  }
+  const style = getComputedStyle(element);
+  if (style.display === 'inline' || style.visibility === 'hidden' || style.opacity === '0') {
+    return false;
+  }
+  return true;
+}
+
+function pickBrandImage(index) {
+  if (!brandAssets.images.length) {
+    return null;
+  }
+  return brandAssets.images[index % brandAssets.images.length];
+}
+
+function pickBrandVideo(index) {
+  if (!brandAssets.videos.length) {
+    return null;
+  }
+  return brandAssets.videos[index % brandAssets.videos.length];
+}
+
+function ensureBrandLayer(state) {
+  const card = state.element;
+  let overlay = card.querySelector(':scope > .global-brand-overlay, :scope > .card-brand-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.className = 'global-brand-overlay';
+    card.appendChild(overlay);
+  } else {
+    overlay.classList.add('global-brand-overlay');
+  }
+  const existingVideo = overlay.querySelector('video');
+  if (existingVideo) {
+    existingVideo.muted = true;
+    existingVideo.loop = true;
+    existingVideo.autoplay = true;
+    existingVideo.playsInline = true;
+    state.brandVideo = existingVideo;
+  }
+
+  const preferVideo = card.dataset.brandVideo === 'true' || card.classList.contains('brand-video-card') || state.index % 3 === 0;
+  const videoSource = preferVideo ? pickBrandVideo(state.index) : null;
+
+  overlay.dataset.brandIndex = state.index;
+
+  if (videoSource) {
+    overlay.style.backgroundImage = 'none';
+    if (!overlay.querySelector('video')) {
+      overlay.innerHTML = '';
+      const video = document.createElement('video');
+      video.src = videoSource;
+      video.autoplay = true;
+      video.loop = true;
+      video.muted = true;
+      video.playsInline = true;
+      video.dataset.globalBrandVideo = 'true';
+      video.addEventListener('canplay', () => {
+        if (state.focus.current > 0.1) {
+          video.play().catch(() => {});
+        }
+      });
+      overlay.appendChild(video);
+      state.brandVideo = video;
+    } else if (state.brandVideo) {
+      state.brandVideo.src = videoSource;
+    }
+  } else {
+    overlay.innerHTML = '';
+    const imageSource = pickBrandImage(state.index);
+    if (imageSource) {
+      overlay.style.backgroundImage = `url('${imageSource}')`;
+    }
+    state.brandVideo = null;
+  }
+
+  return overlay;
+}
+
+function resolveGroupElement(element) {
+  if (!(element instanceof HTMLElement)) {
+    return null;
+  }
+  const groupSelectors = [
+    '[data-card-group]',
+    '.version-grid',
+    '.card-grid',
+    '.cards-grid',
+    '.cards',
+    '.card-collection',
+    '.visualizer-grid',
+    '.layout-grid',
+    '.module-grid',
+    '.experience-grid',
+    '.card-stack',
+    '.card-list'
+  ];
+  const selector = groupSelectors.join(', ');
+  const matched = element.closest(selector);
+  if (matched) {
+    return matched;
+  }
+  const fallback = element.parentElement;
+  if (fallback && fallback !== document.body && fallback !== document.documentElement) {
+    return fallback;
+  }
+  return null;
+}
+
+function attachToGroup(state) {
+  const group = resolveGroupElement(state.element);
+  if (!group) {
+    return null;
+  }
+  group.dataset.globalCardGroup = 'true';
+  let groupState = groupStates.get(group);
+  if (!groupState) {
+    groupState = {
+      element: group,
+      cards: new Set(),
+      focus: { current: 0, target: 0 },
+      pointer: {
+        currentX: 0.5,
+        currentY: 0.5,
+        targetX: 0.5,
+        targetY: 0.5
+      },
+      synergy: { current: 0, target: 0 },
+      section: null
+    };
+    groupStates.set(group, groupState);
+  }
+  groupState.cards.add(state);
+  state.group = group;
+  return group;
+}
+
+function detachFromGroup(state) {
+  if (!state.group) {
+    return;
+  }
+  const groupState = groupStates.get(state.group);
+  if (!groupState) {
+    state.group = null;
+    return;
+  }
+  groupState.cards.delete(state);
+  if (groupState.cards.size === 0) {
+    const { element, section } = groupState;
+    element.removeAttribute('data-global-card-group');
+    element.removeAttribute('data-global-group-active');
+    element.style.removeProperty('--group-focus-amount');
+    element.style.removeProperty('--group-focus-x');
+    element.style.removeProperty('--group-focus-y');
+    element.style.removeProperty('--group-synergy');
+    if (section) {
+      section.removeAttribute('data-global-group-active');
+      section.style.removeProperty('--section-focus-amount');
+      section.style.removeProperty('--section-synergy');
+    }
+    groupStates.delete(state.group);
+  }
+  state.group = null;
+}
+
+function syncGroupAssociation(state) {
+  const resolvedGroup = resolveGroupElement(state.element);
+  if (resolvedGroup === state.group) {
+    return;
+  }
+  detachFromGroup(state);
+  if (resolvedGroup) {
+    attachToGroup(state);
+  }
+}
+
+function createState(element, index) {
+  element.classList.add('global-visualizer-card');
+  element.dataset.globalCardSynergy = 'applied';
+  const state = {
+    element,
+    index,
+    pointer: {
+      targetX: 0.5,
+      targetY: 0.5,
+      smoothX: 0.5,
+      smoothY: 0.5,
+      lastClientX: null,
+      lastClientY: null
+    },
+    focus: { current: 0, target: 0 },
+    support: { current: 0, target: 0 },
+    twist: { current: 0, target: 0 },
+    pulse: { current: 0, target: 0 },
+    scroll: { current: 0, target: 0 },
+    overlay: null,
+    brandVideo: null,
+    group: null
+  };
+  state.overlay = ensureBrandLayer(state);
+  state.element.dataset.supportRole = 'neutral';
+  state.group = attachToGroup(state);
+  cardStates.set(element, state);
+  return state;
+}
+
+function updateSupportTargets(activeState) {
+  activeCardState = activeState;
+  const activeGroup = activeState && activeState.group ? activeState.group : null;
+
+  groupStates.forEach((groupState, groupElement) => {
+    if (!activeGroup) {
+      groupState.synergy.target = 0;
+      groupElement.dataset.globalGroupActive = 'false';
+      return;
+    }
+    if (groupElement === activeGroup) {
+      groupState.synergy.target = 1;
+      groupElement.dataset.globalGroupActive = 'true';
+    } else {
+      groupState.synergy.target = 0.32;
+      groupElement.dataset.globalGroupActive = 'false';
+    }
+  });
+
+  cardStates.forEach((state) => {
+    if (activeState) {
+      if (state === activeState) {
+        state.support.target = 0.38;
+        state.element.dataset.supportRole = 'primary';
+      } else if (activeGroup && state.group === activeGroup) {
+        state.support.target = -0.24;
+        state.element.dataset.supportRole = 'supporting';
+      } else {
+        state.support.target = -0.12;
+        state.element.dataset.supportRole = 'ambient';
+      }
+    } else {
+      state.support.target = 0;
+      state.element.dataset.supportRole = 'neutral';
+    }
+  });
+  globalState.synergy.target = activeState ? 1 : 0;
+  requestTick();
+}
+
+function pointerPosition(event, element) {
+  const rect = element.getBoundingClientRect();
+  const x = normalise(event.clientX, rect.left, rect.right);
+  const y = normalise(event.clientY, rect.top, rect.bottom);
+  return { x, y };
+}
+
+function handlePointerEnter(state, event) {
+  const { x, y } = pointerPosition(event, state.element);
+  state.pointer.targetX = x;
+  state.pointer.targetY = y;
+  state.pointer.smoothX = x;
+  state.pointer.smoothY = y;
+  state.focus.target = 1;
+  state.element.dataset.hasFocus = 'true';
+  state.element.dataset.interactionActive = 'true';
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState) {
+      groupState.pointer.targetX = x;
+      groupState.pointer.targetY = y;
+      groupState.focus.target = Math.max(groupState.focus.target, 0.85);
+      groupState.synergy.target = Math.max(groupState.synergy.target, 0.6);
+    }
+  }
+  if (state.brandVideo) {
+    state.brandVideo.play().catch(() => {});
+  }
+  updateSupportTargets(state);
+  requestTick();
+}
+
+function handlePointerMove(state, event) {
+  const { x, y } = pointerPosition(event, state.element);
+  const deltaX = state.pointer.lastClientX !== null ? event.clientX - state.pointer.lastClientX : 0;
+  const deltaY = state.pointer.lastClientY !== null ? event.clientY - state.pointer.lastClientY : 0;
+  state.pointer.lastClientX = event.clientX;
+  state.pointer.lastClientY = event.clientY;
+  state.pointer.targetX = x;
+  state.pointer.targetY = y;
+  state.focus.target = Math.min(1.2, state.focus.target + 0.05);
+  state.twist.target = Math.max(-22, Math.min(22, state.twist.target * 0.6 + deltaX * 0.18 - deltaY * 0.12));
+  state.element.dataset.interactionActive = 'true';
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState) {
+      groupState.pointer.targetX = x;
+      groupState.pointer.targetY = y;
+      groupState.synergy.target = Math.max(groupState.synergy.target, 0.8);
+    }
+  }
+  requestTick();
+}
+
+function handlePointerLeave(state) {
+  state.pointer.targetX = 0.5;
+  state.pointer.targetY = 0.5;
+  state.pointer.lastClientX = null;
+  state.pointer.lastClientY = null;
+  state.focus.target = 0;
+  state.twist.target = 0;
+  state.element.dataset.hasFocus = 'false';
+  state.element.dataset.interactionActive = 'false';
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState && groupState.cards.size <= 1) {
+      groupState.pointer.targetX = 0.5;
+      groupState.pointer.targetY = 0.5;
+      groupState.focus.target = 0;
+      groupState.synergy.target = Math.max(0, groupState.synergy.target - 0.35);
+    }
+  }
+  if (activeCardState === state) {
+    updateSupportTargets(null);
+  }
+  requestTick();
+}
+
+function handleClick(state) {
+  state.pulse.target = 1;
+  requestTick();
+}
+
+function handleFocusIn(state) {
+  state.focus.target = 0.85;
+  state.element.dataset.hasFocus = 'true';
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState) {
+      groupState.focus.target = Math.max(groupState.focus.target, 0.85);
+      groupState.synergy.target = Math.max(groupState.synergy.target, 0.7);
+    }
+  }
+  updateSupportTargets(state);
+  requestTick();
+}
+
+function handleFocusOut(state) {
+  state.focus.target = 0;
+  state.element.dataset.hasFocus = 'false';
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState && groupState.cards.size <= 1) {
+      groupState.focus.target = 0;
+      groupState.synergy.target = Math.max(0, groupState.synergy.target - 0.4);
+    }
+  }
+  if (activeCardState === state) {
+    updateSupportTargets(null);
+  }
+  requestTick();
+}
+
+function attachListeners(state) {
+  const element = state.element;
+  const pointerEnter = (event) => handlePointerEnter(state, event);
+  const pointerMove = (event) => handlePointerMove(state, event);
+  const pointerLeave = () => handlePointerLeave(state);
+  const click = () => handleClick(state);
+  const focusIn = () => handleFocusIn(state);
+  const focusOut = () => handleFocusOut(state);
+
+  element.addEventListener('pointerenter', pointerEnter, { passive: true });
+  element.addEventListener('pointermove', pointerMove, { passive: true });
+  element.addEventListener('pointerleave', pointerLeave, { passive: true });
+  element.addEventListener('click', click, { passive: true });
+  element.addEventListener('focusin', focusIn);
+  element.addEventListener('focusout', focusOut);
+
+  state.cleanup = () => {
+    element.removeEventListener('pointerenter', pointerEnter);
+    element.removeEventListener('pointermove', pointerMove);
+    element.removeEventListener('pointerleave', pointerLeave);
+    element.removeEventListener('click', click);
+    element.removeEventListener('focusin', focusIn);
+    element.removeEventListener('focusout', focusOut);
+  };
+}
+
+function registerCard(element) {
+  if (!shouldRegister(element)) {
+    return;
+  }
+  const state = createState(element, cardStates.size);
+  attachListeners(state);
+  requestTick();
+}
+
+function collectCandidateElements(root = document) {
+  const selectors = [
+    '[data-visualizer-card]',
+    '[data-card]',
+    '.global-visualizer-card',
+    '.card',
+    '.project-card',
+    '.version-card',
+    '.experience-card',
+    '.portfolio-card',
+    '.innovation-card',
+    '.module-card',
+    '.hero-card',
+    '.focus-card',
+    '.tilt-card',
+    '.holographic-card',
+    '.vib34d-card',
+    '.trading-card',
+    '.clear-seas-card',
+    '.concept-card',
+    '.immersive-card',
+    '.vision-card',
+    '.galaxy-card',
+    '.grid-card',
+    '.quantum-card',
+    '.ai-card',
+    '.story-card',
+    '.lab-card'
+  ];
+  const elements = new Set();
+  selectors.forEach((selector) => {
+    root.querySelectorAll(selector).forEach((element) => elements.add(element));
+  });
+  return Array.from(elements);
+}
+
+function requestTick() {
+  if (rafId) {
+    return;
+  }
+  rafId = requestAnimationFrame(step);
+}
+
+function step() {
+  rafId = null;
+  let continueAnimation = false;
+  let weightedX = 0;
+  let weightedY = 0;
+  let totalFocus = 0;
+  const toRemove = [];
+
+  cardStates.forEach((state, element) => {
+    syncGroupAssociation(state);
+    if (!document.body.contains(element)) {
+      if (state.cleanup) {
+        state.cleanup();
+      }
+      detachFromGroup(state);
+      toRemove.push(element);
+      return;
+    }
+
+    const focusLerp = 0.12;
+    const pointerLerp = 0.14;
+    const supportLerp = 0.1;
+    const twistLerp = 0.18;
+    const pulseLerp = 0.22;
+    const scrollLerp = 0.16;
+
+    state.pointer.smoothX += (state.pointer.targetX - state.pointer.smoothX) * pointerLerp;
+    state.pointer.smoothY += (state.pointer.targetY - state.pointer.smoothY) * pointerLerp;
+    state.focus.current += (state.focus.target - state.focus.current) * focusLerp;
+    state.support.current += (state.support.target - state.support.current) * supportLerp;
+    state.twist.current += (state.twist.target - state.twist.current) * twistLerp;
+    state.pulse.current += (state.pulse.target - state.pulse.current) * pulseLerp;
+    state.pulse.target *= 0.76;
+
+    state.scroll.current += (state.scroll.target - state.scroll.current) * scrollLerp;
+    state.scroll.target *= 0.82;
+
+    const focusStrength = Math.max(0, Math.min(1.2, state.focus.current));
+    const supportStrength = Math.max(-1, Math.min(1, state.support.current));
+    const twistDeg = state.twist.current;
+    const pulse = Math.max(0, state.pulse.current);
+
+    element.style.setProperty('--card-focus-x', state.pointer.smoothX.toFixed(4));
+    element.style.setProperty('--card-focus-y', state.pointer.smoothY.toFixed(4));
+    element.style.setProperty('--card-focus-strength', focusStrength.toFixed(4));
+    element.style.setProperty('--card-support-intensity', supportStrength.toFixed(4));
+    element.style.setProperty('--card-twist', `${twistDeg.toFixed(3)}deg`);
+    element.style.setProperty('--card-pulse', pulse.toFixed(4));
+    element.style.setProperty('--card-scroll-momentum', state.scroll.current.toFixed(4));
+
+    if (focusStrength > 0.05) {
+      weightedX += state.pointer.smoothX * focusStrength;
+      weightedY += state.pointer.smoothY * focusStrength;
+      totalFocus += focusStrength;
+    }
+
+    if (Math.abs(state.pointer.targetX - state.pointer.smoothX) > 0.001 ||
+        Math.abs(state.pointer.targetY - state.pointer.smoothY) > 0.001 ||
+        Math.abs(state.focus.target - state.focus.current) > 0.001 ||
+        Math.abs(state.support.target - state.support.current) > 0.001 ||
+        Math.abs(state.twist.target - state.twist.current) > 0.001 ||
+        Math.abs(state.scroll.current) > 0.001 ||
+        state.pulse.current > 0.01) {
+      continueAnimation = true;
+    }
+  });
+
+  groupStates.forEach((groupState) => {
+    let weightedGroupX = 0;
+    let weightedGroupY = 0;
+    let groupFocus = 0;
+    groupState.cards.forEach((cardState) => {
+      const cardFocus = Math.max(0, Math.min(1.2, cardState.focus.current));
+      if (cardFocus > 0.05) {
+        weightedGroupX += cardState.pointer.smoothX * cardFocus;
+        weightedGroupY += cardState.pointer.smoothY * cardFocus;
+        groupFocus += cardFocus;
+      }
+    });
+
+    groupState.pointer.targetX = groupFocus > 0 ? weightedGroupX / groupFocus : 0.5;
+    groupState.pointer.targetY = groupFocus > 0 ? weightedGroupY / groupFocus : 0.5;
+    groupState.focus.target = Math.min(1, groupFocus);
+
+    groupState.pointer.currentX += (groupState.pointer.targetX - groupState.pointer.currentX) * 0.16;
+    groupState.pointer.currentY += (groupState.pointer.targetY - groupState.pointer.currentY) * 0.16;
+    groupState.focus.current += (groupState.focus.target - groupState.focus.current) * 0.12;
+    groupState.synergy.current += (groupState.synergy.target - groupState.synergy.current) * 0.12;
+
+    const { element, section } = groupState;
+    element.style.setProperty('--group-focus-amount', groupState.focus.current.toFixed(4));
+    element.style.setProperty('--group-focus-x', groupState.pointer.currentX.toFixed(4));
+    element.style.setProperty('--group-focus-y', groupState.pointer.currentY.toFixed(4));
+    element.style.setProperty('--group-synergy', groupState.synergy.current.toFixed(4));
+
+    if (!groupState.section) {
+      groupState.section = element.closest('.section, section, .section-block, .section-wrapper, .group-section') || null;
+    }
+    if (groupState.section) {
+      groupState.section.dataset.globalGroupActive = groupState.synergy.current > 0.05 ? 'true' : 'false';
+      groupState.section.style.setProperty('--section-focus-amount', groupState.focus.current.toFixed(4));
+      groupState.section.style.setProperty('--section-synergy', groupState.synergy.current.toFixed(4));
+    }
+
+    if (Math.abs(groupState.pointer.targetX - groupState.pointer.currentX) > 0.001 ||
+        Math.abs(groupState.pointer.targetY - groupState.pointer.currentY) > 0.001 ||
+        Math.abs(groupState.focus.current - groupState.focus.target) > 0.001 ||
+        Math.abs(groupState.synergy.current - groupState.synergy.target) > 0.001) {
+      continueAnimation = true;
+    }
+  });
+
+  toRemove.forEach((element) => cardStates.delete(element));
+
+  globalState.scroll.current += (globalState.scroll.target - globalState.scroll.current) * 0.12;
+  globalState.scroll.target *= 0.9;
+  if (Math.abs(globalState.scroll.current) > 0.0001 || Math.abs(globalState.scroll.target) > 0.0001) {
+    continueAnimation = true;
+  }
+
+  globalState.synergy.current += (globalState.synergy.target - globalState.synergy.current) * 0.1;
+  if (Math.abs(globalState.synergy.current - globalState.synergy.target) > 0.001) {
+    continueAnimation = true;
+  }
+
+  const root = document.documentElement;
+  root.style.setProperty('--global-scroll-momentum', globalState.scroll.current.toFixed(4));
+  root.style.setProperty('--global-scroll-tilt', `${(globalState.scroll.current * 10).toFixed(3)}deg`);
+  root.style.setProperty('--global-synergy-glow', globalState.synergy.current.toFixed(4));
+
+  if (totalFocus > 0) {
+    root.style.setProperty('--global-focus-x', (weightedX / totalFocus).toFixed(4));
+    root.style.setProperty('--global-focus-y', (weightedY / totalFocus).toFixed(4));
+    root.style.setProperty('--global-focus-amount', Math.min(1, totalFocus).toFixed(4));
+  } else {
+    root.style.setProperty('--global-focus-x', '0.5');
+    root.style.setProperty('--global-focus-y', '0.5');
+    root.style.setProperty('--global-focus-amount', '0');
+  }
+
+  if (continueAnimation) {
+    requestTick();
+  }
+}
+
+function handleScroll() {
+  const now = performance.now();
+  const deltaY = window.scrollY - globalState.scroll.lastY;
+  const deltaTime = Math.max(16, now - globalState.scroll.lastTime);
+  globalState.scroll.lastY = window.scrollY;
+  globalState.scroll.lastTime = now;
+  const velocity = deltaY / deltaTime;
+  const momentum = Math.max(-3, Math.min(3, velocity * 12));
+  globalState.scroll.target = momentum;
+  cardStates.forEach((state) => {
+    state.scroll.target = momentum;
+  });
+  requestTick();
+}
+
+function observeMutations() {
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (!(node instanceof HTMLElement)) {
+          return;
+        }
+        if (shouldRegister(node)) {
+          registerCard(node);
+        }
+        collectCandidateElements(node).forEach((element) => registerCard(element));
+      });
+    });
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+}
+
+async function initialise() {
+  ensureStylesheet('styles/global-card-synergy.css', 'global-card-synergy');
+  collectCandidateElements().forEach((element) => registerCard(element));
+  observeMutations();
+  window.addEventListener('scroll', handleScroll, { passive: true });
+  let resizeTimeout = null;
+  window.addEventListener('resize', () => {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(() => {
+      collectCandidateElements().forEach((element) => registerCard(element));
+    }, 120);
+  });
+  handleScroll();
+  await ensureCardSystem();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initialise, { once: true });
+} else {
+  initialise();
+}

--- a/scripts/vib34d-contained-card-system.js
+++ b/scripts/vib34d-contained-card-system.js
@@ -5,6 +5,88 @@
  * A Paul Phillips Manifestation - Paul@clearseassolutions.com
  */
 
+const VIB34D_BRAND_LIBRARY_DEFAULTS = {
+  overlays: [
+    'assets/Screenshot_20250430-141821.png',
+    'assets/Screenshot_20250430-142002~2.png',
+    'assets/Screenshot_20250430-142024~2.png',
+    'assets/Screenshot_20250430-142032~2.png',
+    'assets/Screenshot_20241012-073718.png',
+    'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+    'assets/file_0000000054a06230817873012865d150.png',
+    'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+    'assets/image_8 (1).png'
+  ],
+  videos: [
+    '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+    '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+    '1746496560073.mp4',
+    '1746500614769.mp4',
+    '1746576068221.mp4'
+  ],
+  logos: [
+    'assets/clear-seas-logo-aurora.svg',
+    'assets/clear-seas-monogram.svg'
+  ]
+};
+
+function ensureVibSharedBrandLibrary() {
+  const mergeUnique = (target, source) => {
+    if (!Array.isArray(source)) return target;
+    source.forEach((item) => {
+      if (typeof item === 'string' && !target.includes(item)) {
+        target.push(item);
+      }
+    });
+    return target;
+  };
+
+  if (window.ClearSeasBrandLibrary && typeof window.clearSeasAcquireBrandAsset === 'function') {
+    mergeUnique(window.ClearSeasBrandLibrary.overlays ||= [], VIB34D_BRAND_LIBRARY_DEFAULTS.overlays);
+    mergeUnique(window.ClearSeasBrandLibrary.videos ||= [], VIB34D_BRAND_LIBRARY_DEFAULTS.videos);
+    mergeUnique(window.ClearSeasBrandLibrary.logos ||= [], VIB34D_BRAND_LIBRARY_DEFAULTS.logos);
+    return window.clearSeasAcquireBrandAsset;
+  }
+
+  const library = {
+    overlays: [...VIB34D_BRAND_LIBRARY_DEFAULTS.overlays],
+    videos: [...VIB34D_BRAND_LIBRARY_DEFAULTS.videos],
+    logos: [...VIB34D_BRAND_LIBRARY_DEFAULTS.logos],
+    cursor: 0
+  };
+
+  const getPool = (preference) => {
+    const pref = (preference || '').toLowerCase();
+    if (pref.startsWith('video')) return library.videos;
+    if (pref.startsWith('logo')) return library.logos.length ? library.logos : library.overlays;
+    if (pref.startsWith('overlay') || pref.startsWith('image') || pref.startsWith('brand')) {
+      return library.overlays.length ? library.overlays : [...library.logos, ...library.videos];
+    }
+    return [...library.videos, ...library.overlays, ...library.logos];
+  };
+
+  const acquire = (preference) => {
+    const pool = getPool(preference);
+    if (!pool.length) {
+      return null;
+    }
+    const index = Math.abs(library.cursor) % pool.length;
+    library.cursor += 1;
+    const src = pool[index];
+    const type = typeof src === 'string' && src.toLowerCase().endsWith('.mp4') ? 'video' : 'image';
+    return { src, type };
+  };
+
+  library.acquire = acquire;
+  window.ClearSeasBrandLibrary = library;
+  window.clearSeasAcquireBrandAsset = acquire;
+  return acquire;
+}
+
+const acquireVibBrandAsset = ensureVibSharedBrandLibrary();
+
 class VIB34DContainedCardSystem {
   constructor() {
     this.cardVisualizers = new Map();
@@ -120,6 +202,18 @@ class VIB34DContainedVisualizer {
       intensity: 0.7
     };
 
+    this.focusState = {
+      current: 0.28,
+      target: 0.35,
+      pulse: 0,
+      raf: null
+    };
+
+    this.brandHost = null;
+    this.brandMedia = null;
+    this.resizeObserver = null;
+    this.layerCanvases = [];
+
     // VIB34D Parameters - Rich parameter sets based on Paul Phillips' system configurations
     this.parameters = this.getVIB34DParametersForSystem(systemType);
 
@@ -137,100 +231,166 @@ class VIB34DContainedVisualizer {
     this.createContainedCanvasSystem();
     this.setupUserInteractions();
     this.createVIB34DEngine();
+    this.startFocusLoop();
     this.start();
   }
 
   createContainedCanvasSystem() {
-    // Create contained canvas system within card boundaries
-    this.canvasContainer = document.createElement('div');
-    this.canvasContainer.className = 'vib34d-card-container';
-    this.canvasContainer.style.cssText = `
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      border-radius: inherit;
-      pointer-events: none;
-      z-index: 1;
-    `;
-
-    // Ensure card is positioned relatively
     if (getComputedStyle(this.card).position === 'static') {
       this.card.style.position = 'relative';
     }
 
-    // Create 5-layer VIB34D canvas system - CONTAINED within card
+    this.card.classList.add('visualizer-host', 'card-brand-enhanced');
+
+    const baseWeight = Number(this.card.dataset.visualizerWeight || '1.1');
+    const bleed = Number.isFinite(baseWeight) ? Math.max(1.22, baseWeight + 0.2) : 1.28;
+    this.card.style.setProperty('--visualizer-bleed', bleed.toFixed(3));
+    this.card.style.setProperty('--visualizer-scale', (bleed + 0.14).toFixed(3));
+    if (!this.card.style.getPropertyValue('--brand-rotation')) {
+      this.card.style.setProperty('--brand-rotation', `${(Math.random() * 36 - 18).toFixed(2)}deg`);
+    }
+
+    this.canvasContainer = document.createElement('div');
+    this.canvasContainer.className = 'visualizer-shell vib34d-card-container';
+    this.canvasContainer.setAttribute('aria-hidden', 'true');
+    this.canvasContainer.style.pointerEvents = 'none';
+
     const layerNames = ['background', 'shadow', 'content', 'highlight', 'accent'];
     const containerId = `vib34d-card-${Math.random().toString(36).substr(2, 9)}`;
+    this.layerCanvases = [];
 
     layerNames.forEach((layerName, index) => {
       const canvas = document.createElement('canvas');
       canvas.id = `${containerId}-${layerName}`;
-      canvas.className = 'vib34d-card-canvas';
-      canvas.style.cssText = `
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        pointer-events: none;
-        z-index: ${index + 1};
-      `;
-
+      canvas.dataset.visualizerLayer = layerName;
+      canvas.className = `visualizer-shell__canvas vib34d-card-layer vib34d-card-layer--${layerName}`;
+      canvas.style.zIndex = String(index + 1);
       this.canvasContainer.appendChild(canvas);
+      this.layerCanvases.push(canvas);
     });
 
-    // Insert as first child so it stays behind card content
+    this.brandHost = this.attachBrandLayer();
+    if (this.brandHost) {
+      this.canvasContainer.appendChild(this.brandHost);
+    }
+
     this.card.insertBefore(this.canvasContainer, this.card.firstChild);
     this.resizeCanvases();
   }
 
   resizeCanvases() {
+    if (!this.canvasContainer) return;
     const rect = this.card.getBoundingClientRect();
-    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const dpr = Math.min(window.devicePixelRatio || 1, 2.5);
+    const bleedFactor = Number(this.card.style.getPropertyValue('--visualizer-bleed')) || 1.28;
+    const resolutionScale = bleedFactor + 0.36;
 
-    const canvases = this.canvasContainer.querySelectorAll('canvas');
+    const canvases = this.layerCanvases && this.layerCanvases.length
+      ? this.layerCanvases
+      : Array.from(this.canvasContainer.querySelectorAll('canvas'));
+
     canvases.forEach(canvas => {
-      canvas.width = rect.width * dpr;
-      canvas.height = rect.height * dpr;
-      canvas.style.width = rect.width + 'px';
-      canvas.style.height = rect.height + 'px';
+      const width = Math.max(1, Math.round(rect.width * resolutionScale * dpr));
+      const height = Math.max(1, Math.round(rect.height * resolutionScale * dpr));
+      if (canvas.width !== width) canvas.width = width;
+      if (canvas.height !== height) canvas.height = height;
+      canvas.style.width = '100%';
+      canvas.style.height = '100%';
     });
+  }
+
+  attachBrandLayer() {
+    const assetPreference = this.card.dataset.visualizerAsset || this.systemType;
+    if (typeof acquireVibBrandAsset !== 'function') {
+      return null;
+    }
+
+    const asset = acquireVibBrandAsset(assetPreference);
+    if (!asset || !asset.src) {
+      return null;
+    }
+
+    const host = document.createElement('div');
+    host.className = 'visualizer-shell__brand';
+    host.dataset.brandType = asset.type;
+
+    if (!this.card.style.getPropertyValue('--brand-rotation')) {
+      this.card.style.setProperty('--brand-rotation', `${(Math.random() * 32 - 16).toFixed(2)}deg`);
+    }
+
+    if (asset.type === 'video') {
+      host.classList.add('visualizer-shell__brand--video');
+      const video = document.createElement('video');
+      video.className = 'visualizer-shell__brand-media';
+      video.src = asset.src;
+      video.muted = true;
+      video.loop = true;
+      video.autoplay = true;
+      video.playsInline = true;
+      video.setAttribute('muted', '');
+      video.setAttribute('playsinline', '');
+      video.addEventListener('loadeddata', () => {
+        video.play().catch(() => {});
+      }, { once: true });
+      host.appendChild(video);
+      this.brandMedia = video;
+    } else {
+      host.classList.add('visualizer-shell__brand--image');
+      host.style.setProperty('--brand-image', `url(${asset.src})`);
+    }
+
+    this.brandHost = host;
+    return host;
   }
 
   setupUserInteractions() {
     // Smart mouse tracking for elegant parameter changes
-    this.card.addEventListener('mouseenter', () => {
+    const handleEnter = () => {
       this.mouseState.intensity = 1.0;
+      this.focusState.target = Math.max(this.focusState.target, 1.05);
       this.updateVIB34DParameters({ intensity: 1.0 });
-    });
+      if (this.brandMedia) {
+        this.brandMedia.play().catch(() => {});
+      }
+    };
 
-    this.card.addEventListener('mouseleave', () => {
+    const handleLeave = () => {
       this.mouseState.intensity = 0.7;
       this.mouseState.targetX = 0.5;
       this.mouseState.targetY = 0.5;
+      this.focusState.target = Math.max(0.32, this.focusState.target * 0.75);
       this.updateVIB34DParameters({ intensity: 0.7 });
-    });
+    };
 
-    this.card.addEventListener('mousemove', (e) => {
+    const handleMove = (e) => {
       const rect = this.card.getBoundingClientRect();
       this.mouseState.targetX = (e.clientX - rect.left) / rect.width;
       this.mouseState.targetY = (e.clientY - rect.top) / rect.height;
 
       // Convert mouse position to VIB34D rotation parameters
       this.updateMouseBasedParameters();
+    };
+
+    this.card.addEventListener('mouseenter', handleEnter);
+    this.card.addEventListener('mouseleave', handleLeave);
+    this.card.addEventListener('mousemove', handleMove);
+    this.card.addEventListener('pointerdown', () => {
+      this.focusState.pulse = 1;
+      if (this.brandMedia) {
+        this.brandMedia.play().catch(() => {});
+      }
     });
+    this.card.addEventListener('focusin', handleEnter);
+    this.card.addEventListener('focusout', handleLeave);
 
     // Responsive resize observer
-    const resizeObserver = new ResizeObserver(() => {
+    this.resizeObserver = new ResizeObserver(() => {
       this.resizeCanvases();
       if (this.engine && this.engine.resize) {
         this.engine.resize();
       }
     });
-    resizeObserver.observe(this.card);
+    this.resizeObserver.observe(this.card);
   }
 
   getVIB34DParametersForSystem(systemType) {
@@ -339,6 +499,43 @@ class VIB34DContainedVisualizer {
       intensity: Math.max(0.3, Math.min(2.0, intensityModulation)),
       saturation: this.parameters.saturation
     });
+
+    const tiltXDeg = (0.5 - this.mouseState.y) * 18;
+    const tiltYDeg = (this.mouseState.x - 0.5) * 18;
+    this.card.style.setProperty('--tilt-x', `${tiltXDeg.toFixed(2)}deg`);
+    this.card.style.setProperty('--tilt-y', `${tiltYDeg.toFixed(2)}deg`);
+    this.card.style.setProperty('--tilt-x-value', tiltXDeg.toFixed(4));
+    this.card.style.setProperty('--tilt-y-value', tiltYDeg.toFixed(4));
+    this.card.style.setProperty('--focus-pointer-x', this.mouseState.x.toFixed(3));
+    this.card.style.setProperty('--focus-pointer-y', this.mouseState.y.toFixed(3));
+  }
+
+  startFocusLoop() {
+    if (this.focusState.raf) {
+      cancelAnimationFrame(this.focusState.raf);
+    }
+
+    const step = () => {
+      const isEngaged = this.card.matches(':hover') || this.card.matches(':focus-within');
+      const baseTarget = isEngaged ? 1.05 : 0.32;
+      this.focusState.target += (baseTarget - this.focusState.target) * 0.08;
+      this.focusState.current += (this.focusState.target - this.focusState.current) * 0.12;
+      this.focusState.pulse *= 0.88;
+
+      const focusValue = Math.max(0, this.focusState.current);
+      this.card.style.setProperty('--focus-intensity', focusValue.toFixed(3));
+      this.card.style.setProperty('--focus-pulse', this.focusState.pulse.toFixed(3));
+
+      if (this.brandMedia instanceof HTMLVideoElement) {
+        const scrollVelocity = Number(this.card.style.getPropertyValue('--scroll-velocity') || 0);
+        const playbackRate = 0.85 + focusValue * 0.42 + Math.abs(scrollVelocity) * 0.18;
+        this.brandMedia.playbackRate = Math.min(1.8, Math.max(0.7, playbackRate));
+      }
+
+      this.focusState.raf = requestAnimationFrame(step);
+    };
+
+    this.focusState.raf = requestAnimationFrame(step);
   }
 
   updateVIB34DParameters(newParams) {
@@ -467,10 +664,31 @@ class VIB34DContainedVisualizer {
       if (this.engine.destroy) this.engine.destroy();
     }
 
+    if (this.focusState.raf) {
+      cancelAnimationFrame(this.focusState.raf);
+      this.focusState.raf = null;
+    }
+
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+
+    if (this.brandHost && this.brandHost.parentNode) {
+      this.brandHost.parentNode.removeChild(this.brandHost);
+    }
+
     // Remove canvas container
     if (this.canvasContainer && this.canvasContainer.parentNode) {
       this.canvasContainer.parentNode.removeChild(this.canvasContainer);
     }
+
+    this.card.classList.remove('visualizer-host');
+    this.card.classList.remove('card-brand-enhanced');
+    this.brandHost = null;
+    this.brandMedia = null;
+    this.layerCanvases = [];
+    this.canvasContainer = null;
 
     console.log('🗑️ VIB34D contained visualizer destroyed');
   }

--- a/src/core/CanvasManager.js
+++ b/src/core/CanvasManager.js
@@ -115,31 +115,38 @@ export class CanvasManager {
     const canvasIds = this.getCanvasIdsForSystem(systemName);
     
     // Create 5 fresh canvases
+    const bleedScale = 1.3;
     canvasIds.forEach((canvasId, index) => {
       const canvas = document.createElement('canvas');
       canvas.id = canvasId;
       canvas.className = 'visualization-canvas';
       canvas.style.position = 'absolute';
-      canvas.style.top = '0';
-      canvas.style.left = '0';
-      canvas.style.width = '100%';
-      canvas.style.height = '100%';
+      canvas.style.top = '50%';
+      canvas.style.left = '50%';
+      canvas.style.width = `${bleedScale * 100}%`;
+      canvas.style.height = `${bleedScale * 100}%`;
+      canvas.style.transform = 'translate(-50%, -50%) scale(1)';
+      canvas.style.transformOrigin = 'center';
+      canvas.style.pointerEvents = 'none';
+      canvas.style.willChange = 'transform, filter';
       canvas.style.zIndex = index + 1;
-      
-      // Set canvas dimensions
+
+      // Set canvas dimensions with bleed so resolution matches the visual expansion
       const viewWidth = window.innerWidth;
       const viewHeight = window.innerHeight;
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      canvas.width = viewWidth * dpr;
-      canvas.height = viewHeight * dpr;
-      
+      canvas.width = viewWidth * dpr * bleedScale;
+      canvas.height = viewHeight * dpr * bleedScale;
+
       targetContainer.appendChild(canvas);
     });
-    
+
     // Show the target container
     targetContainer.style.display = 'block';
     targetContainer.style.visibility = 'visible';
     targetContainer.style.opacity = '1';
+    targetContainer.style.overflow = 'visible';
+    targetContainer.style.transformStyle = 'preserve-3d';
     
     console.log(`✅ Created 5 fresh canvases for ${systemName}: ${canvasIds.join(', ')}`);
   }

--- a/src/export/TradingCardGenerator.js
+++ b/src/export/TradingCardGenerator.js
@@ -365,6 +365,8 @@ export class TradingCardGenerator {
             --mouse-x: 50%;
             --mouse-y: 50%;
             --bend-intensity: 0;
+            --scroll-tilt: 0;
+            --visualizer-scroll-tilt: 0;
         }
         
         .trading-card:hover {
@@ -482,13 +484,13 @@ export class TradingCardGenerator {
         /* GALLERY-STYLE: Card preview expands and tilts based on mouse position */
         .trading-card:hover .card-preview {
             /* Match gallery card preview behavior exactly */
-            transform: 
+            transform:
                 perspective(1000px)
                 translateZ(30px)
                 scale(1.1)
-                rotateY(calc((var(--mouse-x) - 50) * 0.2deg))
-                rotateX(calc((var(--mouse-y) - 50) * 0.15deg));
-            box-shadow: 
+                rotateY(calc((var(--mouse-x) - 50) * 0.2deg + var(--scroll-tilt, var(--visualizer-scroll-tilt, 0)) * 4deg))
+                rotateX(calc((var(--mouse-y) - 50) * 0.15deg - var(--scroll-tilt, var(--visualizer-scroll-tilt, 0)) * 6deg));
+            box-shadow:
                 0 0 50px rgba(0, 255, 255, 0.6),
                 0 0 100px rgba(255, 0, 255, 0.4),
                 inset 0 0 20px rgba(255, 255, 255, 0.1);
@@ -506,15 +508,28 @@ export class TradingCardGenerator {
             height: 100%;
             position: relative;
             border-radius: 12px;
-            overflow: hidden;
+            overflow: visible;
             background: #000;
+            transform-style: preserve-3d;
+            --visualizer-scroll-tilt: var(--scroll-tilt);
         }
-        
+
         .visualizer-canvas {
-            width: 100%;
-            height: 100%;
-            display: block;
-            border-radius: 10px;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 130%;
+            height: 130%;
+            transform: translate(-50%, -50%) scale(1.12)
+                rotateX(calc(var(--visualizer-scroll-tilt, var(--scroll-tilt, 0)) * -5deg))
+                rotateY(calc(var(--visualizer-scroll-tilt, var(--scroll-tilt, 0)) * 2.5deg));
+            transform-origin: center;
+            border-radius: 16px;
+            filter: saturate(1.1) brightness(1.05);
+            pointer-events: none;
+            box-shadow:
+                0 0 45px rgba(0, 255, 255, 0.25),
+                0 0 85px rgba(255, 0, 255, 0.18);
         }
         
         .stats-panel {
@@ -805,6 +820,8 @@ export class TradingCardGenerator {
             display: flex;
             box-shadow: 0 0 40px hsla(${state.hue}, 80%, 50%, 0.3);
             animation: cardPulse 4s ease-in-out infinite alternate;
+            --scroll-tilt: 0;
+            --visualizer-scroll-tilt: 0;
         }
         
         @keyframes cardPulse {
@@ -816,20 +833,38 @@ export class TradingCardGenerator {
             flex: 1;
             position: relative;
             background: radial-gradient(ellipse at center, hsla(${state.hue}, 80%, 50%, 0.1), rgba(0, 0, 0, 0.8));
+            overflow: visible;
+            transform-style: preserve-3d;
+            --visualizer-scroll-tilt: var(--scroll-tilt);
         }
-        
+
         .visualizer-canvas {
-            width: 100%;
-            height: 100%;
-            display: block;
-            border-radius: 10px;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 135%;
+            height: 135%;
+            transform: translate(-50%, -50%) scale(1.08)
+                rotateX(calc(var(--visualizer-scroll-tilt, var(--scroll-tilt, 0)) * -4deg))
+                rotateY(calc(var(--visualizer-scroll-tilt, var(--scroll-tilt, 0)) * 2deg));
+            transform-origin: center;
+            border-radius: 18px;
+            pointer-events: none;
+            box-shadow:
+                0 0 45px rgba(0, 255, 255, 0.25),
+                0 0 90px rgba(255, 0, 255, 0.18);
         }
         
         .visualizer-container img {
-            width: 100%;
-            height: 100%;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 135%;
+            height: 135%;
+            transform: translate(-50%, -50%) scale(1.08);
             object-fit: cover;
-            border-radius: 10px;
+            border-radius: 18px;
+            pointer-events: none;
         }
         
         .card-info {

--- a/src/holograms/HolographicVisualizer.js
+++ b/src/holograms/HolographicVisualizer.js
@@ -64,11 +64,16 @@ export class HolographicVisualizer {
         this.parallaxDepth = 0.0;
         this.gridDensityShift = 0.0;
         this.colorScrollShift = 0.0;
-        
+        this.scrollTilt = 0.0;
+        this.scrollTiltTarget = 0.0;
+        this.scrollRotationXW = 0.0;
+        this.scrollRotationYW = 0.0;
+        this.scrollRotationZW = 0.0;
+
         // Density system
         this.densityVariation = 0.0;
         this.densityTarget = 0.0;
-        
+
         // Audio reactivity
         this.audioData = { bass: 0, mid: 0, high: 0 };
         this.audioDensityBoost = 0.0;
@@ -76,7 +81,13 @@ export class HolographicVisualizer {
         this.audioSpeedBoost = 0.0;
         this.audioChaosBoost = 0.0;
         this.audioColorShift = 0.0;
-        
+
+        this.externalRotations = {
+            xw: this.variantParams.rot4dXW || 0.0,
+            yw: this.variantParams.rot4dYW || 0.0,
+            zw: this.variantParams.rot4dZW || 0.0
+        };
+
         this.startTime = Date.now();
         this.initShaders();
         this.initBuffers();
@@ -651,6 +662,9 @@ export class HolographicVisualizer {
     updateScroll(deltaY) {
         this.scrollVelocity += deltaY * 0.001;
         this.scrollVelocity = Math.max(-2.0, Math.min(2.0, this.scrollVelocity));
+        const normalized = Math.max(-1.2, Math.min(1.2, deltaY * 0.0025));
+        this.scrollTiltTarget += normalized;
+        this.scrollTiltTarget = Math.max(-2.0, Math.min(2.0, this.scrollTiltTarget));
     }
     
     // Audio reactivity now handled directly in render() loop
@@ -708,6 +722,14 @@ export class HolographicVisualizer {
         this.parallaxDepth = Math.sin(this.scrollPosition * 0.1) * 0.5;
         this.gridDensityShift = Math.sin(this.scrollPosition * 0.05) * 0.3;
         this.colorScrollShift = (this.scrollPosition * 0.02) % (Math.PI * 2);
+        this.scrollTilt += (this.scrollTiltTarget - this.scrollTilt) * 0.12;
+        this.scrollTiltTarget *= 0.88;
+        if (Math.abs(this.scrollTilt) < 0.0005) {
+            this.scrollTilt = 0;
+        }
+        this.scrollRotationXW = this.scrollTilt * 0.48;
+        this.scrollRotationYW = this.scrollTilt * -0.32;
+        this.scrollRotationZW = this.scrollTilt * 0.22;
     }
     
     render() {
@@ -806,9 +828,16 @@ export class HolographicVisualizer {
         this.gl.uniform1f(this.uniforms.audioColorShift, audioColor);
         
         // 4D rotation uniforms
-        this.gl.uniform1f(this.uniforms.rot4dXW, this.variantParams.rot4dXW || 0.0);
-        this.gl.uniform1f(this.uniforms.rot4dYW, this.variantParams.rot4dYW || 0.0);
-        this.gl.uniform1f(this.uniforms.rot4dZW, this.variantParams.rot4dZW || 0.0);
+        const baseRotXW = this.externalRotations.xw ?? (this.variantParams.rot4dXW || 0.0);
+        const baseRotYW = this.externalRotations.yw ?? (this.variantParams.rot4dYW || 0.0);
+        const baseRotZW = this.externalRotations.zw ?? (this.variantParams.rot4dZW || 0.0);
+        const dynamicRotXW = baseRotXW + this.scrollRotationXW;
+        const dynamicRotYW = baseRotYW + this.scrollRotationYW;
+        const dynamicRotZW = baseRotZW + this.scrollRotationZW;
+
+        this.gl.uniform1f(this.uniforms.rot4dXW, dynamicRotXW);
+        this.gl.uniform1f(this.uniforms.rot4dYW, dynamicRotYW);
+        this.gl.uniform1f(this.uniforms.rot4dZW, dynamicRotZW);
         
         this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
     }
@@ -874,9 +903,17 @@ export class HolographicVisualizer {
                         scaledValue = 0.3 + (parseFloat(params[param]) - 5) / 95 * 2.2;
                         console.log(`🔧 Density scaling: gridDensity=${params[param]} → density=${scaledValue.toFixed(3)} (normal range)`);
                     }
-                    
+
                     this.variantParams[mappedParam] = scaledValue;
-                    
+
+                    if (mappedParam === 'rot4dXW') {
+                        this.externalRotations.xw = scaledValue;
+                    } else if (mappedParam === 'rot4dYW') {
+                        this.externalRotations.yw = scaledValue;
+                    } else if (mappedParam === 'rot4dZW') {
+                        this.externalRotations.zw = scaledValue;
+                    }
+
                     // Handle special parameter types
                     if (mappedParam === 'geometryType') {
                         // Regenerate role params with new geometry

--- a/styles/clear-seas-ai.css
+++ b/styles/clear-seas-ai.css
@@ -240,6 +240,161 @@ body::after {
     z-index: -1;
 }
 
+:root,
+.visualizer-host,
+.canvas-card,
+.stacked-card,
+.hero__module,
+.flow-step,
+.flow-thread,
+.system-card,
+.variant-card,
+.signal-card,
+.signal-node,
+.resource-card,
+.micro-card,
+.metric {
+    --tilt-x: 0deg;
+    --tilt-y: 0deg;
+    --tilt-x-value: 0;
+    --tilt-y-value: 0;
+    --tilt-scroll: 0deg;
+    --visualizer-parallax: 0px;
+    --visualizer-rot-xw: 0deg;
+    --visualizer-rot-yw: 0deg;
+    --visualizer-rot-zw: 0deg;
+    --scroll-velocity: 0;
+    --focus-intensity: 0;
+    --focus-pulse: 0;
+    --focus-pointer-x: 0.5;
+    --focus-pointer-y: 0.5;
+    --visualizer-bleed: 1.28;
+    --visualizer-scale: 1.22;
+    --bend-intensity: 0;
+    --bend-tilt-x-deg: 0deg;
+    --bend-tilt-y-deg: 0deg;
+    --bend-skew-x-deg: 0deg;
+    --bend-skew-y-deg: 0deg;
+    --bend-twist-deg: 0deg;
+    --bend-depth: 0px;
+    --visualizer-bend-depth: 0px;
+    --lift-scale: 1;
+    --lift-translate-y: 0px;
+}
+
+.visualizer-host,
+.canvas-card,
+.stacked-card,
+.hero__module,
+.flow-step,
+.flow-thread,
+.system-card,
+.variant-card,
+.signal-card,
+.signal-node,
+.resource-card,
+.micro-card,
+.metric {
+    position: relative;
+    overflow: visible;
+    transform-style: preserve-3d;
+}
+
+.visualizer-host > :not(.visualizer-shell),
+.canvas-card > :not(.visualizer-shell),
+.stacked-card > :not(.visualizer-shell),
+.hero__module > :not(.visualizer-shell) {
+    position: relative;
+    z-index: 2;
+}
+
+.visualizer-shell {
+    position: absolute;
+    inset: calc(-16% * var(--visualizer-bleed, 1.32));
+    pointer-events: none;
+    z-index: 0;
+    overflow: visible;
+    transform-style: preserve-3d;
+    filter: drop-shadow(0 26px 48px rgba(20, 42, 96, 0.45));
+    will-change: transform, filter, opacity;
+}
+
+.visualizer-shell__canvas {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: calc(120% * var(--visualizer-scale, 1.2));
+    height: calc(120% * var(--visualizer-scale, 1.2));
+    transform:
+        translate(-50%, -50%)
+        rotateX(calc(var(--tilt-x, 0deg) + var(--tilt-scroll, 0deg) + var(--bend-tilt-x-deg, 0deg) * 0.55))
+        rotateY(calc(var(--tilt-y, 0deg) + var(--bend-tilt-y-deg, 0deg) * 0.55))
+        rotateZ(calc(var(--visualizer-rot-zw, 0deg) + var(--bend-twist-deg, 0deg) * 0.42))
+        skewX(calc(var(--bend-skew-x-deg, 0deg) * 0.65))
+        skewY(calc(var(--bend-skew-y-deg, 0deg) * 0.65))
+        translate3d(
+            calc(var(--tilt-y-value, 0) * -18px),
+            calc(var(--tilt-x-value, 0) * 18px + var(--visualizer-parallax, 0px)),
+            calc(var(--focus-intensity, 0) * 36px + var(--visualizer-bend-depth, 0px))
+        );
+    border-radius: 28px;
+    opacity: calc(0.78 + var(--focus-intensity, 0) * 0.22);
+    mix-blend-mode: screen;
+    filter:
+        saturate(calc(1.05 + var(--focus-intensity, 0) * 0.35))
+        brightness(calc(1.05 + var(--focus-intensity, 0) * 0.28))
+        contrast(1.05);
+    transition: filter 320ms ease, opacity 280ms ease;
+    backface-visibility: hidden;
+    will-change: transform, opacity, filter;
+}
+
+.visualizer-shell__brand {
+    position: absolute;
+    inset: calc(-28% * var(--visualizer-bleed, 1.2));
+    pointer-events: none;
+    transform-style: preserve-3d;
+    mix-blend-mode: screen;
+    opacity: calc(0.22 + var(--focus-intensity, 0) * 0.42 + var(--focus-pulse, 0) * 0.25);
+    transform:
+        rotate(var(--brand-rotation, 0deg))
+        translate3d(
+            calc(var(--tilt-y-value, 0) * -22px),
+            calc(var(--tilt-x-value, 0) * 22px),
+            calc(var(--focus-intensity, 0) * 42px)
+        );
+    transition:
+        transform 420ms cubic-bezier(0.22, 0.67, 0.3, 1),
+        opacity 320ms ease;
+    filter: saturate(calc(1.1 + var(--focus-intensity, 0) * 0.4)) drop-shadow(0 0 32px rgba(118, 198, 255, 0.35));
+    will-change: transform, opacity, filter;
+}
+
+.visualizer-shell__brand--image::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: var(--brand-image, none);
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.visualizer-shell__brand--video .visualizer-shell__brand-media {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    mix-blend-mode: screen;
+    opacity: 0.78;
+    filter: saturate(1.15) brightness(1.1);
+    border-radius: 28px;
+}
+
+.visualizer-shell__brand-media {
+    display: block;
+    pointer-events: none;
+}
+
 :root[data-background-mode="quantum"] {
     --text-hue-gradient: linear-gradient(130deg, #7af0ff 0%, #ff74f9 44%, #ffd86c 78%, #7effeb 100%);
     --text-hue-glow: rgba(138, 224, 255, 0.4);
@@ -775,7 +930,16 @@ body::after {
     box-shadow: inset 0 0 0 1px rgba(122, 213, 255, 0.05), var(--shadow-soft);
     backdrop-filter: blur(16px);
     transition: transform var(--transition-fast), border-color var(--transition-fast);
-    transform: perspective(900px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(900px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .metric::after {
@@ -857,7 +1021,16 @@ body::after {
     box-shadow: var(--shadow-soft);
     backdrop-filter: blur(18px);
     overflow: hidden;
-    transform: perspective(1300px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1300px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
     transform-style: preserve-3d;
     transition: transform var(--transition-slow), box-shadow var(--transition-fast);
 }
@@ -996,7 +1169,16 @@ body::after {
     backdrop-filter: blur(18px);
     overflow: hidden;
     transition: transform var(--transition-slow), border-color var(--transition-fast), box-shadow var(--transition-fast);
-    transform: perspective(1200px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1200px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .canvas-card::after {
@@ -1088,7 +1270,16 @@ body::after {
     border: 1px solid hsla(var(--card-secondary-hue), 78%, 60%, 0.4);
     box-shadow: 0 50px 110px rgba(10, 12, 36, 0.6);
     backdrop-filter: blur(22px) saturate(145%);
-    transform: perspective(1400px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--stack-translate)) scale(var(--tilt-scale));
+    transform:
+        perspective(1400px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--stack-translate))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--tilt-scale));
     opacity: 0.2;
     filter: blur(var(--stack-blur)) saturate(92%);
     transition: transform 680ms cubic-bezier(0.22, 0.61, 0.36, 1), opacity 520ms ease, filter 520ms ease, border-color 420ms ease, box-shadow 420ms ease, background 560ms ease;
@@ -1215,12 +1406,30 @@ body::after {
     0% {
         opacity: 1;
         filter: blur(0) saturate(118%);
-        transform: perspective(1400px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(0) scale(1);
+        transform:
+            perspective(1400px)
+            rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+            rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+            rotateZ(var(--bend-twist-deg, 0deg))
+            skewX(var(--bend-skew-x-deg, 0deg))
+            skewY(var(--bend-skew-y-deg, 0deg))
+            translateY(0)
+            translateZ(var(--bend-depth, 0px))
+            scale(1);
     }
     100% {
         opacity: 0;
         filter: blur(18px) saturate(80%);
-        transform: perspective(1400px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(-22%) scale(0.86);
+        transform:
+            perspective(1400px)
+            rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+            rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+            rotateZ(var(--bend-twist-deg, 0deg))
+            skewX(var(--bend-skew-x-deg, 0deg))
+            skewY(var(--bend-skew-y-deg, 0deg))
+            translateY(-22%)
+            translateZ(var(--bend-depth, 0px))
+            scale(0.86);
     }
 }
 
@@ -1259,7 +1468,16 @@ body::after {
     box-shadow: var(--shadow-lift);
     backdrop-filter: blur(16px);
     transition: transform var(--transition-slow), box-shadow var(--transition-fast);
-    transform: perspective(1100px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1100px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .flow-step:hover,
@@ -1306,7 +1524,16 @@ body::after {
     overflow: hidden;
     box-shadow: var(--shadow-soft);
     transition: transform var(--transition-slow), border-color var(--transition-fast);
-    transform: perspective(1200px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1200px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .case::before {
@@ -1402,7 +1629,16 @@ body::after {
     border: 1px solid rgba(100, 135, 255, 0.25);
     box-shadow: var(--shadow-lift);
     transition: transform var(--transition-slow), border-color var(--transition-fast);
-    transform: perspective(1100px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1100px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .insight:hover,
@@ -1464,7 +1700,16 @@ body::after {
     border: 1px solid rgba(108, 150, 255, 0.28);
     box-shadow: var(--shadow-lift);
     backdrop-filter: blur(16px);
-    transform: perspective(1100px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1100px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
     transition: transform var(--transition-slow), border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 

--- a/styles/consolidated-styles.css
+++ b/styles/consolidated-styles.css
@@ -153,6 +153,166 @@ body {
 body.loading { overflow: hidden; }
 body.loading * { animation-play-state: paused !important; transition: none !important; }
 
+:root,
+.visualizer-host,
+.tech-card,
+.unified-card,
+.portfolio-item,
+.card,
+.card-shell,
+.polytopal-card,
+.system-card,
+.variant-card,
+.signal-card,
+.resource-card,
+.micro-card,
+.metric,
+.canvas-card,
+.stacked-card {
+    --tilt-x: 0deg;
+    --tilt-y: 0deg;
+    --tilt-x-value: 0;
+    --tilt-y-value: 0;
+    --tilt-scroll: 0deg;
+    --visualizer-parallax: 0px;
+    --visualizer-rot-xw: 0deg;
+    --visualizer-rot-yw: 0deg;
+    --visualizer-rot-zw: 0deg;
+    --scroll-velocity: 0;
+    --focus-intensity: 0;
+    --focus-pulse: 0;
+    --focus-pointer-x: 0.5;
+    --focus-pointer-y: 0.5;
+    --visualizer-bleed: 1.24;
+    --visualizer-scale: 1.18;
+    --bend-intensity: 0;
+    --bend-tilt-x-deg: 0deg;
+    --bend-tilt-y-deg: 0deg;
+    --bend-skew-x-deg: 0deg;
+    --bend-skew-y-deg: 0deg;
+    --bend-twist-deg: 0deg;
+    --bend-depth: 0px;
+    --visualizer-bend-depth: 0px;
+    --lift-scale: 1;
+    --lift-translate-y: 0px;
+}
+
+.visualizer-host,
+.tech-card,
+.unified-card,
+.portfolio-item,
+.card,
+.system-card,
+.variant-card,
+.signal-card,
+.resource-card,
+.micro-card,
+.metric,
+.canvas-card,
+.stacked-card {
+    position: relative;
+    overflow: visible;
+    transform-style: preserve-3d;
+}
+
+.visualizer-host > :not(.visualizer-shell),
+.tech-card > :not(.visualizer-shell),
+.unified-card > :not(.visualizer-shell),
+.portfolio-item > :not(.visualizer-shell),
+.card > :not(.visualizer-shell),
+.canvas-card > :not(.visualizer-shell),
+.stacked-card > :not(.visualizer-shell) {
+    position: relative;
+    z-index: 2;
+}
+
+.visualizer-shell {
+    position: absolute;
+    inset: calc(-14% * var(--visualizer-bleed, 1.26));
+    pointer-events: none;
+    z-index: 0;
+    overflow: visible;
+    transform-style: preserve-3d;
+    filter: drop-shadow(0 28px 52px rgba(10, 24, 64, 0.52));
+    will-change: transform, filter, opacity;
+}
+
+.visualizer-shell__canvas {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: calc(118% * var(--visualizer-scale, 1.16));
+    height: calc(118% * var(--visualizer-scale, 1.16));
+    transform:
+        translate(-50%, -50%)
+        rotateX(calc(var(--tilt-x, 0deg) + var(--tilt-scroll, 0deg) + var(--bend-tilt-x-deg, 0deg) * 0.55))
+        rotateY(calc(var(--tilt-y, 0deg) + var(--bend-tilt-y-deg, 0deg) * 0.55))
+        rotateZ(calc(var(--visualizer-rot-zw, 0deg) + var(--bend-twist-deg, 0deg) * 0.4))
+        skewX(calc(var(--bend-skew-x-deg, 0deg) * 0.65))
+        skewY(calc(var(--bend-skew-y-deg, 0deg) * 0.65))
+        translate3d(
+            calc(var(--tilt-y-value, 0) * -16px),
+            calc(var(--tilt-x-value, 0) * 16px + var(--visualizer-parallax, 0px)),
+            calc(var(--focus-intensity, 0) * 34px + var(--visualizer-bend-depth, 0px))
+        );
+    border-radius: 26px;
+    opacity: calc(0.76 + var(--focus-intensity, 0) * 0.24);
+    mix-blend-mode: screen;
+    filter:
+        saturate(calc(1.04 + var(--focus-intensity, 0) * 0.32))
+        brightness(calc(1.04 + var(--focus-intensity, 0) * 0.26))
+        contrast(1.04);
+    transition: filter 320ms ease, opacity 280ms ease;
+    backface-visibility: hidden;
+    will-change: transform, opacity, filter;
+}
+
+.visualizer-shell__brand {
+    position: absolute;
+    inset: calc(-24% * var(--visualizer-bleed, 1.2));
+    pointer-events: none;
+    transform-style: preserve-3d;
+    mix-blend-mode: screen;
+    opacity: calc(0.2 + var(--focus-intensity, 0) * 0.4 + var(--focus-pulse, 0) * 0.24);
+    transform:
+        rotate(var(--brand-rotation, 0deg))
+        translate3d(
+            calc(var(--tilt-y-value, 0) * -18px),
+            calc(var(--tilt-x-value, 0) * 18px),
+            calc(var(--focus-intensity, 0) * 40px)
+        );
+    transition:
+        transform 400ms cubic-bezier(0.24, 0.66, 0.32, 1),
+        opacity 300ms ease;
+    filter: saturate(calc(1.08 + var(--focus-intensity, 0) * 0.36)) drop-shadow(0 0 28px rgba(90, 192, 255, 0.32));
+    will-change: transform, opacity, filter;
+}
+
+.visualizer-shell__brand--image::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: var(--brand-image, none);
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+.visualizer-shell__brand--video .visualizer-shell__brand-media {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    mix-blend-mode: screen;
+    opacity: 0.76;
+    filter: saturate(1.1) brightness(1.08);
+    border-radius: 26px;
+}
+
+.visualizer-shell__brand-media {
+    display: block;
+    pointer-events: none;
+}
+
 /* ==========================================================================
    3. TYPOGRAPHY SYSTEM
    ========================================================================== */
@@ -356,11 +516,28 @@ a:hover {
     border-radius: 20px;
     background: var(--bg-secondary);
     transform-style: preserve-3d;
-    transition: transform var(--duration-normal) var(--ease-spring), 
+    --card-hover-scale: 1;
+    --card-hover-translate-z: 0px;
+    --card-perspective: var(--perspective, 1400px);
+    transition: transform var(--duration-normal) var(--ease-spring),
                 box-shadow var(--duration-normal) var(--ease-spring);
-    
+    transform:
+        perspective(var(--card-perspective))
+        rotateX(calc(var(--tilt-x, 0deg) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y, 0deg) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translate3d(
+            calc(var(--focus-parallax-x, 0px) * 0.08),
+            calc(var(--lift-translate-y, 0px) + var(--focus-parallax-y, 0px) * 0.08),
+            calc(var(--card-hover-translate-z, 0px) + var(--bend-depth, 0px))
+        )
+        scale(var(--lift-scale, 1))
+        scale(var(--card-hover-scale));
+
     /* Neoskeuomorphic base shadow */
-    box-shadow: 
+    box-shadow:
         -8px -8px 16px var(--neo-shadow-light),
          8px  8px 16px var(--neo-shadow-dark),
          inset 1px 1px 0 var(--neo-highlight);
@@ -368,8 +545,9 @@ a:hover {
 
 /* Total Reactivity System - Pop-out on Hover */
 .unified-card:hover, .tech-card:hover, .portfolio-item:hover {
-    transform: scale(var(--pop-out-scale)) translateZ(var(--pop-out-translate-z));
-    box-shadow: 
+    --card-hover-scale: var(--pop-out-scale);
+    --card-hover-translate-z: var(--pop-out-translate-z);
+    box-shadow:
         0 0 50px var(--theme-primary),
         0 0 80px var(--theme-secondary),
         -12px -12px 24px var(--neo-shadow-light),

--- a/styles/global-card-synergy.css
+++ b/styles/global-card-synergy.css
@@ -1,0 +1,324 @@
+:root {
+  --global-focus-x: 0.5;
+  --global-focus-y: 0.5;
+  --global-focus-amount: 0;
+  --global-scroll-momentum: 0;
+  --global-scroll-tilt: 0deg;
+  --global-synergy-glow: 0;
+}
+
+body {
+  --global-background-shift-x: calc((var(--global-focus-x) - 0.5) * 12px + var(--global-scroll-momentum) * 18px);
+  --global-background-shift-y: calc((0.5 - var(--global-focus-y)) * 10px);
+  background-position: calc(50% + var(--global-background-shift-x)) calc(50% + var(--global-background-shift-y));
+  transition: background-position 0.8s ease, filter 0.8s ease;
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: -45%;
+  z-index: -1;
+  pointer-events: none;
+  background: radial-gradient(
+    circle at calc(var(--global-focus-x) * 100%) calc(var(--global-focus-y) * 100%),
+    rgba(0, 255, 255, calc(0.08 + var(--global-synergy-glow) * 0.4)),
+    rgba(110, 40, 255, calc(0.06 + var(--global-synergy-glow) * 0.35)) 52%,
+    rgba(8, 10, 24, 0) 82%
+  );
+  opacity: calc(0.12 + var(--global-synergy-glow) * 0.45);
+  filter: blur(calc(120px - var(--global-synergy-glow) * 60px));
+  transform: rotateZ(var(--global-scroll-tilt))
+    scale(calc(1 + var(--global-synergy-glow) * 0.22))
+    translateZ(-60px);
+  transition: opacity 0.8s ease, transform 0.8s ease, filter 0.8s ease;
+  mix-blend-mode: screen;
+}
+
+[data-global-card-group="true"] {
+  position: relative;
+  z-index: 0;
+  --group-focus-amount: 0;
+  --group-focus-x: 0.5;
+  --group-focus-y: 0.5;
+  --group-synergy: 0;
+  transform-style: preserve-3d;
+  transition: transform 0.6s ease, filter 0.6s ease, box-shadow 0.6s ease;
+  overflow: visible;
+}
+
+[data-global-card-group="true"]::before {
+  content: '';
+  position: absolute;
+  inset: -8% -6%;
+  z-index: -2;
+  border-radius: clamp(18px, 6vw, 48px);
+  background: radial-gradient(
+    circle at calc(var(--group-focus-x) * 100%) calc(var(--group-focus-y) * 100%),
+    rgba(0, 255, 255, calc(0.08 + var(--group-focus-amount) * 0.35 + var(--group-synergy) * 0.25)),
+    rgba(132, 56, 255, calc(0.05 + var(--group-synergy) * 0.25)) 48%,
+    rgba(8, 10, 24, 0) 80%
+  );
+  opacity: calc(0.12 + var(--group-synergy) * 0.4);
+  filter: blur(calc(28px - var(--group-focus-amount) * 12px));
+  transform: translateZ(-60px) scale(calc(1 + var(--group-synergy) * 0.08));
+  transition: opacity 0.6s ease, filter 0.6s ease, transform 0.6s ease;
+  pointer-events: none;
+}
+
+[data-global-card-group="true"] > * {
+  position: relative;
+  z-index: 1;
+}
+
+[data-global-group-active="true"] {
+  filter: saturate(calc(1 + var(--section-synergy, 0) * 0.35))
+    brightness(calc(1 + var(--section-synergy, 0) * 0.15));
+  transition: filter 0.6s ease;
+}
+
+[data-global-card-group="true"] :is(h1, h2, h3, h4, h5, h6,
+  .section-title,
+  .version-title,
+  .card-title,
+  .group-title,
+  .section-intro,
+  .version-description,
+  .card-description) {
+  transition: color 0.6s ease, text-shadow 0.6s ease, transform 0.6s ease;
+}
+
+[data-global-card-group="true"][data-global-group-active="true"] :is(h1, h2, h3, h4, h5, h6,
+  .section-title,
+  .version-title,
+  .card-title,
+  .group-title) {
+  color: rgba(255, 255, 255, calc(0.82 + var(--group-focus-amount) * 0.25));
+  text-shadow:
+    0 0 calc(12px + var(--group-focus-amount) * 20px) rgba(0, 255, 255, 0.28),
+    0 0 calc(22px + var(--group-synergy) * 40px) rgba(132, 56, 255, 0.24);
+  transform: translateZ(calc(var(--group-focus-amount) * 12px));
+}
+
+[data-global-card-group="true"][data-global-group-active="true"] :is(.section-intro,
+  .version-description,
+  .card-description) {
+  color: rgba(255, 255, 255, calc(0.68 + var(--group-synergy) * 0.2));
+  text-shadow: 0 0 calc(10px + var(--group-synergy) * 16px) rgba(0, 255, 255, 0.18);
+}
+
+.global-visualizer-card,
+[data-visualizer-card] {
+  position: relative;
+  transform-style: preserve-3d;
+  --card-focus-x: 0.5;
+  --card-focus-y: 0.5;
+  --card-focus-strength: 0;
+  --card-support-intensity: 0;
+  --card-scroll-momentum: 0;
+  --card-twist: 0deg;
+  --card-pulse: 0;
+  --card-overlay-shift: 0px;
+  transition:
+    box-shadow 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+    border-color 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+    filter 0.6s ease;
+  will-change: transform, box-shadow, filter;
+  contain: layout paint;
+}
+
+.global-visualizer-card[data-support-role="primary"],
+[data-visualizer-card][data-support-role="primary"] {
+  z-index: 5;
+  filter: saturate(calc(1.05 + var(--card-focus-strength) * 0.45))
+    brightness(calc(1 + var(--card-focus-strength) * 0.2));
+}
+
+.global-visualizer-card[data-support-role="supporting"],
+[data-visualizer-card][data-support-role="supporting"] {
+  opacity: calc(0.82 + var(--card-support-intensity) * 0.18);
+  filter: saturate(calc(0.86 + var(--card-focus-strength) * 0.2));
+  transform: perspective(1600px)
+    rotateX(calc((0.5 - var(--card-focus-y)) * 22deg + var(--card-scroll-momentum) * 4deg))
+    rotateY(calc((var(--card-focus-x) - 0.5) * 20deg))
+    rotateZ(calc(var(--card-twist) * 0.82))
+    translateZ(calc(var(--card-focus-strength) * 26px))
+    scale(calc(1 + var(--card-focus-strength) * 0.04 + var(--card-support-intensity) * 0.02));
+}
+
+.global-visualizer-card[data-support-role="ambient"],
+[data-visualizer-card][data-support-role="ambient"] {
+  opacity: calc(0.72 + var(--card-support-intensity) * 0.2);
+  filter: saturate(calc(0.78 + var(--card-focus-strength) * 0.18));
+  transform: perspective(1500px)
+    rotateX(calc((0.5 - var(--card-focus-y)) * 18deg + var(--card-scroll-momentum) * 2deg))
+    rotateY(calc((var(--card-focus-x) - 0.5) * 18deg))
+    rotateZ(calc(var(--card-twist) * 0.65))
+    translateZ(calc(var(--card-focus-strength) * 18px))
+    scale(calc(0.98 + var(--card-support-intensity) * 0.02));
+}
+
+.global-visualizer-card[data-support-role="neutral"],
+[data-visualizer-card][data-support-role="neutral"] {
+  opacity: 1;
+}
+
+.global-visualizer-card::before,
+[data-visualizer-card]::before {
+  content: '';
+  position: absolute;
+  inset: -14%;
+  background: radial-gradient(
+    circle at calc(var(--card-focus-x) * 100%) calc(var(--card-focus-y) * 100%),
+    rgba(0, 255, 255, calc(0.18 + var(--card-focus-strength) * 0.4 + var(--card-support-intensity) * 0.2)),
+    rgba(132, 56, 255, calc(0.12 + var(--card-support-intensity) * 0.25)) 45%,
+    rgba(12, 12, 32, 0) 78%
+  );
+  opacity: calc(0.35 + var(--card-focus-strength) * 0.5 + var(--card-support-intensity) * 0.25 + var(--group-synergy, 0) * 0.3 + var(--card-pulse) * 0.25);
+  filter: blur(calc(22px - var(--card-focus-strength) * 8px - var(--group-synergy, 0) * 6px - var(--card-pulse) * 4px));
+  transform: translateZ(-24px) scale(calc(1.08 + var(--group-synergy, 0) * 0.06 + var(--card-pulse) * 0.05));
+  pointer-events: none;
+  z-index: 0;
+  transition: opacity 0.6s ease, filter 0.6s ease;
+}
+
+.global-visualizer-card::after,
+[data-visualizer-card]::after {
+  content: '';
+  position: absolute;
+  inset: -8%;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, calc(0.1 + var(--card-support-intensity) * 0.3));
+  opacity: calc(0.25 + var(--card-focus-strength) * 0.35 + var(--group-synergy, 0) * 0.2);
+  filter: blur(calc(6px - var(--card-focus-strength) * 2px - var(--group-synergy, 0) * 1.2px));
+  pointer-events: none;
+  z-index: 1;
+  mix-blend-mode: screen;
+  transition: opacity 0.6s ease, filter 0.6s ease;
+}
+
+.global-visualizer-card,
+[data-visualizer-card] {
+  transform:
+    perspective(1600px)
+    rotateX(calc((0.5 - var(--card-focus-y)) * 26deg + var(--card-scroll-momentum) * 6deg))
+    rotateY(calc((var(--card-focus-x) - 0.5) * 28deg))
+    rotateZ(calc(var(--card-twist)))
+    translateZ(calc(var(--card-focus-strength) * 48px))
+    scale(calc(1 + var(--card-focus-strength) * 0.06 + var(--card-support-intensity) * 0.03));
+  box-shadow:
+    0 30px 70px rgba(8, 12, 32, calc(0.25 + var(--card-focus-strength) * 0.35)),
+    0 12px 34px rgba(0, 240, 255, calc(0.12 + var(--card-support-intensity) * 0.3)),
+    inset 0 1px 0 rgba(255, 255, 255, calc(0.2 + var(--card-focus-strength) * 0.3)),
+    0 0 calc(26px + var(--card-pulse) * 80px) rgba(0, 255, 255, calc(0.12 + var(--card-pulse) * 0.35));
+  border: 1px solid rgba(255, 255, 255, calc(0.18 + var(--card-focus-strength) * 0.35));
+  filter: saturate(calc(1 + var(--card-focus-strength) * 0.4 + var(--card-support-intensity) * 0.3))
+    brightness(calc(1 + var(--card-support-intensity) * 0.15));
+}
+
+.global-visualizer-card .global-brand-overlay,
+[data-visualizer-card] .global-brand-overlay {
+  position: absolute;
+  inset: -22%;
+  z-index: 2;
+  border-radius: inherit;
+  pointer-events: none;
+  background-size: cover;
+  background-position: center;
+  opacity: calc(0.2 + var(--card-focus-strength) * 0.55 + var(--card-support-intensity) * 0.35 + var(--group-synergy, 0) * 0.18 + var(--card-pulse) * 0.3);
+  mix-blend-mode: screen;
+  filter: saturate(calc(1.2 + var(--card-focus-strength) * 1.4 + var(--group-synergy, 0) * 0.6))
+    blur(calc((0.4 - var(--card-focus-strength) * 0.3 - var(--group-synergy, 0) * 0.1) * 18px - var(--card-pulse) * 6px));
+  transform:
+    translateZ(calc(18px + var(--card-focus-strength) * 36px + var(--group-synergy, 0) * 24px))
+    rotateX(calc(var(--card-scroll-momentum) * -1.8deg + var(--group-synergy, 0) * -1.2deg))
+    rotateY(calc(var(--card-scroll-momentum) * 1.6deg + var(--group-synergy, 0) * 1.1deg))
+    scale(calc(1.02 + var(--card-pulse) * 0.08));
+  transition: opacity 0.5s ease, filter 0.6s ease, transform 0.6s ease;
+}
+
+.global-brand-overlay video,
+.global-brand-overlay img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.9;
+  filter: inherit;
+  mix-blend-mode: inherit;
+}
+
+.global-brand-overlay::after {
+  content: '';
+  position: absolute;
+  inset: -10%;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+  opacity: calc(0.45 + var(--card-focus-strength) * 0.4);
+  transform: translateZ(12px);
+}
+
+.global-visualizer-card canvas[data-visualizer],
+.global-visualizer-card canvas[data-vib34d],
+.global-visualizer-card canvas[class*="visualizer"],
+.global-visualizer-card canvas[class*="hologram"],
+.global-visualizer-card .holographic-canvas canvas,
+[data-visualizer-card] canvas[data-visualizer],
+[data-visualizer-card] canvas[data-vib34d],
+[data-visualizer-card] canvas[class*="visualizer"],
+[data-visualizer-card] canvas[class*="hologram"],
+[data-visualizer-card] .holographic-canvas canvas {
+  position: absolute;
+  inset: -18%;
+  width: 136%;
+  height: 136%;
+  transform:
+    translateZ(calc(-36px + var(--card-focus-strength) * -18px - var(--group-synergy, 0) * 16px))
+    rotateX(calc((0.5 - var(--card-focus-y)) * 18deg + var(--card-scroll-momentum) * 4deg + var(--group-synergy, 0) * 2deg))
+    rotateY(calc((var(--card-focus-x) - 0.5) * 18deg + var(--group-synergy, 0) * -2deg))
+    scale(calc(1.02 + var(--card-pulse) * 0.05));
+  filter: saturate(calc(1.1 + var(--card-focus-strength) * 0.4 + var(--group-synergy, 0) * 0.25));
+  pointer-events: none;
+  transition: transform 0.6s ease, filter 0.6s ease;
+}
+
+.global-visualizer-card[data-has-focus="true"]::before,
+[data-visualizer-card][data-has-focus="true"]::before {
+  opacity: calc(0.5 + var(--card-focus-strength) * 0.35);
+}
+
+.global-visualizer-card[data-has-focus="true"]::after,
+[data-visualizer-card][data-has-focus="true"]::after {
+  opacity: calc(0.38 + var(--card-focus-strength) * 0.4);
+}
+
+.global-visualizer-card .supporting-layer,
+[data-visualizer-card] .supporting-layer {
+  transform: translateZ(calc(-20px + var(--card-support-intensity) * -10px));
+  opacity: calc(0.6 + var(--card-support-intensity) * 0.4);
+  transition: transform 0.6s ease, opacity 0.6s ease;
+}
+
+.global-visualizer-card[data-interaction-active="true"],
+[data-visualizer-card][data-interaction-active="true"] {
+  filter: brightness(calc(1.05 + var(--card-focus-strength) * 0.2));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .global-visualizer-card,
+  [data-visualizer-card] {
+    transition: none;
+    transform: none !important;
+    box-shadow: none;
+  }
+
+  .global-visualizer-card::before,
+  [data-visualizer-card]::before,
+  .global-visualizer-card::after,
+  [data-visualizer-card]::after,
+  .global-visualizer-card .global-brand-overlay,
+  [data-visualizer-card] .global-brand-overlay {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- convert each card's scroll momentum tracking into a smoothed target/current pair so the orchestrator keeps tilt cues aligned with global velocity
- extend the global synergy stylesheet with a scroll-reactive backdrop aura and pulse-amplified overlays so supporting layers echo the focused card

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d5b334633c8329b71690cbd1ca4576