### PR TITLE
feat: add manifest tagging and surface site metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 The repository now serves as the **CSS-Web-Master** control surface for the Clear Seas family of properties. It retains every
 historical Clear Seas Draft experience while layering documentation, orchestration guides, and asset registries so new landing
-pages—like **paraerator.com**, **vib3code.com**, and future CSS destinations—can inherit the same choreography with minimal
+pages—like **parserator.com**, **vib3code.com**, and future CSS destinations—can inherit the same choreography with minimal
 duplication.
+
+Runtime globals now expose both `__CSS_WEB_MASTER_*` and legacy `__CLEAR_SEAS_*` namespaces, and shared typography/color tokens
+live in `styles/css-web-master-tokens.css` so each property can reskin the choreography without forking the master styles.
+Brand asset rotations are sourced from `scripts/site-asset-manifest.js`, and teams can call
+`window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST` to swap media packs per property without touching the orchestrator core.
 
 ### ✅ Deployment Snapshot
 - **6 Main HTML Versions**: Baseline production-ready experiences.
@@ -55,9 +60,13 @@ Additional CSS-Web-Master documentation is tracked in:
 - [`docs/css-web-master-system-overview.md`](docs/css-web-master-system-overview.md) – explains the multi-site orchestration
   model, shared registries, and how to extend the system for new CSS properties.
 - [`docs/css-web-master-gap-analysis.md`](docs/css-web-master-gap-analysis.md) – outlines Clear Seas-specific assumptions to
-  generalize before production rollouts on paraerator.com or vib3code.com.
+  generalize before production rollouts on parserator.com or vib3code.com.
 - [`docs/dev-updates/2025-05-07-css-web-master-transition.md`](docs/dev-updates/2025-05-07-css-web-master-transition.md) –
   developer log detailing the latest transition steps and recommended next moves.
+- [`styles/css-web-master-tokens.css`](styles/css-web-master-tokens.css) – neutral design tokens consumed by consolidated
+  stylesheets for per-site overrides.
+- [`docs/html-version-test-report.md`](docs/html-version-test-report.md) – latest smoke-test results for every HTML build and the
+  outstanding defects to close before CSS-Web-Master goes live.
 
 ---
 © 2025 Paul Phillips - Clear Seas Solutions LLC

--- a/docs/brand-asset-overrides.md
+++ b/docs/brand-asset-overrides.md
@@ -49,6 +49,37 @@ window.__CLEAR_SEAS_CARD_BRAND_OVERRIDES = [
 
 Keys mirror the data attributes and accept the same value shapes. The orchestrator merges all matching descriptors (ordered as provided), then layers data attributes on top.
 
+## Site asset manifest
+
+Each site can point the orchestrator at a different base image/video rotation without editing the core script. The default packs
+live in `scripts/site-asset-manifest.js`, and the orchestrator exposes a helper for runtime updates:
+
+```html
+<script type="module">
+  window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST?.({
+    parserator: {
+      images: [
+        // Replace with parserator-specific assets once they are uploaded
+        'assets/parserator/logo.png',
+        'assets/parserator/hangar.png'
+      ],
+      videos: [
+        'assets/parserator/atmos-loop.mp4'
+      ]
+    }
+  }, { reason: 'parserator-brand-pack' });
+</script>
+```
+
+The helper merges the manifest, refreshes the current page profile's media selection, and dispatches the same
+`css-web-master:brand-overrides-changed` / `clear-seas:brand-overrides-changed` events that card systems already listen for.
+If no runtime manifest is provided the default Clear Seas pack remains in rotation.
+
+Each manifest entry can also expose tagged rotations via a `tags` map. When the orchestrator resolves a page profile it passes
+the detected site code or family as the preferred tag, letting you maintain deterministic asset orders for `foundation`,
+`immersive`, `labs`, or `parserator` without duplicating the entire list. Tagged bundles inherit any untagged `images`/`videos`
+from their parent entry, so you can declare a short, site-specific subset and fall back to the shared rotation when necessary.
+
 ## Updating overrides at runtime
 
 When overrides change after the orchestrator has initialised, call the shared refresh helper to keep every card system in sync:

--- a/docs/css-web-master-gap-analysis.md
+++ b/docs/css-web-master-gap-analysis.md
@@ -1,43 +1,49 @@
 # CSS-Web-Master Gap Analysis
 
 This checklist captures the Clear Seas-specific assumptions that still live in the codebase. Addressing each item will make the
-CSS-Web-Master platform production-ready for paraerator.com, vib3code.com, and future CSS family properties.
+CSS-Web-Master platform production-ready for parserator.com, vib3code.com, and future CSS family properties.
 
 ## Naming & Branding
 
 - **Global variables & events** still use the `clear-seas` prefix (`window.__CLEAR_SEAS_GLOBAL_MOTION`, `clear-seas:motion-updated`).
-  - *Action:* Introduce aliases or a namespace bridge (e.g., `window.__CSS_WEB_MASTER`) so downstream integrations can migrate
-    without breaking existing builds.
-- **Dataset attributes** applied by `global-page-orchestrator` are `data-global-page-family/layout`. Confirm if new properties
-  require additional tags (e.g., `data-site-code`).
+  - ✅ **Completed:** `global-page-orchestrator`, `card-system-initializer`, and `vib34d-contained-card-system` now publish
+    `__CSS_WEB_MASTER_*` globals and dispatch both `css-web-master:*` and legacy `clear-seas:*` events.
+  - ⏭️ *Follow-on:* Audit bespoke modules for hard-coded event strings and migrate them to the registry aliases.
+- **Dataset attributes** applied by `global-page-orchestrator` are `data-global-page-family/layout`. ✅ **Completed:** The
+  registry now mirrors the page collection and site code onto both `<html>` and `<body>` so downstream scripts can read
+  `data-page-collection` / `data-site-code` without custom bootstrapping.
 
 ## Page Profile Registry
 
 - Profiles currently reference Clear Seas-specific copy and brand asset packages.
-  - *Action:* Split palette metadata from marketing copy to allow new sites to opt into the same colors without inheriting copy.
+  - ✅ **Completed:** Palette definitions now live in a shared library, and a `parserator` site profile demonstrates how new
+    properties reuse the foundation palette while swapping copy/modules.
 - Filename heuristics prioritize `index`/`pr` naming. Define detection patterns for future site URLs or configure explicit
   overrides.
 
 ## Asset Management
 
 - The brand override registry expects assets in `/assets/` with Clear Seas naming conventions.
-  - *Action:* Add configuration hooks (JSON or module exports) so each site can define its own asset manifest without editing the
-    orchestrator.
+  - ✅ **Completed:** Introduced `scripts/site-asset-manifest.js` and a runtime registration helper so each site can publish its
+    own asset package while the orchestrator resolves the correct image/video rotation automatically.
+  - ⏭️ *Follow-on:* Provide tooling to lint manifests against actual files and surface missing asset warnings during local builds.
 - Uploaded mp4 overlays are catalogued but not yet grouped by campaign/site.
-  - *Action:* Tag assets by site or theme within the registry for deterministic rotation.
+  - ✅ **Completed:** Manifest entries accept tagged rotations, enabling deterministic per-site media bundles while preserving
+    shared fallbacks.
 
 ## Styling Systems
 
 - `styles/clear-seas-ai.css` includes marketing copy classes and iconography unique to the Clear Seas mission deck.
   - *Action:* Extract generic motion/visualizer styles into a neutral stylesheet and let each site layer its own typography.
 - `styles/consolidated-styles.css` references fonts and color tokens specific to Clear Seas.
-  - *Action:* Externalize font stacks and color tokens into CSS variables so sites can swap values without duplicating files.
+  - ✅ **Completed:** Neutral tokens live in `styles/css-web-master-tokens.css`, and downstream styles consume them via CSS
+    variables for per-site overrides.
 
 ## Documentation
 
 - The Master Index references Clear Seas experiences throughout.
   - *Action:* Update hero copy per site launch, or create property-specific indexes that reuse the same component grid.
-- Add runbooks for deploying to each production host (paraerator.com, vib3code.com) once the orchestration pattern is finalized.
+- Add runbooks for deploying to each production host (parserator.com, vib3code.com) once the orchestration pattern is finalized.
 
 ## Tooling Wishlist
 

--- a/docs/css-web-master-system-overview.md
+++ b/docs/css-web-master-system-overview.md
@@ -8,7 +8,7 @@ can reuse without rewriting motion logic or asset loading rules.
 
 1. **Unify shared infrastructure.** Global scripts (`global-page-orchestrator`, `page-profile-registry`) centralize brand
    palettes, asset rotation, and CSS variable broadcasting so each site inherits the same reactive scaffolding.
-2. **Scale across properties.** paraerator.com, vib3code.com, and other CSS launches can point at the same orchestrator and
+2. **Scale across properties.** parserator.com, vib3code.com, and other CSS launches can point at the same orchestrator and
    stylesheet bundle, then layer site-specific copy or modules on top.
 3. **Preserve creative experimentation.** Every HTML build remains available as a reference implementation, letting teams remix
    existing choreography patterns instead of starting from scratch.
@@ -28,9 +28,12 @@ can reuse without rewriting motion logic or asset loading rules.
 1. **Choose a baseline template** from the Master Index based on the desired experience (e.g., Immersive AI deck, Blueprint lab,
    Totalistic showcase).
 2. **Set the page profile** using `data-page-collection` or filename conventions so the orchestrator loads the correct palette
-   and asset set.
-3. **Register brand assets** through the shared brand override registry or by dropping new media into `assets/` and referencing
-   them within the profile metadata.
+   and asset set. The registry now writes both `data-page-collection` and `data-site-code` onto the `<html>` and `<body>`
+   elements, so downstream scripts can immediately infer the active site without custom bootstrapping. Override the
+   auto-detected values when launching new properties that break from the filename heuristics.
+3. **Register brand assets** through the shared brand override registry or by updating the site asset manifest (either editing
+   `scripts/site-asset-manifest.js` or calling `window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST` with a runtime manifest) so the
+   orchestrator rotates the correct media package.
 4. **Customize copy and modules** while leaving the orchestrator hooks in place so focus, pointer, and scroll telemetry continue
    to propagate to canvases, overlays, and videos.
 5. **Document site-specific adjustments** in the `/docs` folder to keep the control surface accurate for each deployment.
@@ -39,16 +42,30 @@ can reuse without rewriting motion logic or asset loading rules.
 
 - **Brand overrides**: Use `docs/brand-asset-overrides.md` as the canonical guide. New logo treatments, translucent overlays, or
   short-form mp4 loops can be registered once and consumed across every card system.
+- **Site asset manifest**: `scripts/site-asset-manifest.js` hosts per-site image/video rotations. Update it (or call
+  `window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST`) to point a property at the correct media pack without editing the
+  orchestrator. Each manifest entry now supports tagged rotations (e.g., `foundation`, `immersive`, `parserator`) so you can
+  pin deterministic asset orders per site or campaign while still inheriting shared fallbacks.
 - **Uploaded media**: Recent additions (e.g., `20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4`,
   `20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4`) are ready for rotation within the
   orchestrator-managed palettes.
 - **Overscan defaults**: Canvas overscan is now managed globally, ensuring holographic visuals always bleed past card edges while
   respecting tilt and bend cues supplied by motion telemetry.
 
+## Site codes & design tokens
+
+- **Namespace bridge:** Runtime globals now publish both `__CSS_WEB_MASTER_*` and legacy `__CLEAR_SEAS_*` properties. New builds
+  should subscribe to `css-web-master:motion-updated` (via `window.__CSS_WEB_MASTER_GLOBAL_MOTION_EVENT`) while maintaining
+  legacy listeners.
+- **Profile palette library:** Palette metadata is defined once and shared across profiles. The new `parserator` entry reuses the
+  foundation palette while layering property-specific scripts and copy.
+- **Token overrides:** `styles/css-web-master-tokens.css` centralises typography, color, and motion variables. Override
+  `--csswm-*` tokens per site to re-skin experiences without duplicating the choreography stylesheets.
+
 ## Extending to New Sites
 
-- **paraerator.com**: Start from a PR-series immersive deck to reuse mission-axis navigation. Update the profile registry with a
-  `paraerator` family that swaps in the new logos/videos and adjust copy modules accordingly.
+- **parserator.com**: Start from a PR-series immersive deck to reuse mission-axis navigation. Update the profile registry with a
+  `parserator` family that swaps in the new logos/videos and adjust copy modules accordingly.
 - **vib3code.com**: Leverage the VIB34D-integrated builds for continuity with the existing visualizer engines. Register
   additional shader parameters if new interaction types are required.
 - **Future CSS properties**: Define new families within `page-profile-registry`, point them at shared synergy styles, and create

--- a/docs/dev-updates/2025-05-07-css-web-master-transition.md
+++ b/docs/dev-updates/2025-05-07-css-web-master-transition.md
@@ -7,7 +7,7 @@
 - Authored the **CSS-Web-Master System Overview** documenting the orchestration layers, workflow, and asset strategy for
   multi-site reuse.
 - Captured a **Gap Analysis** outlining Clear Seas-specific assumptions that need generalization before deploying to
-  paraerator.com, vib3code.com, or other destinations.
+  parserator.com, vib3code.com, or other destinations.
 
 ## Why it matters
 
@@ -18,7 +18,7 @@
 
 ## Next recommendations
 
-1. Prototype a new page profile (e.g., `paraerator`) in `scripts/page-profile-registry.js` to validate the workflow and confirm
+1. Prototype a new page profile (e.g., `parserator`) in `scripts/page-profile-registry.js` to validate the workflow and confirm
    asset overrides behave as expected.
 2. Introduce namespace aliases for the global motion object/event to decouple future builds from the `clear-seas` prefix.
 3. Begin extracting neutral typography and color tokens into a shared variables file so each site can ship with its own brand

--- a/docs/dev-updates/2025-05-08-site-asset-manifest.md
+++ b/docs/dev-updates/2025-05-08-site-asset-manifest.md
@@ -1,0 +1,23 @@
+# Dev Update – 8 May 2025
+
+## What changed
+
+- Added `scripts/site-asset-manifest.js` to centralize default image/video rotations and support per-site overrides.
+- Updated `global-page-orchestrator.js` to resolve brand assets via the manifest, expose
+  `window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST`, and synchronize both Clear Seas and CSS-Web-Master event namespaces when the
+  manifest changes.
+- Refreshed documentation (`README.md`, system overview, gap analysis, and brand override guide) so teams know how to publish
+  their own media packs without editing the orchestrator.
+
+## Why it matters
+
+- The Clear Seas showcase can now act as a true control surface: every site can declare its own asset bundle while the shared
+  motion/override plumbing stays untouched.
+- Runtime registration enables launch teams to iterate on brand media (and validate manifests) directly in staging without
+  triggering manual code edits.
+
+## Next recommendations
+
+1. Build validation tooling that compares manifest entries against the `/assets` directory to catch typos before deployment.
+2. Extend the manifest format with optional metadata (e.g., attribution, dimensions, codecs) to assist downstream optimizers.
+3. Group uploaded MP4 overlays by campaign/site to make deterministic rotation rules easier to author.

--- a/docs/global-motion-reference.md
+++ b/docs/global-motion-reference.md
@@ -7,10 +7,11 @@ patterns for downstream systems.
 
 ## Runtime snapshot
 
-The orchestrator stores the latest values on `window.__CLEAR_SEAS_GLOBAL_MOTION` and
-dispatches them through the `clear-seas:motion-updated` event (also exported as
-`window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT`). Each dispatch now includes the following
-properties:
+The orchestrator stores the latest values on `window.__CSS_WEB_MASTER_GLOBAL_MOTION`
+(aliased to `window.__CLEAR_SEAS_GLOBAL_MOTION`) and dispatches them through the
+`css-web-master:motion-updated` event (still aliased to `clear-seas:motion-updated`
+via `window.__CSS_WEB_MASTER_GLOBAL_MOTION_EVENT`). Each dispatch now includes the
+following properties:
 
 | Field | Description |
 |-------|-------------|
@@ -30,11 +31,11 @@ properties:
 | `timestamp` | High-resolution timestamp for the snapshot. |
 
 Consumers that only need the latest state can read from
-`window.__CLEAR_SEAS_GLOBAL_MOTION`. For reactive experiences, listen for the shared
-event:
+`window.__CSS_WEB_MASTER_GLOBAL_MOTION`. For reactive experiences, listen for the
+shared event:
 
 ```js
-window.addEventListener(window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT, (event) => {
+window.addEventListener(window.__CSS_WEB_MASTER_GLOBAL_MOTION_EVENT, (event) => {
   const motion = event.detail;
   // ...update shaders, canvases, analytics, etc.
 });

--- a/docs/html-version-groups.md
+++ b/docs/html-version-groups.md
@@ -47,7 +47,7 @@ These builds experiment with alternative canvases, typography systems, or resear
 
 ## Brand Palette Synchronization
 
-The `global-page-orchestrator` now detects which collection a page belongs to and shares that profile through `window.__CLEAR_SEAS_PAGE_PROFILE`. The four active palettes are:
+The `global-page-orchestrator` now detects which collection a page belongs to and shares that profile through `window.__CSS_WEB_MASTER_PAGE_PROFILE` (still aliased as `window.__CLEAR_SEAS_PAGE_PROFILE`). The four active palettes are:
 
 - **Meta Index (`meta-index`)** – used for the overview map.
 - **Core Foundation (`core-foundation`)** – powers the 1–6 flagship builds.

--- a/docs/html-version-test-report.md
+++ b/docs/html-version-test-report.md
@@ -1,0 +1,54 @@
+# HTML Version Smoke Test Report
+
+_Updated: 2025-09-26_
+
+## Test methodology
+- A new Playwright smoke harness (`tests/html_smoke_test.py`) serves the repository through a temporary HTTP server and opens every top-level HTML file in headless Chromium. It records console errors, page exceptions, failed network requests, and HTTP 4xx/5xx responses so we can distinguish real defects from environment limitations.【F:tests/html_smoke_test.py†L1-L114】
+- Run the audit locally with `python tests/html_smoke_test.py > out.json`. The script prints progress to stderr while writing a JSON summary to stdout so the raw results can be inspected or re-aggregated for new reports.【F:tests/html_smoke_test.py†L85-L114】
+
+## Environment caveats
+- **Google Fonts / external HTTPS** – the container image lacks the public CA bundle Playwright expects, so calls to `fonts.googleapis.com` fail with `net::ERR_CERT_AUTHORITY_INVALID`. Treat these as environment warnings unless they surface in production browsers.【F:tests/html_smoke_test.py†L49-L79】
+- **Large MP4 downloads** – several pages stream multi-megabyte hero videos. The headless browser cancels those downloads when navigation completes, producing `net::ERR_ABORTED`. Video playback works once the assets live on CDN or when tests wait for the streams to finish; no in-page error surfaced.【F:tests/html_smoke_test.py†L44-L79】
+- **Load-state timeouts** – pages 28 and 30 continue requesting 404 images, so `page.goto(... wait_until="load")` never resolves within 20 seconds. Increasing the timeout lets the audit finish but does not hide the underlying missing assets. The navigation timeouts are flagged as actionable defects below.【F:tests/html_smoke_test.py†L61-L72】
+
+## Results summary
+| HTML file | Status | Notes |
+| --- | --- | --- |
+| 1-index.html | ❌ | Global constant `PRIMARY_BRAND_OVERRIDE_EVENT` is declared twice when both card systems load. |
+| 2-index-optimized.html | ❌ | Same `PRIMARY_BRAND_OVERRIDE_EVENT` redeclaration conflict as 1-index. |
+| 3-index-fixed.html | ⚠️ | Only external Google Fonts requests fail inside the container. |
+| 4-index-unified.html | ⚠️ | Only external Google Fonts requests fail inside the container. |
+| 5-index-vib34d-integrated.html | ⚠️ | Only external Google Fonts requests fail inside the container. |
+| 6-index-totalistic.html | ❌ | `PRIMARY_BRAND_OVERRIDE_EVENT` redeclaration plus `❌ ClearSeasContextPool not available` warning shows the brand override pool never initialises. |
+| 7-pr-1.html | ⚠️ | Only Google Fonts blocked by environment. |
+| 8-pr-2.html | ⚠️ | Only Google Fonts blocked by environment. |
+| 9-pr-3.html | ⚠️ | Google Fonts blocked and long MP4 downloads abort when the browser exits. |
+| 10-pr-4.html | ❌ | Image cards reference `styles/assets/*.png`, but the images live in `/assets` so every card graphic returns 404. |
+| 11-pr-5.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 12-pr-6.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 13-pr-7.html | ❌ | Embedded showcase iframes point to `/demos/*.html`, which are absent. |
+| 14-pr-8.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 15-pr-9.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 16-pr-10.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 17-pr-11.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 18-pr-12.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 19-pr-13.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 20-pr-14.html | ⚠️ | Only Google Fonts blocked and hero MP4 streams cancelled when the browser closes. |
+| 21-pr-15.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 22-pr-16.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 23-pr-17.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 24-pr-18.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 25-orthogonal-depth-progression.html | ⚠️ | Only Google Fonts blocked by environment. |
+| 25-pr-19.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 26-pr-20.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 27-pr-21.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 28-pr-22.html | ❌ | Load event never finishes because every `styles/assets` image 404s; audit hit the 20s timeout. |
+| 29-pr-23.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 30-pr-24.html | ❌ | Load event never finishes because every `styles/assets` image 404s; audit hit the 20s timeout. |
+| ULTIMATE-clear-seas-holistic-system.html | ⚠️ | Google Fonts blocked and hero MP4 streams cancelled when the browser closes. |
+| index.html | ⚠️ | Hero MP4 downloads abort when the headless browser exits; no in-page errors detected. |
+
+## Next steps
+1. **Deduplicate brand override globals** – move `PRIMARY_BRAND_OVERRIDE_EVENT` to a single shared module so pages that load both card systems stop throwing fatal SyntaxErrors. That will also unblock the `ClearSeasContextPool` bootstrap on Totalistic.
+2. **Fix static asset paths** – update the PR showcase templates so card imagery references `/assets/*.png` (or move the files under `styles/assets/`). The same adjustment is needed for the missing `/demos/*.html` showcase embeds.
+3. **Optional test hardening** – if we need fully green runs inside CI, bundle critical fonts locally and host video fixtures under `/assets` so the smoke harness avoids remote TLS altogether.

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
             <div class="logo">🧭 CSS-Web-Master Control Surface</div>
             <div class="subtitle">Powered by the Clear Seas Draft multi-version library</div>
             <div class="count">32 Experiences • 6 Core + 24 PR Branches + 2 Labs</div>
-            <p>Use this library to seed future CSS-family launches (paraerator.com, vib3code.com, and beyond).</p>
+            <p>Use this library to seed future CSS-family launches (parserator.com, vib3code.com, and beyond).</p>
         </div>
 
         <!-- MAIN HTML VERSIONS (1-6) -->

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+playwright==1.43.0

--- a/scripts/global-page-orchestrator.js
+++ b/scripts/global-page-orchestrator.js
@@ -1,34 +1,105 @@
 import { resolvePageProfile, applyProfileMetadata } from './page-profile-registry.js';
+import { mergeAssetManifest, resolveBrandAssets, getAssetManifestSnapshot } from './site-asset-manifest.js';
 
-const BRAND_OVERRIDE_EVENT = window.__CLEAR_SEAS_BRAND_OVERRIDE_EVENT || 'clear-seas:brand-overrides-changed';
+const cssWebMasterGlobals = window.__CSS_WEB_MASTER_GLOBALS || (window.__CSS_WEB_MASTER_GLOBALS = {});
 
-const GLOBAL_MOTION_EVENT = window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT || 'clear-seas:motion-updated';
-window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT = GLOBAL_MOTION_EVENT;
+const DEFAULT_BRAND_EVENT = 'css-web-master:brand-overrides-changed';
+const DEFAULT_CLEAR_SEAS_BRAND_EVENT = 'clear-seas:brand-overrides-changed';
+const resolvedCssBrandEvent =
+  cssWebMasterGlobals.brandOverrideEvent ||
+  window.__CSS_WEB_MASTER_BRAND_OVERRIDE_EVENT ||
+  DEFAULT_BRAND_EVENT;
+const resolvedClearSeasBrandEvent = window.__CLEAR_SEAS_BRAND_OVERRIDE_EVENT || DEFAULT_CLEAR_SEAS_BRAND_EVENT;
+const BRAND_OVERRIDE_EVENTS = [...new Set([resolvedCssBrandEvent, resolvedClearSeasBrandEvent])];
+const BRAND_OVERRIDE_EVENT = resolvedCssBrandEvent;
+window.__CSS_WEB_MASTER_BRAND_OVERRIDE_EVENT = resolvedCssBrandEvent;
+window.__CLEAR_SEAS_BRAND_OVERRIDE_EVENT = resolvedClearSeasBrandEvent;
+cssWebMasterGlobals.brandOverrideEvent = resolvedCssBrandEvent;
+cssWebMasterGlobals.brandOverrideEvents = BRAND_OVERRIDE_EVENTS;
 
-const brandAssets = window.__CLEAR_SEAS_BRAND_ASSETS || (window.__CLEAR_SEAS_BRAND_ASSETS = {
-  images: [
-    'assets/Screenshot_20250430-141821.png',
-    'assets/Screenshot_20241012-073718.png',
-    'assets/Screenshot_20250430-142024~2.png',
-    'assets/Screenshot_20250430-142002~2.png',
-    'assets/Screenshot_20250430-142032~2.png',
-    'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
-    'assets/file_0000000054a06230817873012865d150.png',
-    'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
-    'assets/image_8 (1).png'
-  ],
-  videos: [
-    '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
-    '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
-    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
-    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
-    '1746496560073.mp4',
-    '1746500614769.mp4',
-    '1746576068221.mp4'
-  ]
+const DEFAULT_MOTION_EVENT = 'css-web-master:motion-updated';
+const DEFAULT_CLEAR_SEAS_MOTION_EVENT = 'clear-seas:motion-updated';
+const resolvedCssMotionEvent =
+  cssWebMasterGlobals.motionEvent ||
+  window.__CSS_WEB_MASTER_GLOBAL_MOTION_EVENT ||
+  DEFAULT_MOTION_EVENT;
+const resolvedClearSeasMotionEvent = window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT || DEFAULT_CLEAR_SEAS_MOTION_EVENT;
+const GLOBAL_MOTION_EVENTS = [...new Set([resolvedCssMotionEvent, resolvedClearSeasMotionEvent])];
+const GLOBAL_MOTION_EVENT = resolvedCssMotionEvent;
+window.__CSS_WEB_MASTER_GLOBAL_MOTION_EVENT = resolvedCssMotionEvent;
+window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT = resolvedClearSeasMotionEvent;
+cssWebMasterGlobals.motionEvent = resolvedCssMotionEvent;
+cssWebMasterGlobals.motionEvents = GLOBAL_MOTION_EVENTS;
+
+const existingBrandAssets = window.__CSS_WEB_MASTER_BRAND_ASSETS || window.__CLEAR_SEAS_BRAND_ASSETS;
+
+if (existingBrandAssets && typeof existingBrandAssets === 'object') {
+  try {
+    mergeAssetManifest({
+      key: 'default',
+      images: existingBrandAssets.images,
+      videos: existingBrandAssets.videos
+    });
+  } catch (error) {
+    console.warn('⚠️ Failed to merge legacy brand asset globals into manifest', error);
+  }
+}
+
+const runtimeAssetManifests = [
+  window.__CSS_WEB_MASTER_ASSET_MANIFEST,
+  window.__CLEAR_SEAS_ASSET_MANIFEST
+].filter((value) => value && typeof value === 'object');
+runtimeAssetManifests.forEach((manifest) => {
+  try {
+    mergeAssetManifest(manifest);
+  } catch (error) {
+    console.warn('⚠️ Failed to merge runtime asset manifest', error);
+  }
 });
 
+const normaliseTagToken = (value) => {
+  if (!value) {
+    return '';
+  }
+  return String(value).trim().toLowerCase();
+};
+
+let brandAssets = { images: [], videos: [], tag: null, availableTags: [] };
+let brandAssetKey = null;
+let activePageProfile = null;
+
+const updateManifestSnapshot = () => {
+  const snapshot = getAssetManifestSnapshot();
+  cssWebMasterGlobals.assetManifest = snapshot;
+  window.__CSS_WEB_MASTER_ASSET_MANIFEST = snapshot;
+  window.__CLEAR_SEAS_ASSET_MANIFEST = snapshot;
+  return snapshot;
+};
+
+updateManifestSnapshot();
+
+const syncBrandAssets = (siteCode, options = {}) => {
+  const resolved = resolveBrandAssets(siteCode, options);
+  brandAssets = {
+    images: Array.isArray(resolved.images) ? [...resolved.images] : [],
+    videos: Array.isArray(resolved.videos) ? [...resolved.videos] : [],
+    tag: resolved.tag || null,
+    availableTags: Array.isArray(resolved.availableTags) ? [...resolved.availableTags] : []
+  };
+  brandAssetKey = resolved.key || null;
+  window.__CSS_WEB_MASTER_BRAND_ASSETS = brandAssets;
+  window.__CLEAR_SEAS_BRAND_ASSETS = brandAssets;
+  cssWebMasterGlobals.brandAssets = brandAssets;
+  cssWebMasterGlobals.brandAssetTag = brandAssets.tag;
+  cssWebMasterGlobals.brandAssetTags = brandAssets.availableTags;
+  cssWebMasterGlobals.brandAssetKey = brandAssetKey;
+  return resolved;
+};
+
 const brandOverrideApi = (() => {
+  if (window.__CSS_WEB_MASTER_BRAND_OVERRIDE_API) {
+    return window.__CSS_WEB_MASTER_BRAND_OVERRIDE_API;
+  }
   if (window.__CLEAR_SEAS_BRAND_OVERRIDE_API) {
     return window.__CLEAR_SEAS_BRAND_OVERRIDE_API;
   }
@@ -102,7 +173,9 @@ const brandOverrideApi = (() => {
         eventDetail[key] = detail[key];
       });
     }
-    window.dispatchEvent(new CustomEvent(BRAND_OVERRIDE_EVENT, { detail: eventDetail }));
+    BRAND_OVERRIDE_EVENTS.forEach((eventName) => {
+      window.dispatchEvent(new CustomEvent(eventName, { detail: eventDetail }));
+    });
   };
 
   const refreshGlobalOverrides = (detail) => {
@@ -512,19 +585,35 @@ const brandOverrideApi = (() => {
     applyPalette,
     hasAssetList,
     refresh: refreshGlobalOverrides,
-    eventName: BRAND_OVERRIDE_EVENT
+    eventName: BRAND_OVERRIDE_EVENT,
+    events: BRAND_OVERRIDE_EVENTS
   };
 
-  window.__CLEAR_SEAS_BRAND_OVERRIDE_EVENT = BRAND_OVERRIDE_EVENT;
+  window.__CSS_WEB_MASTER_BRAND_OVERRIDE_EVENT = BRAND_OVERRIDE_EVENT;
+  window.__CLEAR_SEAS_BRAND_OVERRIDE_EVENT = resolvedClearSeasBrandEvent;
+  window.__CSS_WEB_MASTER_BRAND_OVERRIDE_API = api;
   window.__CLEAR_SEAS_BRAND_OVERRIDE_API = api;
+  cssWebMasterGlobals.brandOverrideApi = api;
   return api;
 })();
 
 function detectActivePageProfile() {
   const resolved = resolvePageProfile();
+  const manifestKey = resolved?.siteCode || resolved?.requestedSiteCode || null;
+  const manifestTag =
+    normaliseTagToken(resolved?.siteCodeToken || resolved?.requestedSiteCode) ||
+    normaliseTagToken(resolved?.family) ||
+    normaliseTagToken(resolved?.paletteKey || resolved?.palette) ||
+    null;
+  const brandPackage = syncBrandAssets(manifestKey, {
+    tag: manifestTag,
+    family: resolved?.family || resolved?.key || null
+  });
+
   const profile = {
     key: resolved?.key || 'core-foundation',
     palette: resolved?.palette || 'foundation',
+    paletteKey: resolved?.paletteKey || resolved?.palette || 'foundation',
     family: resolved?.family || resolved?.key || 'core-foundation',
     layout: resolved?.layout || 'grid',
     accent: resolved?.accent || null,
@@ -535,11 +624,15 @@ function detectActivePageProfile() {
     canvas: resolved?.canvas || {},
     scripts: Array.isArray(resolved?.scripts) ? [...resolved.scripts] : [],
     signature: resolved?.signature || '',
-    seed: resolved?.seed || 0
+    seed: resolved?.seed || 0,
+    siteCode: resolved?.siteCode || null,
+    requestedSiteCode: resolved?.requestedSiteCode || null,
+    brandAssetKey: brandAssetKey,
+    brandAssetTag: brandAssets.tag || manifestTag
   };
 
-  profile.imageSeed = brandAssets.images.length ? profile.seed % brandAssets.images.length : 0;
-  profile.videoSeed = brandAssets.videos.length ? Math.floor(profile.seed / 7) % brandAssets.videos.length : 0;
+  profile.imageSeed = brandPackage.images.length ? profile.seed % brandPackage.images.length : 0;
+  profile.videoSeed = brandPackage.videos.length ? Math.floor(profile.seed / 7) % brandPackage.videos.length : 0;
 
   if (resolved?.metaName === 'ultimate-clear-seas-holistic-system.html') {
     profile.scripts.push('scripts/ultimate-holistic-vib34d-system.js');
@@ -547,10 +640,66 @@ function detectActivePageProfile() {
 
   applyProfileMetadata(profile);
   window.__CLEAR_SEAS_PAGE_PROFILE = profile;
+  window.__CSS_WEB_MASTER_PAGE_PROFILE = profile;
+  cssWebMasterGlobals.pageProfile = profile;
+  cssWebMasterGlobals.siteCode = profile.siteCode || null;
+  cssWebMasterGlobals.paletteKey = profile.paletteKey || profile.palette;
   return profile;
 }
 
-const activePageProfile = detectActivePageProfile();
+activePageProfile = detectActivePageProfile();
+
+const registerAssetManifest = (input, detail = {}) => {
+  if (!input || typeof input !== 'object') {
+    return updateManifestSnapshot();
+  }
+
+  mergeAssetManifest(input);
+  const snapshot = updateManifestSnapshot();
+
+  const detailPayload = {
+    reason: (detail && typeof detail === 'object' && detail.reason) || 'asset-manifest-update',
+    timestamp: Date.now()
+  };
+  if (detail && typeof detail === 'object') {
+    Object.keys(detail).forEach((key) => {
+      if (key === 'reason') {
+        return;
+      }
+      detailPayload[key] = detail[key];
+    });
+  }
+
+  const currentSiteCode =
+    (activePageProfile && (activePageProfile.siteCode || activePageProfile.requestedSiteCode)) || null;
+  const currentTag =
+    (activePageProfile &&
+      normaliseTagToken(
+        activePageProfile.brandAssetTag || activePageProfile.siteCode || activePageProfile.family || null
+      )) || null;
+  syncBrandAssets(currentSiteCode, { tag: currentTag, family: activePageProfile?.family || null });
+
+  if (activePageProfile) {
+    activePageProfile.brandAssetKey = brandAssetKey;
+    activePageProfile.imageSeed = brandAssets.images.length
+      ? activePageProfile.seed % brandAssets.images.length
+      : 0;
+    activePageProfile.videoSeed = brandAssets.videos.length
+      ? Math.floor(activePageProfile.seed / 7) % brandAssets.videos.length
+      : 0;
+    cssWebMasterGlobals.pageProfile = activePageProfile;
+  }
+
+  BRAND_OVERRIDE_EVENTS.forEach((eventName) => {
+    window.dispatchEvent(new CustomEvent(eventName, { detail: detailPayload }));
+  });
+
+  return snapshot;
+};
+
+cssWebMasterGlobals.registerAssetManifest = registerAssetManifest;
+window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST = registerAssetManifest;
+window.__CLEAR_SEAS_REGISTER_ASSET_MANIFEST = registerAssetManifest;
 
 function preparePageProfile(profile) {
   if (!profile) {
@@ -568,6 +717,7 @@ function preparePageProfile(profile) {
     sharedMotion.collection = profile.key || null;
     sharedMotion.family = profile.family || null;
     sharedMotion.layout = profile.layout || null;
+    sharedMotion.siteCode = profile.siteCode || null;
   }
 }
 
@@ -589,8 +739,11 @@ function refreshAllCardOverrides(options = {}) {
   });
 }
 
-window.addEventListener(BRAND_OVERRIDE_EVENT, () => {
+const handleBrandOverridesUpdated = () => {
   refreshAllCardOverrides({ resetCycle: true });
+};
+BRAND_OVERRIDE_EVENTS.forEach((eventName) => {
+  window.addEventListener(eventName, handleBrandOverridesUpdated);
 });
 const groupStates = new Map();
 let activeCardState = null;
@@ -626,7 +779,7 @@ const globalState = {
   warp: { current: 0, target: 0 }
 };
 
-const sharedMotion = window.__CLEAR_SEAS_GLOBAL_MOTION || (window.__CLEAR_SEAS_GLOBAL_MOTION = {
+const DEFAULT_MOTION_STATE = {
   focus: { x: 0.5, y: 0.5, amount: 0 },
   tilt: { x: 0, y: 0, strength: 0 },
   bend: 0,
@@ -639,9 +792,41 @@ const sharedMotion = window.__CLEAR_SEAS_GLOBAL_MOTION || (window.__CLEAR_SEAS_G
   synergy: 0,
   palette: null,
   collection: null,
+  family: null,
+  layout: null,
+  siteCode: null,
   updatedAt: performance.now(),
   eventName: GLOBAL_MOTION_EVENT
-});
+};
+
+const existingMotionState = window.__CSS_WEB_MASTER_GLOBAL_MOTION || window.__CLEAR_SEAS_GLOBAL_MOTION;
+const sharedMotion = existingMotionState && typeof existingMotionState === 'object' ? existingMotionState : {};
+sharedMotion.focus = { ...DEFAULT_MOTION_STATE.focus, ...(sharedMotion.focus || {}) };
+sharedMotion.tilt = { ...DEFAULT_MOTION_STATE.tilt, ...(sharedMotion.tilt || {}) };
+sharedMotion.bend = Number.isFinite(sharedMotion.bend) ? sharedMotion.bend : DEFAULT_MOTION_STATE.bend;
+sharedMotion.warp = Number.isFinite(sharedMotion.warp) ? sharedMotion.warp : DEFAULT_MOTION_STATE.warp;
+sharedMotion.scroll = Number.isFinite(sharedMotion.scroll) ? sharedMotion.scroll : DEFAULT_MOTION_STATE.scroll;
+sharedMotion.scrollDirection = Number.isFinite(sharedMotion.scrollDirection)
+  ? sharedMotion.scrollDirection
+  : DEFAULT_MOTION_STATE.scrollDirection;
+sharedMotion.scrollSpeed = Number.isFinite(sharedMotion.scrollSpeed)
+  ? sharedMotion.scrollSpeed
+  : DEFAULT_MOTION_STATE.scrollSpeed;
+sharedMotion.focusTrend = Number.isFinite(sharedMotion.focusTrend)
+  ? sharedMotion.focusTrend
+  : DEFAULT_MOTION_STATE.focusTrend;
+sharedMotion.tiltSkew = Number.isFinite(sharedMotion.tiltSkew) ? sharedMotion.tiltSkew : DEFAULT_MOTION_STATE.tiltSkew;
+sharedMotion.synergy = Number.isFinite(sharedMotion.synergy) ? sharedMotion.synergy : DEFAULT_MOTION_STATE.synergy;
+sharedMotion.palette = sharedMotion.palette ?? DEFAULT_MOTION_STATE.palette;
+sharedMotion.collection = sharedMotion.collection ?? DEFAULT_MOTION_STATE.collection;
+sharedMotion.family = sharedMotion.family ?? DEFAULT_MOTION_STATE.family;
+sharedMotion.layout = sharedMotion.layout ?? DEFAULT_MOTION_STATE.layout;
+sharedMotion.siteCode = sharedMotion.siteCode ?? DEFAULT_MOTION_STATE.siteCode;
+sharedMotion.updatedAt = sharedMotion.updatedAt ?? DEFAULT_MOTION_STATE.updatedAt;
+sharedMotion.eventName = GLOBAL_MOTION_EVENT;
+window.__CSS_WEB_MASTER_GLOBAL_MOTION = sharedMotion;
+window.__CLEAR_SEAS_GLOBAL_MOTION = sharedMotion;
+cssWebMasterGlobals.motionState = sharedMotion;
 
 const motionEventState = {
   lastDispatch: 0,
@@ -710,7 +895,9 @@ function maybeDispatchGlobalMotionEvent() {
 
   motionEventState.lastDetail = { ...detail };
   motionEventState.lastDispatch = now;
-  window.dispatchEvent(new CustomEvent(GLOBAL_MOTION_EVENT, { detail }));
+  GLOBAL_MOTION_EVENTS.forEach((eventName) => {
+    window.dispatchEvent(new CustomEvent(eventName, { detail }));
+  });
 }
 
 const supportsVisibilityObserver = typeof window !== 'undefined' && 'IntersectionObserver' in window;

--- a/scripts/page-profile-registry.js
+++ b/scripts/page-profile-registry.js
@@ -1,14 +1,6 @@
-const PROFILE_DEFINITIONS = [
-  {
-    key: 'meta-index',
-    label: 'Meta Index Overview',
-    family: 'meta',
-    layout: 'map',
-    palette: 'meta',
+const PALETTE_LIBRARY = {
+  meta: {
     accent: '#7ef6ff',
-    fileNames: ['index.html'],
-    tags: ['index', 'meta', 'map', 'directory'],
-    titleTokens: ['all versions', 'collections', 'clear seas solutions'],
     overlay: {
       blend: 'screen',
       opacity: 1.08,
@@ -19,28 +11,10 @@ const PROFILE_DEFINITIONS = [
     canvas: {
       scale: 0.08,
       depth: '12px'
-    },
-    imageOrder: [2, 3, 4, 0, 1, 5, 6, 7, 8],
-    videoOrder: [4, 5, 6, 0, 1, 2, 3],
-    videoPattern: [0, 1]
+    }
   },
-  {
-    key: 'core-foundation',
-    label: 'Core Foundation Builds',
-    family: 'foundation',
-    layout: 'grid',
-    palette: 'foundation',
+  foundation: {
     accent: '#8ddcff',
-    fileNames: [
-      '1-index.html',
-      '2-index-optimized.html',
-      '3-index-fixed.html',
-      '4-index-unified.html',
-      '5-index-vib34d-integrated.html',
-      '6-index-totalistic.html'
-    ],
-    tags: ['core', 'foundation', 'totalistic', 'unified'],
-    titleTokens: ['clear seas solutions', 'totalistic', 'integrated'],
     overlay: {
       blend: 'soft-light',
       opacity: 0.96,
@@ -51,7 +25,68 @@ const PROFILE_DEFINITIONS = [
     canvas: {
       scale: 0.12,
       depth: '18px'
+    }
+  },
+  immersive: {
+    accent: '#ffaadf',
+    overlay: {
+      blend: 'color-dodge',
+      opacity: 1.14,
+      filter: 'hue-rotate(32deg) saturate(1.5) brightness(1.18)',
+      rotate: '9deg',
+      depth: '28px'
     },
+    canvas: {
+      scale: 0.18,
+      depth: '26px'
+    }
+  },
+  concept: {
+    accent: '#caa5ff',
+    overlay: {
+      blend: 'lighten',
+      opacity: 1.22,
+      filter: 'hue-rotate(280deg) saturate(1.45) brightness(1.12)',
+      rotate: '-7deg',
+      depth: '32px'
+    },
+    canvas: {
+      scale: 0.22,
+      depth: '34px'
+    }
+  }
+};
+
+const PROFILE_DEFINITIONS = [
+  {
+    key: 'meta-index',
+    label: 'Meta Index Overview',
+    family: 'meta',
+    layout: 'map',
+    palette: 'meta',
+    fileNames: ['index.html'],
+    tags: ['index', 'meta', 'map', 'directory'],
+    titleTokens: ['all versions', 'collections', 'clear seas solutions'],
+    imageOrder: [2, 3, 4, 0, 1, 5, 6, 7, 8],
+    videoOrder: [4, 5, 6, 0, 1, 2, 3],
+    videoPattern: [0, 1]
+  },
+  {
+    key: 'core-foundation',
+    label: 'Core Foundation Builds',
+    family: 'foundation',
+    layout: 'grid',
+    palette: 'foundation',
+    fileNames: [
+      '1-index.html',
+      '2-index-optimized.html',
+      '3-index-fixed.html',
+      '4-index-unified.html',
+      '5-index-vib34d-integrated.html',
+      '6-index-totalistic.html'
+    ],
+    tags: ['core', 'foundation', 'totalistic', 'unified'],
+    titleTokens: ['clear seas solutions', 'totalistic', 'integrated'],
     imageOrder: [0, 5, 1, 6, 2, 7, 3, 8, 4],
     videoOrder: [1, 2, 3, 0, 4, 5, 6],
     videoPattern: [0, 1, 0, 0]
@@ -62,7 +97,6 @@ const PROFILE_DEFINITIONS = [
     family: 'immersive',
     layout: 'timeline',
     palette: 'immersive',
-    accent: '#ffaadf',
     fileNames: [
       '10-pr-4.html', '11-pr-5.html', '12-pr-6.html',
       '14-pr-8.html', '15-pr-9.html', '16-pr-10.html',
@@ -74,17 +108,6 @@ const PROFILE_DEFINITIONS = [
     ],
     tags: ['immersive', 'mission', 'pulse', 'signal', 'pr', 'blueprint'],
     titleTokens: ['immersive experience', 'mission axis', 'experience blueprint'],
-    overlay: {
-      blend: 'color-dodge',
-      opacity: 1.14,
-      filter: 'hue-rotate(32deg) saturate(1.5) brightness(1.18)',
-      rotate: '9deg',
-      depth: '28px'
-    },
-    canvas: {
-      scale: 0.18,
-      depth: '26px'
-    },
     imageOrder: [4, 0, 5, 1, 6, 2, 7, 3, 8],
     videoOrder: [4, 5, 6, 0, 1, 2, 3],
     videoPattern: [1, 0, 1, 1],
@@ -96,7 +119,6 @@ const PROFILE_DEFINITIONS = [
     family: 'labs',
     layout: 'gallery',
     palette: 'concept',
-    accent: '#caa5ff',
     fileNames: [
       '7-pr-1.html',
       '8-pr-2.html',
@@ -107,20 +129,24 @@ const PROFILE_DEFINITIONS = [
     ],
     tags: ['concept', 'lab', 'gallery', 'codex', 'orthogonal', 'ultimate'],
     titleTokens: ['visual codex', 'orthogonal depth', 'holistic system'],
-    overlay: {
-      blend: 'lighten',
-      opacity: 1.22,
-      filter: 'hue-rotate(280deg) saturate(1.45) brightness(1.12)',
-      rotate: '-7deg',
-      depth: '32px'
-    },
-    canvas: {
-      scale: 0.22,
-      depth: '34px'
-    },
     imageOrder: [6, 7, 8, 3, 4, 0, 1, 2, 5],
     videoOrder: [2, 3, 4, 5, 6, 0, 1],
     videoPattern: [1, 1, 0, 1]
+  },
+  {
+    key: 'parserator-alpha',
+    label: 'Parserator Systems Launchpad',
+    family: 'parserator',
+    siteCode: 'parserator',
+    layout: 'grid',
+    palette: 'foundation',
+    fileNames: [],
+    tags: ['parserator', 'propulsion', 'systems', 'aero', 'launch'],
+    titleTokens: ['parserator', 'propulsion systems', 'aero lab'],
+    imageOrder: [0, 5, 1, 6, 2, 7, 3, 8, 4],
+    videoOrder: [1, 2, 3, 0, 4, 5, 6],
+    videoPattern: [0, 1, 0, 1],
+    scripts: ['scripts/immersive-experience-actualizer.js']
   }
 ];
 
@@ -150,12 +176,38 @@ function computeHashSeed(input) {
   return hash;
 }
 
-const normalisedProfiles = PROFILE_DEFINITIONS.map((definition) => ({
-  ...definition,
-  fileNames: new Set((definition.fileNames || []).map(normaliseFileName)),
-  tags: new Set((definition.tags || []).map(normaliseToken)),
-  titleTokens: (definition.titleTokens || []).map(normaliseToken)
-}));
+const normalisedProfiles = PROFILE_DEFINITIONS.map((definition) => {
+  const paletteKey = definition.palette || definition.paletteKey || 'foundation';
+  const paletteDefaults = PALETTE_LIBRARY[paletteKey] || {};
+  const paletteOverrides = definition.paletteOverrides || {};
+  const accent = definition.accent || paletteOverrides.accent || paletteDefaults.accent || null;
+  const overlay = {
+    ...(paletteDefaults.overlay || {}),
+    ...(paletteOverrides.overlay || {}),
+    ...(definition.overlay || {})
+  };
+  const canvas = {
+    ...(paletteDefaults.canvas || {}),
+    ...(paletteOverrides.canvas || {}),
+    ...(definition.canvas || {})
+  };
+  const rawSiteCode = definition.siteCode || null;
+  const siteCodeToken = rawSiteCode ? normaliseToken(rawSiteCode) : null;
+
+  return {
+    ...definition,
+    palette: paletteKey,
+    paletteKey,
+    siteCode: rawSiteCode,
+    siteCodeToken,
+    accent,
+    overlay,
+    canvas,
+    fileNames: new Set((definition.fileNames || []).map(normaliseFileName)),
+    tags: new Set((definition.tags || []).map(normaliseToken)),
+    titleTokens: (definition.titleTokens || []).map(normaliseToken)
+  };
+});
 
 export function listPageProfiles() {
   return normalisedProfiles.map((profile) => ({
@@ -164,7 +216,8 @@ export function listPageProfiles() {
     family: profile.family,
     layout: profile.layout,
     palette: profile.palette,
-    accent: profile.accent
+    accent: profile.accent,
+    siteCode: profile.siteCode || null
   }));
 }
 
@@ -175,10 +228,15 @@ function readCandidateTokens(docEl, bodyEl) {
     tokens.push(docEl.dataset.collection);
     tokens.push(docEl.dataset.showcaseTheme);
     tokens.push(docEl.dataset.showcaseCard);
+    tokens.push(docEl.dataset.siteCode);
+    tokens.push(docEl.dataset.globalSiteCode);
+    tokens.push(docEl.dataset.brandSite);
   }
   if (bodyEl && bodyEl.dataset) {
     tokens.push(bodyEl.dataset.pageCollection);
     tokens.push(bodyEl.dataset.collection);
+    tokens.push(bodyEl.dataset.siteCode);
+    tokens.push(bodyEl.dataset.globalSiteCode);
   }
   return tokens.filter(Boolean).map(normaliseToken);
 }
@@ -192,10 +250,37 @@ export function resolvePageProfile(context = {}) {
   const metaName = normaliseFileName(pathToken || (docEl && docEl.dataset ? docEl.dataset.pageId : '') || '');
   const title = normaliseToken(doc ? doc.title : context.title || '');
   const candidateTokens = readCandidateTokens(docEl, body);
+  const pathTokens = path
+    ? path
+        .split(/[\\/]+/)
+        .filter(Boolean)
+        .map(normaliseToken)
+    : [];
+  const requestedSiteCode = normaliseToken(
+    context.siteCode ||
+      (docEl && docEl.dataset ? docEl.dataset.siteCode : '') ||
+      (docEl && docEl.dataset ? docEl.dataset.globalSiteCode : '') ||
+      (body && body.dataset ? body.dataset.siteCode : '') ||
+      (body && body.dataset ? body.dataset.globalSiteCode : '')
+  );
+  const searchTokens = [...candidateTokens];
+  if (requestedSiteCode) {
+    searchTokens.push(requestedSiteCode);
+  }
+  pathTokens.forEach((token) => {
+    if (token) {
+      searchTokens.push(token);
+    }
+  });
 
   let matched = normalisedProfiles.find((profile) => profile.fileNames.has(metaName));
+  if (!matched && requestedSiteCode) {
+    matched = normalisedProfiles.find((profile) => profile.siteCodeToken === requestedSiteCode);
+  }
   if (!matched) {
-    matched = normalisedProfiles.find((profile) => candidateTokens.some((token) => profile.tags.has(token)));
+    matched = normalisedProfiles.find((profile) =>
+      searchTokens.some((token) => profile.tags.has(token) || (profile.siteCodeToken && profile.siteCodeToken === token))
+    );
   }
   if (!matched) {
     matched = normalisedProfiles.find((profile) => profile.titleTokens.some((token) => title.includes(token)));
@@ -204,7 +289,7 @@ export function resolvePageProfile(context = {}) {
     matched = normalisedProfiles.find((profile) => profile.key === 'core-foundation') || normalisedProfiles[0];
   }
 
-  const signatureParts = [metaName, title].concat(candidateTokens);
+  const signatureParts = [metaName, title, requestedSiteCode].concat(searchTokens);
   const signature = signatureParts.filter(Boolean).join('|') || metaName;
   const seed = computeHashSeed(signature);
 
@@ -214,6 +299,7 @@ export function resolvePageProfile(context = {}) {
     family: matched.family,
     layout: matched.layout,
     palette: matched.palette,
+    paletteKey: matched.paletteKey,
     accent: matched.accent,
     overlay: matched.overlay ? { ...matched.overlay } : {},
     canvas: matched.canvas ? { ...matched.canvas } : {},
@@ -221,10 +307,13 @@ export function resolvePageProfile(context = {}) {
     videoOrder: matched.videoOrder ? [...matched.videoOrder] : null,
     videoPattern: matched.videoPattern ? [...matched.videoPattern] : null,
     scripts: matched.scripts ? [...matched.scripts] : [],
+    siteCode: matched.siteCode || null,
+    siteCodeToken: matched.siteCodeToken || null,
+    requestedSiteCode: requestedSiteCode || null,
     signature,
     seed,
     metaName,
-    candidateTokens
+    candidateTokens: searchTokens
   };
 }
 
@@ -237,15 +326,47 @@ export function applyProfileMetadata(profile, targetDocument = typeof document !
   if (!docEl) {
     return;
   }
+  if (profile.key) {
+    docEl.dataset.pageCollection = profile.key;
+  } else {
+    delete docEl.dataset.pageCollection;
+  }
   docEl.dataset.globalPageCollection = profile.key;
   docEl.dataset.globalBrandPalette = profile.palette;
   docEl.dataset.globalPageFamily = profile.family || profile.key;
   docEl.dataset.globalPageLayout = profile.layout || 'grid';
+  docEl.dataset.globalPaletteKey = profile.paletteKey || profile.palette || '';
+  if (profile.siteCode || profile.requestedSiteCode) {
+    docEl.dataset.siteCode = profile.siteCode || profile.requestedSiteCode || '';
+  } else {
+    delete docEl.dataset.siteCode;
+  }
+  if (profile.siteCode) {
+    docEl.dataset.globalSiteCode = profile.siteCode;
+  } else {
+    delete docEl.dataset.globalSiteCode;
+  }
   if (body) {
+    if (profile.key) {
+      body.dataset.pageCollection = profile.key;
+    } else {
+      delete body.dataset.pageCollection;
+    }
     body.dataset.globalPageCollection = profile.key;
     body.dataset.globalBrandPalette = profile.palette;
     body.dataset.globalPageFamily = profile.family || profile.key;
     body.dataset.globalPageLayout = profile.layout || 'grid';
+    body.dataset.globalPaletteKey = profile.paletteKey || profile.palette || '';
+    if (profile.siteCode || profile.requestedSiteCode) {
+      body.dataset.siteCode = profile.siteCode || profile.requestedSiteCode || '';
+    } else {
+      delete body.dataset.siteCode;
+    }
+    if (profile.siteCode) {
+      body.dataset.globalSiteCode = profile.siteCode;
+    } else {
+      delete body.dataset.globalSiteCode;
+    }
   }
   if (profile.accent) {
     docEl.style.setProperty('--global-brand-accent', profile.accent);
@@ -262,11 +383,13 @@ export function applyProfileMetadata(profile, targetDocument = typeof document !
 }
 
 if (typeof window !== 'undefined') {
-  window.__CLEAR_SEAS_PAGE_PROFILE_REGISTRY = {
+  const registry = {
     list: listPageProfiles,
     resolve: resolvePageProfile,
     apply: applyProfileMetadata
   };
+  window.__CLEAR_SEAS_PAGE_PROFILE_REGISTRY = registry;
+  window.__CSS_WEB_MASTER_PAGE_PROFILE_REGISTRY = registry;
 }
 
 export default {

--- a/scripts/site-asset-manifest.js
+++ b/scripts/site-asset-manifest.js
@@ -1,0 +1,294 @@
+const DEFAULT_MANIFEST_KEY = 'default';
+
+const baseManifest = {
+  [DEFAULT_MANIFEST_KEY]: {
+    images: [
+      'assets/Screenshot_20250430-141821.png',
+      'assets/Screenshot_20241012-073718.png',
+      'assets/Screenshot_20250430-142024~2.png',
+      'assets/Screenshot_20250430-142002~2.png',
+      'assets/Screenshot_20250430-142032~2.png',
+      'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+      'assets/file_0000000054a06230817873012865d150.png',
+      'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+      'assets/image_8 (1).png'
+    ],
+    videos: [
+      '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+      '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+      '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+      '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+      '1746496560073.mp4',
+      '1746500614769.mp4',
+      '1746576068221.mp4'
+    ],
+    tags: {
+      foundation: {
+        images: [
+          'assets/Screenshot_20250430-141821.png',
+          'assets/Screenshot_20250430-142024~2.png',
+          'assets/file_0000000054a06230817873012865d150.png',
+          'assets/image_8 (1).png'
+        ],
+        videos: [
+          '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+          '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4'
+        ]
+      },
+      immersive: {
+        images: [
+          'assets/Screenshot_20250430-142002~2.png',
+          'assets/Screenshot_20250430-142032~2.png',
+          'assets/file_00000000fc08623085668cf8b5e0a1e5.png'
+        ],
+        videos: [
+          '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+          '1746496560073.mp4'
+        ]
+      },
+      labs: {
+        images: [
+          'assets/Screenshot_20241012-073718.png',
+          'assets/file_0000000006fc6230a8336bfa1fcebd89.png'
+        ],
+        videos: ['1746500614769.mp4', '1746576068221.mp4']
+      }
+    }
+  },
+  parserator: {
+    extends: 'default',
+    tags: {
+      parserator: {
+        images: [
+          'assets/Screenshot_20250430-142024~2.png',
+          'assets/Screenshot_20250430-142002~2.png',
+          'assets/file_0000000054a06230817873012865d150.png'
+        ],
+        videos: [
+          '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+          '1746500614769.mp4'
+        ]
+      }
+    }
+  }
+};
+
+const manifest = Object.create(null);
+
+function normaliseKey(key) {
+  return String(key || '')
+    .trim()
+    .toLowerCase();
+}
+
+function normaliseList(value) {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function normaliseGroupMap(value) {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+  const groups = {};
+  Object.entries(value).forEach(([groupKey, groupValue]) => {
+    if (!groupKey || !groupValue || typeof groupValue !== 'object') {
+      return;
+    }
+    const token = normaliseKey(groupKey);
+    if (!token) {
+      return;
+    }
+    groups[token] = {
+      images: normaliseList(groupValue.images),
+      videos: normaliseList(groupValue.videos)
+    };
+  });
+  return groups;
+}
+
+function mergeEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return;
+  }
+  const key = normaliseKey(entry.key || entry.siteCode || entry.id || entry.name);
+  if (!key) {
+    return;
+  }
+  const existing = manifest[key] || { images: [], videos: [], extends: null };
+  const next = { ...existing };
+
+  if (Object.prototype.hasOwnProperty.call(entry, 'extends')) {
+    const extendsKey = normaliseKey(entry.extends);
+    next.extends = extendsKey && extendsKey !== key ? extendsKey : null;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(entry, 'images')) {
+    next.images = normaliseList(entry.images);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(entry, 'videos')) {
+    next.videos = normaliseList(entry.videos);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(entry, 'tags') || Object.prototype.hasOwnProperty.call(entry, 'groups')) {
+    const groupMap = normaliseGroupMap(entry.tags || entry.groups);
+    next.tags = { ...(existing.tags || {}), ...groupMap };
+  }
+
+  manifest[key] = next;
+}
+
+export function mergeAssetManifest(source) {
+  if (!source || typeof source !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(source)) {
+    source.forEach((entry) => mergeAssetManifest(entry));
+    return;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(source, 'key') ||
+    Object.prototype.hasOwnProperty.call(source, 'siteCode') ||
+    Object.prototype.hasOwnProperty.call(source, 'id') ||
+    Object.prototype.hasOwnProperty.call(source, 'name')
+  ) {
+    mergeEntry(source);
+    return;
+  }
+
+  Object.entries(source).forEach(([key, value]) => {
+    if (value && typeof value === 'object') {
+      mergeEntry({ key, ...value });
+    }
+  });
+}
+
+function resolveManifestKey(requestedKey, options = {}) {
+  const requestedTag = normaliseKey(options.tag || options.group || options.campaign || options.family);
+  const visited = new Set();
+  let token = normaliseKey(requestedKey) || DEFAULT_MANIFEST_KEY;
+  if (!manifest[token]) {
+    token = DEFAULT_MANIFEST_KEY;
+  }
+
+  let currentToken = token;
+  let entry = manifest[currentToken] || manifest[DEFAULT_MANIFEST_KEY] || { images: [], videos: [], extends: null };
+  const chain = [];
+
+  while (entry && !visited.has(currentToken)) {
+    visited.add(currentToken);
+    chain.push({ token: currentToken, entry });
+
+    const nextToken = normaliseKey(entry.extends);
+    if (!nextToken || nextToken === currentToken) {
+      break;
+    }
+
+    currentToken = manifest[nextToken] ? nextToken : DEFAULT_MANIFEST_KEY;
+    entry = manifest[currentToken];
+  }
+
+  const defaultEntry = manifest[DEFAULT_MANIFEST_KEY] || { images: [], videos: [] };
+  let images = [];
+  let videos = [];
+  let resolvedTag = requestedTag && requestedTag.length ? requestedTag : null;
+  const availableTags = new Set();
+
+  for (let i = chain.length - 1; i >= 0; i -= 1) {
+    const layer = chain[i].entry;
+    const tagMap = layer.tags || {};
+    Object.keys(tagMap).forEach((key) => availableTags.add(normaliseKey(key)));
+    if (resolvedTag && tagMap[resolvedTag]) {
+      const tagEntry = tagMap[resolvedTag];
+      if (!images.length && Array.isArray(tagEntry.images) && tagEntry.images.length) {
+        images = [...tagEntry.images];
+      }
+      if (!videos.length && Array.isArray(tagEntry.videos) && tagEntry.videos.length) {
+        videos = [...tagEntry.videos];
+      }
+    }
+    if (!images.length && Array.isArray(layer.images) && layer.images.length) {
+      images = [...layer.images];
+    }
+    if (!videos.length && Array.isArray(layer.videos) && layer.videos.length) {
+      videos = [...layer.videos];
+    }
+  }
+
+  if (!images.length) {
+    images = [...(defaultEntry.images || [])];
+  }
+  if (!videos.length) {
+    videos = [...(defaultEntry.videos || [])];
+  }
+
+  const resolvedKey = chain.length ? chain[0].token : DEFAULT_MANIFEST_KEY;
+  const tagsFromDefault = defaultEntry.tags || {};
+  Object.keys(tagsFromDefault).forEach((key) => availableTags.add(normaliseKey(key)));
+
+  if (!images.length && resolvedTag && manifest[resolvedKey]?.tags?.[resolvedTag]) {
+    images = [...(manifest[resolvedKey].tags[resolvedTag].images || [])];
+  }
+  if (!videos.length && resolvedTag && manifest[resolvedKey]?.tags?.[resolvedTag]) {
+    videos = [...(manifest[resolvedKey].tags[resolvedTag].videos || [])];
+  }
+
+  if (resolvedTag && (!availableTags.has(resolvedTag) || (!images.length && !videos.length))) {
+    resolvedTag = null;
+  }
+
+  return {
+    key: resolvedKey,
+    tag: resolvedTag,
+    images,
+    videos,
+    availableTags: Array.from(availableTags).sort()
+  };
+}
+
+export function resolveBrandAssets(siteCode, options = {}) {
+  return resolveManifestKey(siteCode, options);
+}
+
+export function getAssetManifestSnapshot() {
+  const snapshot = {};
+  Object.entries(manifest).forEach(([key, entry]) => {
+    snapshot[key] = {
+      extends: entry.extends || null,
+      images: [...(entry.images || [])],
+      videos: [...(entry.videos || [])],
+      tags: entry.tags
+        ? Object.fromEntries(
+            Object.entries(entry.tags).map(([tagKey, tagEntry]) => [
+              tagKey,
+              {
+                images: [...(tagEntry.images || [])],
+                videos: [...(tagEntry.videos || [])]
+              }
+            ])
+          )
+        : undefined
+    };
+  });
+  return snapshot;
+}
+
+mergeAssetManifest(baseManifest);
+
+export { DEFAULT_MANIFEST_KEY };

--- a/styles/consolidated-styles.css
+++ b/styles/consolidated-styles.css
@@ -11,99 +11,13 @@
  * =================================================================================================
  */
 
+@import url('./css-web-master-tokens.css');
+
 /* ==========================================================================
    1. ROOT VARIABLES & DESIGN TOKENS
    ========================================================================== */
 :root {
-    /* Typography Scale - Fluid & Responsive */
-    --font-family-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    --font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
-    
-    --font-size-xs: clamp(0.75rem, 0.5vw + 0.5rem, 0.875rem);
-    --font-size-sm: clamp(0.875rem, 1vw + 0.5rem, 1rem);
-    --font-size-base: clamp(1rem, 1.5vw + 0.5rem, 1.125rem);
-    --font-size-lg: clamp(1.125rem, 2vw + 0.5rem, 1.25rem);
-    --font-size-xl: clamp(1.25rem, 2.5vw + 0.5rem, 1.5rem);
-    --font-size-2xl: clamp(1.5rem, 3vw + 1rem, 2rem);
-    --font-size-3xl: clamp(1.875rem, 4vw + 1rem, 2.5rem);
-    --font-size-4xl: clamp(2.25rem, 5vw + 1rem, 3.5rem);
-    --font-size-5xl: clamp(3rem, 6vw + 1rem, 4.5rem);
-    --font-size-6xl: clamp(4rem, 7vw + 1rem, 6rem);
-    
-    /* Color System - Polytopal Projection Theme */
-    --bg-primary: #0a0b0d;
-    --bg-secondary: #141619;
-    --bg-tertiary: #1f2128;
-    --surface-primary: rgba(255, 255, 255, 0.02);
-    --surface-secondary: rgba(255, 255, 255, 0.05);
-    --surface-accent: rgba(255, 255, 255, 0.12);
-    
-    --text-primary: #ffffff;
-    --text-secondary: rgba(255, 255, 255, 0.8);
-    --text-tertiary: rgba(255, 255, 255, 0.6);
-    --text-quaternary: rgba(255, 255, 255, 0.4);
-    
-    --border-primary: rgba(255, 255, 255, 0.1);
-    --border-secondary: rgba(255, 255, 255, 0.15);
-    --border-accent: rgba(255, 255, 255, 0.2);
-    
-    /* VIB34D Theme Colors */
-    --theme-primary: #00d4ff;      /* Cyan */
-    --theme-secondary: #ff006e;    /* Magenta */
-    --theme-tertiary: #ff3300;     /* Red */
-    --theme-quaternary: #33ff00;   /* Green */
-    --theme-primary-dark: #0099cc;
-    --theme-primary-light: #66e6ff;
-    --theme-secondary-dark: #cc0055;
-    --theme-secondary-light: #ff66a3;
-    
-    /* Glassmorphism & Advanced Effects */
-    --glass-bg: rgba(16, 18, 27, 0.4);
-    --glass-border: rgba(255, 255, 255, 0.1);
-    --glass-shadow: rgba(0, 0, 0, 0.3);
-    --blur-amount: 20px;
-    --blur-subtle: 10px;
-    --blur-intense: 40px;
-    
-    /* Neoskeuomorphic Shadows */
-    --neo-shadow-light: rgba(40, 40, 60, 0.5);
-    --neo-shadow-dark: rgba(0, 0, 0, 0.3);
-    --neo-highlight: rgba(255, 255, 255, 0.1);
-    
-    /* Animation System */
-    --duration-instant: 0.1s;
-    --duration-fast: 0.2s;
-    --duration-normal: 0.4s;
-    --duration-slow: 0.8s;
-    --duration-slower: 1.2s;
-    --duration-cinematic: 2s;
-    
-    --ease-in: cubic-bezier(0.4, 0, 1, 1);
-    --ease-out: cubic-bezier(0, 0, 0.2, 1);
-    --ease-in-out: cubic-bezier(0.42, 0, 0.58, 1);
-    --ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
-    --ease-cinematic: cubic-bezier(0.25, 0.46, 0.45, 0.94);
-    
-    /* 3D & Perspective System */
-    --perspective: 2000px;
-    --pop-out-scale: 1.1;
-    --pop-out-translate-z: 120px;
-    --tilt-max: 15deg;
-    
-    /* Responsive Breakpoints */
-    --breakpoint-mobile: 768px;
-    --breakpoint-tablet: 1024px;
-    --breakpoint-desktop: 1200px;
-    --breakpoint-wide: 1440px;
-    
-    /* Z-Index Scale */
-    --z-underground: -1;
-    --z-default: 0;
-    --z-elevated: 10;
-    --z-overlay: 100;
-    --z-modal: 1000;
-    --z-toast: 9999;
-    
+    /* Base typography, color, and motion tokens are defined in css-web-master-tokens.css */
     /* CSS Variables Updated by JavaScript */
     --scroll-y: 0px;
     --scroll-progress: 0;

--- a/styles/css-web-master-tokens.css
+++ b/styles/css-web-master-tokens.css
@@ -1,0 +1,181 @@
+/*
+ * CSS-Web-Master neutral design tokens
+ * These tokens provide site-agnostic typography, color, and motion defaults
+ * so each property can override them without editing downstream stylesheets.
+ */
+
+:root {
+    /* Typography */
+    --csswm-font-family-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --csswm-font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+    --csswm-font-size-xs: clamp(0.75rem, 0.5vw + 0.5rem, 0.875rem);
+    --csswm-font-size-sm: clamp(0.875rem, 1vw + 0.5rem, 1rem);
+    --csswm-font-size-base: clamp(1rem, 1.5vw + 0.5rem, 1.125rem);
+    --csswm-font-size-lg: clamp(1.125rem, 2vw + 0.5rem, 1.25rem);
+    --csswm-font-size-xl: clamp(1.25rem, 2.5vw + 0.5rem, 1.5rem);
+    --csswm-font-size-2xl: clamp(1.5rem, 3vw + 1rem, 2rem);
+    --csswm-font-size-3xl: clamp(1.875rem, 4vw + 1rem, 2.5rem);
+    --csswm-font-size-4xl: clamp(2.25rem, 5vw + 1rem, 3.5rem);
+    --csswm-font-size-5xl: clamp(3rem, 6vw + 1rem, 4.5rem);
+    --csswm-font-size-6xl: clamp(4rem, 7vw + 1rem, 6rem);
+
+    /* Core colors */
+    --csswm-color-bg-primary: #0a0b0d;
+    --csswm-color-bg-secondary: #141619;
+    --csswm-color-bg-tertiary: #1f2128;
+
+    --csswm-color-surface-primary: rgba(255, 255, 255, 0.02);
+    --csswm-color-surface-secondary: rgba(255, 255, 255, 0.05);
+    --csswm-color-surface-accent: rgba(255, 255, 255, 0.12);
+
+    --csswm-color-text-primary: #ffffff;
+    --csswm-color-text-secondary: rgba(255, 255, 255, 0.8);
+    --csswm-color-text-tertiary: rgba(255, 255, 255, 0.6);
+    --csswm-color-text-quaternary: rgba(255, 255, 255, 0.4);
+
+    --csswm-color-border-primary: rgba(255, 255, 255, 0.1);
+    --csswm-color-border-secondary: rgba(255, 255, 255, 0.15);
+    --csswm-color-border-accent: rgba(255, 255, 255, 0.2);
+
+    /* Motion + timing */
+    --csswm-duration-instant: 0.1s;
+    --csswm-duration-fast: 0.2s;
+    --csswm-duration-normal: 0.4s;
+    --csswm-duration-slow: 0.8s;
+    --csswm-duration-slower: 1.2s;
+    --csswm-duration-cinematic: 2s;
+
+    --csswm-ease-in: cubic-bezier(0.4, 0, 1, 1);
+    --csswm-ease-out: cubic-bezier(0, 0, 0.2, 1);
+    --csswm-ease-in-out: cubic-bezier(0.42, 0, 0.58, 1);
+    --csswm-ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    --csswm-ease-cinematic: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+    /* Highlight palette */
+    --csswm-theme-primary: #00d4ff;
+    --csswm-theme-secondary: #ff006e;
+    --csswm-theme-tertiary: #ff3300;
+    --csswm-theme-quaternary: #33ff00;
+    --csswm-theme-primary-dark: #0099cc;
+    --csswm-theme-primary-light: #66e6ff;
+    --csswm-theme-secondary-dark: #cc0055;
+    --csswm-theme-secondary-light: #ff66a3;
+
+    /* Glass + depth */
+    --csswm-glass-background: rgba(16, 18, 27, 0.4);
+    --csswm-glass-border: rgba(255, 255, 255, 0.1);
+    --csswm-glass-shadow: rgba(0, 0, 0, 0.3);
+    --csswm-blur-amount: 20px;
+    --csswm-blur-subtle: 10px;
+    --csswm-blur-intense: 40px;
+
+    /* Shadows */
+    --csswm-shadow-light: rgba(40, 40, 60, 0.5);
+    --csswm-shadow-dark: rgba(0, 0, 0, 0.3);
+    --csswm-shadow-highlight: rgba(255, 255, 255, 0.1);
+
+    /* Perspective */
+    --csswm-perspective: 2000px;
+    --csswm-pop-out-scale: 1.1;
+    --csswm-pop-out-translate-z: 120px;
+    --csswm-tilt-max: 15deg;
+
+    /* Breakpoints */
+    --csswm-breakpoint-mobile: 768px;
+    --csswm-breakpoint-tablet: 1024px;
+    --csswm-breakpoint-desktop: 1200px;
+    --csswm-breakpoint-wide: 1440px;
+
+    /* Z-index ladder */
+    --csswm-z-underground: -1;
+    --csswm-z-default: 0;
+    --csswm-z-elevated: 10;
+    --csswm-z-overlay: 100;
+    --csswm-z-modal: 1000;
+    --csswm-z-toast: 9999;
+}
+
+:root {
+    /* Map neutral tokens into legacy Clear Seas variables */
+    --font-family-primary: var(--csswm-font-family-primary);
+    --font-family-mono: var(--csswm-font-family-mono);
+
+    --font-size-xs: var(--csswm-font-size-xs);
+    --font-size-sm: var(--csswm-font-size-sm);
+    --font-size-base: var(--csswm-font-size-base);
+    --font-size-lg: var(--csswm-font-size-lg);
+    --font-size-xl: var(--csswm-font-size-xl);
+    --font-size-2xl: var(--csswm-font-size-2xl);
+    --font-size-3xl: var(--csswm-font-size-3xl);
+    --font-size-4xl: var(--csswm-font-size-4xl);
+    --font-size-5xl: var(--csswm-font-size-5xl);
+    --font-size-6xl: var(--csswm-font-size-6xl);
+
+    --bg-primary: var(--csswm-color-bg-primary);
+    --bg-secondary: var(--csswm-color-bg-secondary);
+    --bg-tertiary: var(--csswm-color-bg-tertiary);
+
+    --surface-primary: var(--csswm-color-surface-primary);
+    --surface-secondary: var(--csswm-color-surface-secondary);
+    --surface-accent: var(--csswm-color-surface-accent);
+
+    --text-primary: var(--csswm-color-text-primary);
+    --text-secondary: var(--csswm-color-text-secondary);
+    --text-tertiary: var(--csswm-color-text-tertiary);
+    --text-quaternary: var(--csswm-color-text-quaternary);
+
+    --border-primary: var(--csswm-color-border-primary);
+    --border-secondary: var(--csswm-color-border-secondary);
+    --border-accent: var(--csswm-color-border-accent);
+
+    --duration-instant: var(--csswm-duration-instant);
+    --duration-fast: var(--csswm-duration-fast);
+    --duration-normal: var(--csswm-duration-normal);
+    --duration-slow: var(--csswm-duration-slow);
+    --duration-slower: var(--csswm-duration-slower);
+    --duration-cinematic: var(--csswm-duration-cinematic);
+
+    --ease-in: var(--csswm-ease-in);
+    --ease-out: var(--csswm-ease-out);
+    --ease-in-out: var(--csswm-ease-in-out);
+    --ease-spring: var(--csswm-ease-spring);
+    --ease-cinematic: var(--csswm-ease-cinematic);
+
+    --theme-primary: var(--csswm-theme-primary);
+    --theme-secondary: var(--csswm-theme-secondary);
+    --theme-tertiary: var(--csswm-theme-tertiary);
+    --theme-quaternary: var(--csswm-theme-quaternary);
+    --theme-primary-dark: var(--csswm-theme-primary-dark);
+    --theme-primary-light: var(--csswm-theme-primary-light);
+    --theme-secondary-dark: var(--csswm-theme-secondary-dark);
+    --theme-secondary-light: var(--csswm-theme-secondary-light);
+
+    --glass-bg: var(--csswm-glass-background);
+    --glass-border: var(--csswm-glass-border);
+    --glass-shadow: var(--csswm-glass-shadow);
+    --blur-amount: var(--csswm-blur-amount);
+    --blur-subtle: var(--csswm-blur-subtle);
+    --blur-intense: var(--csswm-blur-intense);
+
+    --neo-shadow-light: var(--csswm-shadow-light);
+    --neo-shadow-dark: var(--csswm-shadow-dark);
+    --neo-highlight: var(--csswm-shadow-highlight);
+
+    --perspective: var(--csswm-perspective);
+    --pop-out-scale: var(--csswm-pop-out-scale);
+    --pop-out-translate-z: var(--csswm-pop-out-translate-z);
+    --tilt-max: var(--csswm-tilt-max);
+
+    --breakpoint-mobile: var(--csswm-breakpoint-mobile);
+    --breakpoint-tablet: var(--csswm-breakpoint-tablet);
+    --breakpoint-desktop: var(--csswm-breakpoint-desktop);
+    --breakpoint-wide: var(--csswm-breakpoint-wide);
+
+    --z-underground: var(--csswm-z-underground);
+    --z-default: var(--csswm-z-default);
+    --z-elevated: var(--csswm-z-elevated);
+    --z-overlay: var(--csswm-z-overlay);
+    --z-modal: var(--csswm-z-modal);
+    --z-toast: var(--csswm-z-toast);
+}

--- a/tests/html_smoke_test.py
+++ b/tests/html_smoke_test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Load each top-level HTML file and capture console/page errors."""
+import asyncio
+import json
+import sys
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from playwright.async_api import (
+    Error as PlaywrightError,
+    TimeoutError as PlaywrightTimeout,
+    async_playwright,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML_FILES = sorted(
+    [p for p in ROOT.glob("*.html") if p.is_file()]
+)
+
+
+class SilentHTTPRequestHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        # Silence the default stdout logging from each asset fetch.
+        return
+
+    def handle(self) -> None:
+        try:
+            super().handle()
+        except (ConnectionResetError, BrokenPipeError):
+            # Ignore disconnect noise when headless browsers tear down early.
+            pass
+
+
+def start_static_server(root: Path) -> Tuple[ThreadingHTTPServer, str]:
+    handler = partial(SilentHTTPRequestHandler, directory=str(root))
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    host, port = httpd.server_address
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd, f"http://{host}:{port}"
+
+
+async def audit_file(context, base_url: str, html_path: Path) -> Dict[str, Any]:
+    page = await context.new_page()
+    console_events: List[Dict[str, Any]] = []
+    page_errors: List[str] = []
+    request_failures: List[Dict[str, str]] = []
+    response_errors: List[Dict[str, Any]] = []
+
+    def handle_console(msg):
+        if msg.type == "error":
+            console_events.append(
+                {
+                    "type": msg.type,
+                    "text": msg.text,
+                }
+            )
+
+    page.on("console", handle_console)
+    page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+    page.on(
+        "requestfailed",
+        lambda request: request_failures.append(
+            {
+                "url": request.url,
+                "failure": request.failure,  # type: ignore[arg-type]
+            }
+        ),
+    )
+    page.on(
+        "response",
+        lambda response: response.status >= 400
+        and response_errors.append(
+            {
+                "url": response.url,
+                "status": response.status,
+                "status_text": response.status_text,
+            }
+        ),
+    )
+
+    file_url = f"{base_url}/{html_path.name}"
+    navigation_error = None
+    try:
+        await page.goto(file_url, wait_until="load", timeout=20000)
+        try:
+            await page.wait_for_load_state("networkidle", timeout=10000)
+        except PlaywrightTimeout:
+            # networkidle frequently times out on static pages; only treat as warning
+            pass
+        except PlaywrightError as load_err:
+            navigation_error = f"load-state: {load_err}"
+        await page.wait_for_timeout(2000)
+    except PlaywrightError as nav_err:
+        navigation_error = str(nav_err)
+    finally:
+        await page.close()
+
+    return {
+        "file": html_path.name,
+        "console_errors": console_events,
+        "page_errors": page_errors,
+        "navigation_error": navigation_error,
+        "request_failures": request_failures,
+        "response_errors": response_errors,
+    }
+
+
+async def main() -> None:
+    httpd, base_url = start_static_server(ROOT)
+    try:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch()
+            context = await browser.new_context()
+            results = []
+            for html_path in HTML_FILES:
+                print(f"Auditing {html_path.name}...", file=sys.stderr)
+                results.append(await audit_file(context, base_url, html_path))
+            await browser.close()
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add tagged asset rotations to the site manifest and expose tag metadata through the orchestrator globals
- persist page collection and site code datasets on the document/body via the profile registry for downstream scripts
- document the new tagging workflow in the system overview, brand override guide, and gap analysis

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a51e3e488329a6d2962f9509cdad