### PR TITLE
feat: smooth card tilt response and document per-page needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,32 @@
 
 The repository now serves as the **CSS-Web-Master** control surface for the Clear Seas family of properties. It retains every
 historical Clear Seas Draft experience while layering documentation, orchestration guides, and asset registries so new landing
-pages—like **paraerator.com**, **vib3code.com**, and future CSS destinations—can inherit the same choreography with minimal
+pages—like **parserator.com**, **vib3code.com**, and future CSS destinations—can inherit the same choreography with minimal
 duplication.
+
+Runtime globals now expose both `__CSS_WEB_MASTER_*` and legacy `__CLEAR_SEAS_*` namespaces, and shared typography/color tokens
+live in `styles/css-web-master-tokens.css` so each property can reskin the choreography without forking the master styles.
+Brand asset rotations are sourced from `scripts/site-asset-manifest.js`, and teams can call
+`window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST` to swap media packs per property without touching the orchestrator core.
 
 ### ✅ Deployment Snapshot
 - **6 Main HTML Versions**: Baseline production-ready experiences.
+- **Parserator Launch Surface**: `parserator.html` boots the `parserator-alpha` profile with CSS-Web-Master orchestration.
 - **13 PR Branch Versions**: Themed explorations sourced from the showcase (PRs #1, #4–#24).
-- **Total**: 19+ HTML builds ready to be remixed into site-specific stacks.
 - **Supporting Assets**: Shared scripts, orchestrators, style systems, and uploaded video/logo packs.
 
 ### 🎯 Access Everything
 Use the **[Master Index](https://domusgpt.github.io/Clear-Seas-Draft/)** to browse every build. The index now highlights where
 modules overlap so you can pick the correct starting point for each CSS family site.
+
+### 🚀 Deploying from GitHub Pages
+1. Push the latest `work` branch to GitHub.
+2. In the repository settings, open **Pages** → **Build and deployment** and choose **Deploy from a branch**.
+3. Select the `work` branch and the **/** (root) directory, then save.
+4. After GitHub Pages finishes building, the published site will mirror this repository's root—`index.html`, `parserator.html`,
+   the Master Index, and every supporting asset will be available under the Pages hostname.
+5. Re-run the smoke tests (`python tests/html_smoke_test.py`) after major updates so the latest report reflects the live Pages
+   deployment gaps.
 
 ---
 
@@ -22,10 +36,14 @@ modules overlap so you can pick the correct starting point for each CSS family s
 ### Core HTML Versions (1-6):
 1. **Production** - Main website (index.html)
 2. **Optimized** - Performance enhanced
-3. **Fixed** - Bug fixes applied  
+3. **Fixed** - Bug fixes applied
 4. **Unified** - Unified architecture
 5. **VIB34D Integrated** - Advanced 4D visualization
 6. **Totalistic** - Complete experience
+
+### Site launch surfaces
+- **Parserator Systems** – [`parserator.html`](parserator.html) activates the parserator-specific profile while preserving the
+  Clear Seas fallbacks.
 
 ### PR Branch Versions (7-30):
 - **7-pr-1** - Initial avant-garde consulting experience
@@ -43,7 +61,8 @@ modules overlap so you can pick the correct starting point for each CSS family s
 - **29-pr-23** - Holographic background with pinned showcases
 - **30-pr-24** - Amplified reactive background and card choreography
 
-🚀 **Every version is fully functional with complete assets and dependencies.**
+🚀 **Core versions load successfully; PR galleries still reference placeholder imagery/iframes (see the smoke report for open
+items).**
 
 ### Motion choreography docs
 
@@ -55,9 +74,17 @@ Additional CSS-Web-Master documentation is tracked in:
 - [`docs/css-web-master-system-overview.md`](docs/css-web-master-system-overview.md) – explains the multi-site orchestration
   model, shared registries, and how to extend the system for new CSS properties.
 - [`docs/css-web-master-gap-analysis.md`](docs/css-web-master-gap-analysis.md) – outlines Clear Seas-specific assumptions to
-  generalize before production rollouts on paraerator.com or vib3code.com.
+  generalize before production rollouts on parserator.com or vib3code.com.
 - [`docs/dev-updates/2025-05-07-css-web-master-transition.md`](docs/dev-updates/2025-05-07-css-web-master-transition.md) –
   developer log detailing the latest transition steps and recommended next moves.
+- [`docs/dev-updates/2025-05-10-parserator-launch-surface.md`](docs/dev-updates/2025-05-10-parserator-launch-surface.md) –
+  documents the Parserator entry point, brand-event dedupe, and the current smoke-test focus areas.
+- [`styles/css-web-master-tokens.css`](styles/css-web-master-tokens.css) – neutral design tokens consumed by consolidated
+  stylesheets for per-site overrides.
+- [`docs/html-version-test-report.md`](docs/html-version-test-report.md) – latest smoke-test results for every HTML build and the
+  outstanding defects to close before CSS-Web-Master goes live.
+- `node [tools/validate-asset-manifest.mjs](tools/validate-asset-manifest.mjs)` – verifies manifest paths exist and that site
+  manifests include tagged assets before deployment.
 
 ---
 © 2025 Paul Phillips - Clear Seas Solutions LLC

--- a/docs/brand-asset-overrides.md
+++ b/docs/brand-asset-overrides.md
@@ -49,6 +49,69 @@ window.__CLEAR_SEAS_CARD_BRAND_OVERRIDES = [
 
 Keys mirror the data attributes and accept the same value shapes. The orchestrator merges all matching descriptors (ordered as provided), then layers data attributes on top.
 
+## Site asset manifest
+
+Each site can point the orchestrator at a different base image/video rotation without editing the core script. The default packs
+live in `scripts/site-asset-manifest.js`, and the orchestrator exposes a helper for runtime updates:
+
+```html
+<script type="module">
+  window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST?.({
+    parserator: {
+      images: [
+        {
+          src: 'assets/parserator/logo.png',
+          siteCodes: ['parserator'],
+          tags: ['hero', 'logo']
+        },
+        {
+          src: 'assets/parserator/hangar.png',
+          siteCodes: ['parserator'],
+          tags: ['diagnostic']
+        }
+      ],
+      videos: [
+        {
+          src: 'assets/parserator/atmos-loop.mp4',
+          siteCodes: ['parserator'],
+          tags: ['ambient']
+        }
+      ]
+    }
+  }, { reason: 'parserator-brand-pack' });
+</script>
+```
+
+The helper merges the manifest, refreshes the current page profile's media selection, and dispatches the same
+`css-web-master:brand-overrides-changed` / `clear-seas:brand-overrides-changed` events that card systems already listen for.
+If no runtime manifest is provided the default Clear Seas pack remains in rotation.
+
+### Manifest metadata
+
+Entries can either be bare strings (for backwards compatibility) or objects with additional metadata. The orchestrator now
+tracks the following fields for every asset:
+
+- `src` – required path to the image or video.
+- `siteCodes` – optional list of site tokens. When a page resolves to one of these tokens the manifest will prefer the tagged
+  assets. If no tagged assets exist the orchestrator falls back to the inherited pack.
+- `tags` – free-form descriptors (`hero`, `diagnostic`, `ambient`, etc.) used for reporting and future tooling.
+- `label` – human-readable description that surfaces in debugging overlays.
+- `weight` – optional numeric hint for future weighted rotations.
+
+The resolved brand bundle (available via `window.__CSS_WEB_MASTER_BRAND_ASSETS`) now includes a `meta` map so downstream systems
+can inspect tags or site codes without re-parsing the manifest.
+
+### Validating manifest entries
+
+Run the repository's validator to confirm every manifest path exists and that site-specific manifests include tagged assets:
+
+```bash
+node tools/validate-asset-manifest.mjs
+```
+
+The script fails when files are missing and warns when site manifests do not tag at least one asset with their site code. This
+keeps rotations deterministic as new CSS family properties come online.
+
 ## Updating overrides at runtime
 
 When overrides change after the orchestrator has initialised, call the shared refresh helper to keep every card system in sync:

--- a/docs/css-web-master-gap-analysis.md
+++ b/docs/css-web-master-gap-analysis.md
@@ -1,43 +1,56 @@
 # CSS-Web-Master Gap Analysis
 
 This checklist captures the Clear Seas-specific assumptions that still live in the codebase. Addressing each item will make the
-CSS-Web-Master platform production-ready for paraerator.com, vib3code.com, and future CSS family properties.
+CSS-Web-Master platform production-ready for parserator.com, vib3code.com, and future CSS family properties.
 
 ## Naming & Branding
 
 - **Global variables & events** still use the `clear-seas` prefix (`window.__CLEAR_SEAS_GLOBAL_MOTION`, `clear-seas:motion-updated`).
-  - *Action:* Introduce aliases or a namespace bridge (e.g., `window.__CSS_WEB_MASTER`) so downstream integrations can migrate
-    without breaking existing builds.
+  - ✅ **Completed:** `global-page-orchestrator`, `card-system-initializer`, and `vib34d-contained-card-system` now publish
+    `__CSS_WEB_MASTER_*` globals and dispatch both `css-web-master:*` and legacy `clear-seas:*` events.
+  - ⏭️ *Follow-on:* Audit bespoke modules for hard-coded event strings and migrate them to the registry aliases.
 - **Dataset attributes** applied by `global-page-orchestrator` are `data-global-page-family/layout`. Confirm if new properties
   require additional tags (e.g., `data-site-code`).
 
 ## Page Profile Registry
 
 - Profiles currently reference Clear Seas-specific copy and brand asset packages.
-  - *Action:* Split palette metadata from marketing copy to allow new sites to opt into the same colors without inheriting copy.
+  - ✅ **Completed:** Palette definitions now live in a shared library, and a `parserator` site profile demonstrates how new
+    properties reuse the foundation palette while swapping copy/modules.
 - Filename heuristics prioritize `index`/`pr` naming. Define detection patterns for future site URLs or configure explicit
   overrides.
+
+## Site-specific follow-ups
+
+- ⏳ **Parserator-exclusive scenes** – Inference labs, dataset storytelling, and telemetry overlays are tracked separately so
+  the Clear Seas baseline can ship while Parserator creative work continues.
+- ⏳ **VIB3Code gallery rebuild** – The vib3code.com showcase still references the original Clear Seas layouts and needs a
+  dedicated gallery once single-site priorities rise.
+- ⏳ **Per-site deployment runbooks** – Document hostnames, CI triggers, and CDN packaging steps for parserator.com and
+  vib3code.com before the first live release.
 
 ## Asset Management
 
 - The brand override registry expects assets in `/assets/` with Clear Seas naming conventions.
-  - *Action:* Add configuration hooks (JSON or module exports) so each site can define its own asset manifest without editing the
-    orchestrator.
+  - ✅ **Completed:** Introduced `scripts/site-asset-manifest.js` and a runtime registration helper so each site can publish its
+    own asset package while the orchestrator resolves the correct image/video rotation automatically.
+  - ✅ **Completed:** `tools/validate-asset-manifest.mjs` validates manifest paths and site tags during local builds.
 - Uploaded mp4 overlays are catalogued but not yet grouped by campaign/site.
-  - *Action:* Tag assets by site or theme within the registry for deterministic rotation.
+  - ✅ **Completed:** Manifest entries now ship with site tags and metadata so rotations stay deterministic per property.
 
 ## Styling Systems
 
 - `styles/clear-seas-ai.css` includes marketing copy classes and iconography unique to the Clear Seas mission deck.
   - *Action:* Extract generic motion/visualizer styles into a neutral stylesheet and let each site layer its own typography.
 - `styles/consolidated-styles.css` references fonts and color tokens specific to Clear Seas.
-  - *Action:* Externalize font stacks and color tokens into CSS variables so sites can swap values without duplicating files.
+  - ✅ **Completed:** Neutral tokens live in `styles/css-web-master-tokens.css`, and downstream styles consume them via CSS
+    variables for per-site overrides.
 
 ## Documentation
 
 - The Master Index references Clear Seas experiences throughout.
   - *Action:* Update hero copy per site launch, or create property-specific indexes that reuse the same component grid.
-- Add runbooks for deploying to each production host (paraerator.com, vib3code.com) once the orchestration pattern is finalized.
+- Add runbooks for deploying to each production host (parserator.com, vib3code.com) once the orchestration pattern is finalized.
 
 ## Tooling Wishlist
 

--- a/docs/css-web-master-system-overview.md
+++ b/docs/css-web-master-system-overview.md
@@ -8,7 +8,7 @@ can reuse without rewriting motion logic or asset loading rules.
 
 1. **Unify shared infrastructure.** Global scripts (`global-page-orchestrator`, `page-profile-registry`) centralize brand
    palettes, asset rotation, and CSS variable broadcasting so each site inherits the same reactive scaffolding.
-2. **Scale across properties.** paraerator.com, vib3code.com, and other CSS launches can point at the same orchestrator and
+2. **Scale across properties.** parserator.com, vib3code.com, and other CSS launches can point at the same orchestrator and
    stylesheet bundle, then layer site-specific copy or modules on top.
 3. **Preserve creative experimentation.** Every HTML build remains available as a reference implementation, letting teams remix
    existing choreography patterns instead of starting from scratch.
@@ -28,9 +28,11 @@ can reuse without rewriting motion logic or asset loading rules.
 1. **Choose a baseline template** from the Master Index based on the desired experience (e.g., Immersive AI deck, Blueprint lab,
    Totalistic showcase).
 2. **Set the page profile** using `data-page-collection` or filename conventions so the orchestrator loads the correct palette
-   and asset set.
-3. **Register brand assets** through the shared brand override registry or by dropping new media into `assets/` and referencing
-   them within the profile metadata.
+   and asset set. Provide `data-site-code="<site>`" (or configure an explicit registry override) to target the right site family
+   when launching new properties.
+3. **Register brand assets** through the shared brand override registry or by updating the site asset manifest (either editing
+   `scripts/site-asset-manifest.js` or calling `window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST` with a runtime manifest) so the
+   orchestrator rotates the correct media package.
 4. **Customize copy and modules** while leaving the orchestrator hooks in place so focus, pointer, and scroll telemetry continue
    to propagate to canvases, overlays, and videos.
 5. **Document site-specific adjustments** in the `/docs` folder to keep the control surface accurate for each deployment.
@@ -39,16 +41,33 @@ can reuse without rewriting motion logic or asset loading rules.
 
 - **Brand overrides**: Use `docs/brand-asset-overrides.md` as the canonical guide. New logo treatments, translucent overlays, or
   short-form mp4 loops can be registered once and consumed across every card system.
+- **Site asset manifest**: `scripts/site-asset-manifest.js` hosts per-site image/video rotations. Update it (or call
+  `window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST`) to point a property at the correct media pack without editing the
+  orchestrator. Assets can include metadata (`siteCodes`, `tags`, `label`, `weight`) so rotations stay deterministic per site
+  and downstream tooling can reason about usage.
 - **Uploaded media**: Recent additions (e.g., `20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4`,
   `20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4`) are ready for rotation within the
   orchestrator-managed palettes.
 - **Overscan defaults**: Canvas overscan is now managed globally, ensuring holographic visuals always bleed past card edges while
   respecting tilt and bend cues supplied by motion telemetry.
 
+Run `node tools/validate-asset-manifest.mjs` whenever new media is added to ensure manifests reference existing files and include
+site tags for property-specific rotations.
+
+## Site codes & design tokens
+
+- **Namespace bridge:** Runtime globals now publish both `__CSS_WEB_MASTER_*` and legacy `__CLEAR_SEAS_*` properties. New builds
+  should subscribe to `css-web-master:motion-updated` (via `window.__CSS_WEB_MASTER_GLOBAL_MOTION_EVENT`) while maintaining
+  legacy listeners.
+- **Profile palette library:** Palette metadata is defined once and shared across profiles. The new `parserator` entry reuses the
+  foundation palette while layering property-specific scripts and copy.
+- **Token overrides:** `styles/css-web-master-tokens.css` centralises typography, color, and motion variables. Override
+  `--csswm-*` tokens per site to re-skin experiences without duplicating the choreography stylesheets.
+
 ## Extending to New Sites
 
-- **paraerator.com**: Start from a PR-series immersive deck to reuse mission-axis navigation. Update the profile registry with a
-  `paraerator` family that swaps in the new logos/videos and adjust copy modules accordingly.
+- **parserator.com**: `parserator.html` now boots the `parserator-alpha` profile so the essentials are in place. Follow-up work
+  focuses on Parserator-exclusive scenes (labs, telemetry overlays) that remain flagged in the gap analysis.
 - **vib3code.com**: Leverage the VIB34D-integrated builds for continuity with the existing visualizer engines. Register
   additional shader parameters if new interaction types are required.
 - **Future CSS properties**: Define new families within `page-profile-registry`, point them at shared synergy styles, and create

--- a/docs/dev-updates/2025-05-07-css-web-master-transition.md
+++ b/docs/dev-updates/2025-05-07-css-web-master-transition.md
@@ -7,7 +7,7 @@
 - Authored the **CSS-Web-Master System Overview** documenting the orchestration layers, workflow, and asset strategy for
   multi-site reuse.
 - Captured a **Gap Analysis** outlining Clear Seas-specific assumptions that need generalization before deploying to
-  paraerator.com, vib3code.com, or other destinations.
+  parserator.com, vib3code.com, or other destinations.
 
 ## Why it matters
 
@@ -18,7 +18,7 @@
 
 ## Next recommendations
 
-1. Prototype a new page profile (e.g., `paraerator`) in `scripts/page-profile-registry.js` to validate the workflow and confirm
+1. Prototype a new page profile (e.g., `parserator`) in `scripts/page-profile-registry.js` to validate the workflow and confirm
    asset overrides behave as expected.
 2. Introduce namespace aliases for the global motion object/event to decouple future builds from the `clear-seas` prefix.
 3. Begin extracting neutral typography and color tokens into a shared variables file so each site can ship with its own brand

--- a/docs/dev-updates/2025-05-08-site-asset-manifest.md
+++ b/docs/dev-updates/2025-05-08-site-asset-manifest.md
@@ -1,0 +1,23 @@
+# Dev Update – 8 May 2025
+
+## What changed
+
+- Added `scripts/site-asset-manifest.js` to centralize default image/video rotations and support per-site overrides.
+- Updated `global-page-orchestrator.js` to resolve brand assets via the manifest, expose
+  `window.__CSS_WEB_MASTER_REGISTER_ASSET_MANIFEST`, and synchronize both Clear Seas and CSS-Web-Master event namespaces when the
+  manifest changes.
+- Refreshed documentation (`README.md`, system overview, gap analysis, and brand override guide) so teams know how to publish
+  their own media packs without editing the orchestrator.
+
+## Why it matters
+
+- The Clear Seas showcase can now act as a true control surface: every site can declare its own asset bundle while the shared
+  motion/override plumbing stays untouched.
+- Runtime registration enables launch teams to iterate on brand media (and validate manifests) directly in staging without
+  triggering manual code edits.
+
+## Next recommendations
+
+1. Build validation tooling that compares manifest entries against the `/assets` directory to catch typos before deployment.
+2. Extend the manifest format with optional metadata (e.g., attribution, dimensions, codecs) to assist downstream optimizers.
+3. Group uploaded MP4 overlays by campaign/site to make deterministic rotation rules easier to author.

--- a/docs/dev-updates/2025-05-09-asset-metadata-and-validation.md
+++ b/docs/dev-updates/2025-05-09-asset-metadata-and-validation.md
@@ -1,0 +1,28 @@
+# Dev Update – 9 May 2025
+
+## What changed
+
+- Tagged every default image/video in `scripts/site-asset-manifest.js` with site codes, labels, and descriptor tags so rotations
+  stay deterministic when parserator.com, vib3code.com, or future CSS properties take over the control surface.
+- Exposed manifest metadata to the orchestrator and card controllers (`window.__CSS_WEB_MASTER_BRAND_ASSETS.meta`) so downstream
+  systems can choose assets by tag without re-parsing the manifest.
+- Added `tools/validate-asset-manifest.mjs`, a lightweight Node script that checks each manifest path exists and that site packs
+  include tagged assets before deployment.
+- Updated the brand override guide, README, system overview, and gap analysis to document the metadata format and validation
+  workflow.
+
+## Why it matters
+
+- Manifest metadata finally closes the "tag assets by site" item from the CSS-Web-Master gap analysis, enabling reproducible
+  media rotations per property.
+- Teams can now run a single command to confirm manifests stay healthy, preventing staging surprises when assets move or site
+  packs omit required tags.
+
+## Next recommendations
+
+1. Feed the manifest metadata into dashboard tooling (or the smoke harness) so reports can highlight which assets each site
+   currently rotates.
+2. Extend `tools/validate-asset-manifest.mjs` with optional `--site <code>` filters to preview the exact bundle a property will
+   receive.
+3. Capture additional metadata (codec, resolution, duration) once media files are finalized to support future optimization
+   pipelines.

--- a/docs/dev-updates/2025-05-10-parserator-launch-surface.md
+++ b/docs/dev-updates/2025-05-10-parserator-launch-surface.md
@@ -1,0 +1,11 @@
+# 2025-05-10 – Parserator launch surface & smoke audit cleanup
+
+## Highlights
+- Shipped `parserator.html`, the first dedicated Parserator entry point wired into the shared profile registry and asset manifest.
+- Wrapped both card system bundles in window-scoped IIFEs so `PRIMARY_BRAND_OVERRIDE_EVENT` is resolved once and shared across scripts.
+- Refreshed the smoke-test report after rerunning the Playwright harness; core builds now succeed aside from the missing `ClearSeasContextPool` script on Totalistic and the PR asset placeholders.
+
+## Follow-ups
+- Restore the Clear Seas context pool module for 6-index-totalistic so the layered visualizers stop logging bootstrap errors.
+- Move PR gallery imagery into `/assets` (or change the references) and rebuild the `/demos` showcase embeds to clear the 404 spam.
+- Stand up Parserator-specific scenes (labs, telemetry overlays) once the shared launch surface is approved.

--- a/docs/global-motion-reference.md
+++ b/docs/global-motion-reference.md
@@ -7,10 +7,11 @@ patterns for downstream systems.
 
 ## Runtime snapshot
 
-The orchestrator stores the latest values on `window.__CLEAR_SEAS_GLOBAL_MOTION` and
-dispatches them through the `clear-seas:motion-updated` event (also exported as
-`window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT`). Each dispatch now includes the following
-properties:
+The orchestrator stores the latest values on `window.__CSS_WEB_MASTER_GLOBAL_MOTION`
+(aliased to `window.__CLEAR_SEAS_GLOBAL_MOTION`) and dispatches them through the
+`css-web-master:motion-updated` event (still aliased to `clear-seas:motion-updated`
+via `window.__CSS_WEB_MASTER_GLOBAL_MOTION_EVENT`). Each dispatch now includes the
+following properties:
 
 | Field | Description |
 |-------|-------------|
@@ -30,11 +31,11 @@ properties:
 | `timestamp` | High-resolution timestamp for the snapshot. |
 
 Consumers that only need the latest state can read from
-`window.__CLEAR_SEAS_GLOBAL_MOTION`. For reactive experiences, listen for the shared
-event:
+`window.__CSS_WEB_MASTER_GLOBAL_MOTION`. For reactive experiences, listen for the
+shared event:
 
 ```js
-window.addEventListener(window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT, (event) => {
+window.addEventListener(window.__CSS_WEB_MASTER_GLOBAL_MOTION_EVENT, (event) => {
   const motion = event.detail;
   // ...update shaders, canvases, analytics, etc.
 });

--- a/docs/html-version-groups.md
+++ b/docs/html-version-groups.md
@@ -47,7 +47,7 @@ These builds experiment with alternative canvases, typography systems, or resear
 
 ## Brand Palette Synchronization
 
-The `global-page-orchestrator` now detects which collection a page belongs to and shares that profile through `window.__CLEAR_SEAS_PAGE_PROFILE`. The four active palettes are:
+The `global-page-orchestrator` now detects which collection a page belongs to and shares that profile through `window.__CSS_WEB_MASTER_PAGE_PROFILE` (still aliased as `window.__CLEAR_SEAS_PAGE_PROFILE`). The four active palettes are:
 
 - **Meta Index (`meta-index`)** – used for the overview map.
 - **Core Foundation (`core-foundation`)** – powers the 1–6 flagship builds.

--- a/docs/html-version-test-report.md
+++ b/docs/html-version-test-report.md
@@ -1,0 +1,70 @@
+# HTML Version Smoke Test Report
+
+_Updated: 2025-05-11_
+
+## Test methodology
+- A new Playwright smoke harness (`tests/html_smoke_test.py`) serves the repository through a temporary HTTP server and opens every top-level HTML file in headless Chromium. It records console errors, page exceptions, failed network requests, and HTTP 4xx/5xx responses so we can distinguish real defects from environment limitations.【F:tests/html_smoke_test.py†L1-L114】
+- Run the audit locally with `python tests/html_smoke_test.py > out.json`. The script prints progress to stderr while writing a JSON summary to stdout so the raw results can be inspected or re-aggregated for new reports.【F:tests/html_smoke_test.py†L85-L114】
+
+## Environment caveats
+- **Google Fonts / external HTTPS** – the container image lacks the public CA bundle Playwright expects, so calls to `fonts.googleapis.com` fail with `net::ERR_CERT_AUTHORITY_INVALID`. Treat these as environment warnings unless they surface in production browsers.【F:tests/html_smoke_test.py†L49-L79】
+- **Large MP4 downloads** – several pages stream multi-megabyte hero videos. The headless browser cancels those downloads when navigation completes, producing `net::ERR_ABORTED`. Video playback works once the assets live on CDN or when tests wait for the streams to finish; no in-page error surfaced.【F:tests/html_smoke_test.py†L44-L79】
+- **Load-state timeouts** – pages 28 and 30 continue requesting 404 images, so `page.goto(... wait_until="load")` never resolves within 20 seconds. Increasing the timeout lets the audit finish but does not hide the underlying missing assets. The navigation timeouts are flagged as actionable defects below.【F:tests/html_smoke_test.py†L61-L72】
+
+## Results summary
+| HTML file | Status | Notes |
+| --- | --- | --- |
+| 1-index.html | ⚠️ | Only external Google Fonts requests fail inside the container. |
+| 2-index-optimized.html | ⚠️ | Same Google Fonts warning as 1-index. |
+| 3-index-fixed.html | ⚠️ | Only external Google Fonts requests fail inside the container. |
+| 4-index-unified.html | ⚠️ | Only external Google Fonts requests fail inside the container. |
+| 5-index-vib34d-integrated.html | ⚠️ | Only external Google Fonts requests fail inside the container. |
+| 6-index-totalistic.html | ❌ | `ClearSeasContextPool` still never loads, so the layered visualizer bootstrap logs an error. |
+| 7-pr-1.html | ⚠️ | Only Google Fonts blocked by environment. |
+| 8-pr-2.html | ⚠️ | Only Google Fonts blocked by environment. |
+| 9-pr-3.html | ⚠️ | Google Fonts blocked and long MP4 downloads abort when the browser exits. |
+| 10-pr-4.html | ❌ | Image cards reference `styles/assets/*.png`, but the images live in `/assets` so every card graphic returns 404. |
+| 11-pr-5.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 12-pr-6.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 13-pr-7.html | ❌ | Embedded showcase iframes point to `/demos/*.html`, which are absent. |
+| 14-pr-8.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 15-pr-9.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 16-pr-10.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 17-pr-11.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 18-pr-12.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 19-pr-13.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 20-pr-14.html | ⚠️ | Only Google Fonts blocked and hero MP4 streams cancelled when the browser closes. |
+| 21-pr-15.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 22-pr-16.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 23-pr-17.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 24-pr-18.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 25-orthogonal-depth-progression.html | ⚠️ | Only Google Fonts blocked by environment. |
+| 25-pr-19.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 26-pr-20.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 27-pr-21.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 28-pr-22.html | ❌ | Load event never finishes because every `styles/assets` image 404s; audit hit the 20s timeout. |
+| 29-pr-23.html | ❌ | Same missing `styles/assets` imagery as 10-pr-4. |
+| 30-pr-24.html | ❌ | Load event never finishes because every `styles/assets` image 404s; audit hit the 20s timeout. |
+| ULTIMATE-clear-seas-holistic-system.html | ⚠️ | Google Fonts blocked and hero MP4 streams cancelled when the browser closes. |
+| index.html | ✅ | Navigation reaches `load` with no runtime or network errors. |
+| parserator.html | ⚠️ | Only external Google Fonts requests fail inside the container. |
+
+The `PRIMARY_BRAND_OVERRIDE_EVENT` redeclaration is resolved, so the core builds now load successfully; Totalistic still needs the
+`ClearSeasContextPool` script restored, and the PR galleries continue to 404 their placeholder assets.
+
+## Next steps
+1. **Fix static asset paths** – update the PR showcase templates so card imagery references `/assets/*.png` (or move the files under `styles/assets/`). The same adjustment is needed for the missing `/demos/*.html` showcase embeds.
+2. **Load the ClearSeas context pool** – ensure `6-index-totalistic.html` includes the script that defines `window.ClearSeasContextPool` so the layered visualizers initialise without logging an error.
+3. **Optional test hardening** – if we need fully green runs inside CI, bundle critical fonts locally and host video fixtures under `/assets` so the smoke harness avoids remote TLS altogether.
+
+## Page-by-page upgrade plan
+
+- **index.html** – primary launch surface. The card motion is now smoothed through the shared motion bus, so focus on content polish and call-to-action wiring.
+- **1-index.html / 2-index-optimized.html / 3-index-fixed.html** – keep typography fonts local to avoid TLS warnings and revisit hero video fallbacks so large downloads do not cancel on navigation.
+- **4-index-unified.html** – card tilt now respects the calmer global motion state; next step is replacing remote iframes with in-repo captures and wiring manifest-driven imagery.
+- **5-index-vib34d-integrated.html** – same tilt smoothing applies. Audit embedded viewer URLs and align branding tokens with the CSS-Web-Master palette.
+- **6-index-totalistic.html** – still blocked on the missing `ClearSeasContextPool`; restore the loader script and verify the layered canvases ingest the moderated motion signals.
+- **7-pr-1.html through 30-pr-24.html** – resolve the 404 asset paths (`styles/assets/*`) and either supply the `/demos/*.html` embeds or update the galleries to reuse existing pages. Each PR template should point at the curated `/assets` manifest so the new tilt curve lands on real art.
+- **25-orthogonal-depth-progression.html** – confirm the orthogonal depth lab reads from the shared motion state and bundle any specialty fonts locally.
+- **ULTIMATE-clear-seas-holistic-system.html** – big hero videos still abort when the browser closes; preload lighter-weight clips or provide poster frames so the experience survives audits.
+- **parserator.html** – the parserator profile loads cleanly apart from Google Fonts; next iteration should wire the parserator asset tags into the manifest and replace the remote font dependency.

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
             <div class="logo">🧭 CSS-Web-Master Control Surface</div>
             <div class="subtitle">Powered by the Clear Seas Draft multi-version library</div>
             <div class="count">32 Experiences • 6 Core + 24 PR Branches + 2 Labs</div>
-            <p>Use this library to seed future CSS-family launches (paraerator.com, vib3code.com, and beyond).</p>
+            <p>Use this library to seed future CSS-family launches (parserator.com, vib3code.com, and beyond).</p>
         </div>
 
         <!-- MAIN HTML VERSIONS (1-6) -->

--- a/parserator.html
+++ b/parserator.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en" data-site-code="parserator" data-page-id="parserator">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Parserator Systems – CSS-Web-Master Launch Surface</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/css-web-master-tokens.css">
+  <link rel="stylesheet" href="styles/consolidated-styles.css">
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body.site-parserator {
+      font-family: 'Orbitron', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background: radial-gradient(circle at top, rgba(18, 32, 64, 0.96), rgba(4, 12, 28, 0.96));
+      min-height: 100vh;
+      color: #e5f6ff;
+      display: flex;
+      flex-direction: column;
+    }
+    header.parserator-hero {
+      padding: clamp(3rem, 6vw, 6rem) clamp(2rem, 5vw, 5rem);
+      display: grid;
+      gap: clamp(2rem, 5vw, 4rem);
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      border-bottom: 1px solid rgba(134, 211, 255, 0.24);
+    }
+    header.parserator-hero::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 20% 20%, rgba(134, 211, 255, 0.25), transparent 60%),
+        radial-gradient(circle at 80% 30%, rgba(255, 170, 223, 0.12), transparent 70%);
+      pointer-events: none;
+    }
+    .hero-headline {
+      font-size: clamp(2.6rem, 6vw, 4.6rem);
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--token-primary-400, #8ddcff);
+      text-shadow: 0 12px 32px rgba(18, 32, 64, 0.65);
+    }
+    .hero-subtitle {
+      font-size: clamp(1rem, 2vw, 1.4rem);
+      max-width: 52ch;
+      line-height: 1.6;
+      color: rgba(229, 246, 255, 0.78);
+    }
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+    .hero-actions a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.85rem 1.6rem;
+      border-radius: 999px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #020c1c;
+      background: linear-gradient(135deg, #8ddcff 0%, #7ef6ff 100%);
+      box-shadow: 0 18px 35px rgba(126, 246, 255, 0.32);
+      text-decoration: none;
+    }
+    .hero-actions a.secondary {
+      background: transparent;
+      border: 1px solid rgba(229, 246, 255, 0.4);
+      color: rgba(229, 246, 255, 0.85);
+      box-shadow: none;
+    }
+    .layout-grid {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 3rem);
+      padding: clamp(2.5rem, 5vw, 5rem);
+    }
+    .grid-two-column {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: clamp(1.5rem, 3vw, 2.5rem);
+    }
+    .card {
+      background: rgba(2, 12, 28, 0.58);
+      border: 1px solid rgba(134, 211, 255, 0.24);
+      border-radius: 18px;
+      padding: clamp(1.5rem, 3vw, 2.5rem);
+      box-shadow: 0 22px 45px rgba(2, 12, 28, 0.38);
+      position: relative;
+      overflow: hidden;
+    }
+    .card::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(126, 246, 255, 0.12), transparent 60%);
+      opacity: 0;
+      transition: opacity 220ms ease;
+      pointer-events: none;
+    }
+    .card:hover::before {
+      opacity: 1;
+    }
+    .card h3 {
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 1rem;
+      margin-bottom: 0.75rem;
+      color: var(--token-primary-300, #aee8ff);
+    }
+    .card p {
+      line-height: 1.6;
+      color: rgba(229, 246, 255, 0.75);
+    }
+    .badge-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 1.25rem;
+    }
+    .badge {
+      padding: 0.35rem 0.9rem;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgba(229, 246, 255, 0.85);
+      border: 1px solid rgba(126, 246, 255, 0.35);
+    }
+    footer {
+      padding: 2.5rem clamp(2rem, 5vw, 4rem);
+      border-top: 1px solid rgba(134, 211, 255, 0.2);
+      display: grid;
+      gap: 0.75rem;
+      background: rgba(2, 12, 28, 0.72);
+    }
+    footer p {
+      color: rgba(229, 246, 255, 0.72);
+      line-height: 1.5;
+    }
+  </style>
+</head>
+<body class="site-parserator" data-site-code="parserator" data-page-profile="parserator-alpha">
+  <header class="parserator-hero" data-brand-overlay-filter="hue-rotate(18deg) saturate(1.4)" data-brand-overlay-opacity="1.1">
+    <div>
+      <p class="badge" data-brand-palette="foundation">Parserator Systems</p>
+      <h1 class="hero-headline">Launch the Parserator Flight Deck</h1>
+      <p class="hero-subtitle" data-brand-mode="immersive">
+        Precision parsing, telemetry aware automation, and CSS-Web-Master orchestration united under the Parserator banner.
+        This launch surface routes the asset manifest, brand overlays, and motion telemetry through the same interfaces used by
+        Clear Seas while enabling parserator.com to define its own rotations.
+      </p>
+      <div class="hero-actions">
+        <a href="#mission" data-brand-cycle="focus" data-brand-seed-offset="2">Review Mission</a>
+        <a class="secondary" href="#roadmap" data-brand-cycle="click" data-brand-seed-offset="4">View Roadmap</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="layout-grid">
+    <section id="mission" class="grid-two-column" data-brand-palette="foundation">
+      <article class="card" data-brand-seed="8" data-brand-cycle="hover">
+        <h3>Mission Profile</h3>
+        <p>
+          Parserator amplifies structured intelligence for enterprise knowledge flows. The CSS-Web-Master stack keeps the
+          launch profile aligned with Clear Seas primitives while unlocking Parserator specific tone, asset loops, and
+          telemetry instrumentation.
+        </p>
+        <div class="badge-row">
+          <span class="badge">Structured Intelligence</span>
+          <span class="badge">Telemetry</span>
+          <span class="badge">Brand Sync</span>
+        </div>
+      </article>
+      <article class="card" data-brand-seed="12" data-brand-cycle="hover" data-brand-palette="immersive">
+        <h3>Flight Operations</h3>
+        <p>
+          Shared orchestrator APIs manage the Parserator deck. Brand refreshes flow through
+          <code>css-web-master:brand-overrides-changed</code> while Clear Seas listeners still catch
+          <code>clear-seas:brand-overrides-changed</code> via the bridge.
+        </p>
+        <div class="badge-row">
+          <span class="badge">Dual-Namespace</span>
+          <span class="badge">Override API</span>
+          <span class="badge">Motion Bus</span>
+        </div>
+      </article>
+    </section>
+
+    <section id="roadmap" class="grid-two-column" data-brand-palette="concept">
+      <article class="card" data-brand-cycle="focus" data-brand-seed="18">
+        <h3>Launch Checklist</h3>
+        <p>
+          The essentials are wired: profile registry entry, shared manifest usage, and smoke harness coverage. Next steps focus
+          on Parserator-only scenes like inference labs and live data connectors. These tasks stay flagged in the gap analysis
+          so Clear Seas core work can ship independently.
+        </p>
+        <div class="badge-row">
+          <span class="badge">Essentials Complete</span>
+          <span class="badge">Site Specific TODO</span>
+          <span class="badge">Smoke Tested</span>
+        </div>
+      </article>
+      <article class="card" data-brand-seed="21" data-brand-cycle="hover" data-brand-palette="foundation">
+        <h3>Shared Capabilities</h3>
+        <p>
+          Parserator inherits the consolidated styles, card systems, and manifest tooling. All assets resolve through the new
+          tagged manifest filters ensuring the correct rotations when the site code equals <code>parserator</code>.
+        </p>
+        <div class="badge-row">
+          <span class="badge">Shared Styles</span>
+          <span class="badge">Asset Manifest</span>
+          <span class="badge">Card Systems</span>
+        </div>
+      </article>
+    </section>
+  </main>
+
+  <footer data-brand-palette="foundation">
+    <p>
+      Parserator launch surfaces remain under active construction. Site-specific labs, dataset stories, and telemetry overlays
+      are tracked in the CSS-Web-Master gap analysis so we can focus on the essentials today while highlighting the remaining
+      Parserator-exclusive work.
+    </p>
+    <p>Contact the Clear Seas + Parserator integration team for launch coordination.</p>
+  </footer>
+
+  <script type="module" src="scripts/global-page-orchestrator.js"></script>
+</body>
+</html>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+playwright==1.43.0

--- a/scripts/page-profile-registry.js
+++ b/scripts/page-profile-registry.js
@@ -1,14 +1,6 @@
-const PROFILE_DEFINITIONS = [
-  {
-    key: 'meta-index',
-    label: 'Meta Index Overview',
-    family: 'meta',
-    layout: 'map',
-    palette: 'meta',
+const PALETTE_LIBRARY = {
+  meta: {
     accent: '#7ef6ff',
-    fileNames: ['index.html'],
-    tags: ['index', 'meta', 'map', 'directory'],
-    titleTokens: ['all versions', 'collections', 'clear seas solutions'],
     overlay: {
       blend: 'screen',
       opacity: 1.08,
@@ -19,28 +11,10 @@ const PROFILE_DEFINITIONS = [
     canvas: {
       scale: 0.08,
       depth: '12px'
-    },
-    imageOrder: [2, 3, 4, 0, 1, 5, 6, 7, 8],
-    videoOrder: [4, 5, 6, 0, 1, 2, 3],
-    videoPattern: [0, 1]
+    }
   },
-  {
-    key: 'core-foundation',
-    label: 'Core Foundation Builds',
-    family: 'foundation',
-    layout: 'grid',
-    palette: 'foundation',
+  foundation: {
     accent: '#8ddcff',
-    fileNames: [
-      '1-index.html',
-      '2-index-optimized.html',
-      '3-index-fixed.html',
-      '4-index-unified.html',
-      '5-index-vib34d-integrated.html',
-      '6-index-totalistic.html'
-    ],
-    tags: ['core', 'foundation', 'totalistic', 'unified'],
-    titleTokens: ['clear seas solutions', 'totalistic', 'integrated'],
     overlay: {
       blend: 'soft-light',
       opacity: 0.96,
@@ -51,7 +25,68 @@ const PROFILE_DEFINITIONS = [
     canvas: {
       scale: 0.12,
       depth: '18px'
+    }
+  },
+  immersive: {
+    accent: '#ffaadf',
+    overlay: {
+      blend: 'color-dodge',
+      opacity: 1.14,
+      filter: 'hue-rotate(32deg) saturate(1.5) brightness(1.18)',
+      rotate: '9deg',
+      depth: '28px'
     },
+    canvas: {
+      scale: 0.18,
+      depth: '26px'
+    }
+  },
+  concept: {
+    accent: '#caa5ff',
+    overlay: {
+      blend: 'lighten',
+      opacity: 1.22,
+      filter: 'hue-rotate(280deg) saturate(1.45) brightness(1.12)',
+      rotate: '-7deg',
+      depth: '32px'
+    },
+    canvas: {
+      scale: 0.22,
+      depth: '34px'
+    }
+  }
+};
+
+const PROFILE_DEFINITIONS = [
+  {
+    key: 'meta-index',
+    label: 'Meta Index Overview',
+    family: 'meta',
+    layout: 'map',
+    palette: 'meta',
+    fileNames: ['index.html'],
+    tags: ['index', 'meta', 'map', 'directory'],
+    titleTokens: ['all versions', 'collections', 'clear seas solutions'],
+    imageOrder: [2, 3, 4, 0, 1, 5, 6, 7, 8],
+    videoOrder: [4, 5, 6, 0, 1, 2, 3],
+    videoPattern: [0, 1]
+  },
+  {
+    key: 'core-foundation',
+    label: 'Core Foundation Builds',
+    family: 'foundation',
+    layout: 'grid',
+    palette: 'foundation',
+    fileNames: [
+      '1-index.html',
+      '2-index-optimized.html',
+      '3-index-fixed.html',
+      '4-index-unified.html',
+      '5-index-vib34d-integrated.html',
+      '6-index-totalistic.html'
+    ],
+    tags: ['core', 'foundation', 'totalistic', 'unified'],
+    titleTokens: ['clear seas solutions', 'totalistic', 'integrated'],
     imageOrder: [0, 5, 1, 6, 2, 7, 3, 8, 4],
     videoOrder: [1, 2, 3, 0, 4, 5, 6],
     videoPattern: [0, 1, 0, 0]
@@ -62,7 +97,6 @@ const PROFILE_DEFINITIONS = [
     family: 'immersive',
     layout: 'timeline',
     palette: 'immersive',
-    accent: '#ffaadf',
     fileNames: [
       '10-pr-4.html', '11-pr-5.html', '12-pr-6.html',
       '14-pr-8.html', '15-pr-9.html', '16-pr-10.html',
@@ -74,17 +108,6 @@ const PROFILE_DEFINITIONS = [
     ],
     tags: ['immersive', 'mission', 'pulse', 'signal', 'pr', 'blueprint'],
     titleTokens: ['immersive experience', 'mission axis', 'experience blueprint'],
-    overlay: {
-      blend: 'color-dodge',
-      opacity: 1.14,
-      filter: 'hue-rotate(32deg) saturate(1.5) brightness(1.18)',
-      rotate: '9deg',
-      depth: '28px'
-    },
-    canvas: {
-      scale: 0.18,
-      depth: '26px'
-    },
     imageOrder: [4, 0, 5, 1, 6, 2, 7, 3, 8],
     videoOrder: [4, 5, 6, 0, 1, 2, 3],
     videoPattern: [1, 0, 1, 1],
@@ -96,7 +119,6 @@ const PROFILE_DEFINITIONS = [
     family: 'labs',
     layout: 'gallery',
     palette: 'concept',
-    accent: '#caa5ff',
     fileNames: [
       '7-pr-1.html',
       '8-pr-2.html',
@@ -107,20 +129,24 @@ const PROFILE_DEFINITIONS = [
     ],
     tags: ['concept', 'lab', 'gallery', 'codex', 'orthogonal', 'ultimate'],
     titleTokens: ['visual codex', 'orthogonal depth', 'holistic system'],
-    overlay: {
-      blend: 'lighten',
-      opacity: 1.22,
-      filter: 'hue-rotate(280deg) saturate(1.45) brightness(1.12)',
-      rotate: '-7deg',
-      depth: '32px'
-    },
-    canvas: {
-      scale: 0.22,
-      depth: '34px'
-    },
     imageOrder: [6, 7, 8, 3, 4, 0, 1, 2, 5],
     videoOrder: [2, 3, 4, 5, 6, 0, 1],
     videoPattern: [1, 1, 0, 1]
+  },
+  {
+    key: 'parserator-alpha',
+    label: 'Parserator Systems Launchpad',
+    family: 'parserator',
+    siteCode: 'parserator',
+    layout: 'grid',
+    palette: 'foundation',
+    fileNames: ['parserator.html'],
+    tags: ['parserator', 'propulsion', 'systems', 'aero', 'launch'],
+    titleTokens: ['parserator', 'propulsion systems', 'aero lab'],
+    imageOrder: [0, 5, 1, 6, 2, 7, 3, 8, 4],
+    videoOrder: [1, 2, 3, 0, 4, 5, 6],
+    videoPattern: [0, 1, 0, 1],
+    scripts: ['scripts/immersive-experience-actualizer.js']
   }
 ];
 
@@ -150,12 +176,38 @@ function computeHashSeed(input) {
   return hash;
 }
 
-const normalisedProfiles = PROFILE_DEFINITIONS.map((definition) => ({
-  ...definition,
-  fileNames: new Set((definition.fileNames || []).map(normaliseFileName)),
-  tags: new Set((definition.tags || []).map(normaliseToken)),
-  titleTokens: (definition.titleTokens || []).map(normaliseToken)
-}));
+const normalisedProfiles = PROFILE_DEFINITIONS.map((definition) => {
+  const paletteKey = definition.palette || definition.paletteKey || 'foundation';
+  const paletteDefaults = PALETTE_LIBRARY[paletteKey] || {};
+  const paletteOverrides = definition.paletteOverrides || {};
+  const accent = definition.accent || paletteOverrides.accent || paletteDefaults.accent || null;
+  const overlay = {
+    ...(paletteDefaults.overlay || {}),
+    ...(paletteOverrides.overlay || {}),
+    ...(definition.overlay || {})
+  };
+  const canvas = {
+    ...(paletteDefaults.canvas || {}),
+    ...(paletteOverrides.canvas || {}),
+    ...(definition.canvas || {})
+  };
+  const rawSiteCode = definition.siteCode || null;
+  const siteCodeToken = rawSiteCode ? normaliseToken(rawSiteCode) : null;
+
+  return {
+    ...definition,
+    palette: paletteKey,
+    paletteKey,
+    siteCode: rawSiteCode,
+    siteCodeToken,
+    accent,
+    overlay,
+    canvas,
+    fileNames: new Set((definition.fileNames || []).map(normaliseFileName)),
+    tags: new Set((definition.tags || []).map(normaliseToken)),
+    titleTokens: (definition.titleTokens || []).map(normaliseToken)
+  };
+});
 
 export function listPageProfiles() {
   return normalisedProfiles.map((profile) => ({
@@ -164,7 +216,8 @@ export function listPageProfiles() {
     family: profile.family,
     layout: profile.layout,
     palette: profile.palette,
-    accent: profile.accent
+    accent: profile.accent,
+    siteCode: profile.siteCode || null
   }));
 }
 
@@ -175,10 +228,15 @@ function readCandidateTokens(docEl, bodyEl) {
     tokens.push(docEl.dataset.collection);
     tokens.push(docEl.dataset.showcaseTheme);
     tokens.push(docEl.dataset.showcaseCard);
+    tokens.push(docEl.dataset.siteCode);
+    tokens.push(docEl.dataset.globalSiteCode);
+    tokens.push(docEl.dataset.brandSite);
   }
   if (bodyEl && bodyEl.dataset) {
     tokens.push(bodyEl.dataset.pageCollection);
     tokens.push(bodyEl.dataset.collection);
+    tokens.push(bodyEl.dataset.siteCode);
+    tokens.push(bodyEl.dataset.globalSiteCode);
   }
   return tokens.filter(Boolean).map(normaliseToken);
 }
@@ -192,10 +250,37 @@ export function resolvePageProfile(context = {}) {
   const metaName = normaliseFileName(pathToken || (docEl && docEl.dataset ? docEl.dataset.pageId : '') || '');
   const title = normaliseToken(doc ? doc.title : context.title || '');
   const candidateTokens = readCandidateTokens(docEl, body);
+  const pathTokens = path
+    ? path
+        .split(/[\\/]+/)
+        .filter(Boolean)
+        .map(normaliseToken)
+    : [];
+  const requestedSiteCode = normaliseToken(
+    context.siteCode ||
+      (docEl && docEl.dataset ? docEl.dataset.siteCode : '') ||
+      (docEl && docEl.dataset ? docEl.dataset.globalSiteCode : '') ||
+      (body && body.dataset ? body.dataset.siteCode : '') ||
+      (body && body.dataset ? body.dataset.globalSiteCode : '')
+  );
+  const searchTokens = [...candidateTokens];
+  if (requestedSiteCode) {
+    searchTokens.push(requestedSiteCode);
+  }
+  pathTokens.forEach((token) => {
+    if (token) {
+      searchTokens.push(token);
+    }
+  });
 
   let matched = normalisedProfiles.find((profile) => profile.fileNames.has(metaName));
+  if (!matched && requestedSiteCode) {
+    matched = normalisedProfiles.find((profile) => profile.siteCodeToken === requestedSiteCode);
+  }
   if (!matched) {
-    matched = normalisedProfiles.find((profile) => candidateTokens.some((token) => profile.tags.has(token)));
+    matched = normalisedProfiles.find((profile) =>
+      searchTokens.some((token) => profile.tags.has(token) || (profile.siteCodeToken && profile.siteCodeToken === token))
+    );
   }
   if (!matched) {
     matched = normalisedProfiles.find((profile) => profile.titleTokens.some((token) => title.includes(token)));
@@ -204,7 +289,7 @@ export function resolvePageProfile(context = {}) {
     matched = normalisedProfiles.find((profile) => profile.key === 'core-foundation') || normalisedProfiles[0];
   }
 
-  const signatureParts = [metaName, title].concat(candidateTokens);
+  const signatureParts = [metaName, title, requestedSiteCode].concat(searchTokens);
   const signature = signatureParts.filter(Boolean).join('|') || metaName;
   const seed = computeHashSeed(signature);
 
@@ -214,6 +299,7 @@ export function resolvePageProfile(context = {}) {
     family: matched.family,
     layout: matched.layout,
     palette: matched.palette,
+    paletteKey: matched.paletteKey,
     accent: matched.accent,
     overlay: matched.overlay ? { ...matched.overlay } : {},
     canvas: matched.canvas ? { ...matched.canvas } : {},
@@ -221,10 +307,13 @@ export function resolvePageProfile(context = {}) {
     videoOrder: matched.videoOrder ? [...matched.videoOrder] : null,
     videoPattern: matched.videoPattern ? [...matched.videoPattern] : null,
     scripts: matched.scripts ? [...matched.scripts] : [],
+    siteCode: matched.siteCode || null,
+    siteCodeToken: matched.siteCodeToken || null,
+    requestedSiteCode: requestedSiteCode || null,
     signature,
     seed,
     metaName,
-    candidateTokens
+    candidateTokens: searchTokens
   };
 }
 
@@ -241,11 +330,23 @@ export function applyProfileMetadata(profile, targetDocument = typeof document !
   docEl.dataset.globalBrandPalette = profile.palette;
   docEl.dataset.globalPageFamily = profile.family || profile.key;
   docEl.dataset.globalPageLayout = profile.layout || 'grid';
+  docEl.dataset.globalPaletteKey = profile.paletteKey || profile.palette || '';
+  if (profile.siteCode) {
+    docEl.dataset.globalSiteCode = profile.siteCode;
+  } else {
+    delete docEl.dataset.globalSiteCode;
+  }
   if (body) {
     body.dataset.globalPageCollection = profile.key;
     body.dataset.globalBrandPalette = profile.palette;
     body.dataset.globalPageFamily = profile.family || profile.key;
     body.dataset.globalPageLayout = profile.layout || 'grid';
+    body.dataset.globalPaletteKey = profile.paletteKey || profile.palette || '';
+    if (profile.siteCode) {
+      body.dataset.globalSiteCode = profile.siteCode;
+    } else {
+      delete body.dataset.globalSiteCode;
+    }
   }
   if (profile.accent) {
     docEl.style.setProperty('--global-brand-accent', profile.accent);
@@ -262,11 +363,13 @@ export function applyProfileMetadata(profile, targetDocument = typeof document !
 }
 
 if (typeof window !== 'undefined') {
-  window.__CLEAR_SEAS_PAGE_PROFILE_REGISTRY = {
+  const registry = {
     list: listPageProfiles,
     resolve: resolvePageProfile,
     apply: applyProfileMetadata
   };
+  window.__CLEAR_SEAS_PAGE_PROFILE_REGISTRY = registry;
+  window.__CSS_WEB_MASTER_PAGE_PROFILE_REGISTRY = registry;
 }
 
 export default {

--- a/scripts/site-asset-manifest.js
+++ b/scripts/site-asset-manifest.js
@@ -1,0 +1,419 @@
+const DEFAULT_MANIFEST_KEY = 'default';
+
+const sharedImageRotation = [
+  {
+    src: 'assets/Screenshot_20250430-141821.png',
+    tags: ['hero', 'deck'],
+    siteCodes: ['clear-seas', 'css-web-master'],
+    label: 'Holographic boardroom spread'
+  },
+  {
+    src: 'assets/Screenshot_20241012-073718.png',
+    tags: ['hero', 'canvas'],
+    siteCodes: ['clear-seas', 'css-web-master'],
+    label: 'Noir corridor traversal'
+  },
+  {
+    src: 'assets/Screenshot_20250430-142024~2.png',
+    tags: ['gallery', 'diagnostic'],
+    siteCodes: ['clear-seas', 'css-web-master'],
+    label: 'Mission analytics lens'
+  },
+  {
+    src: 'assets/Screenshot_20250430-142002~2.png',
+    tags: ['gallery', 'diagnostic'],
+    siteCodes: ['clear-seas', 'css-web-master'],
+    label: 'Beacon matrix overlay'
+  },
+  {
+    src: 'assets/Screenshot_20250430-142032~2.png',
+    tags: ['gallery', 'diagnostic'],
+    siteCodes: ['clear-seas', 'css-web-master'],
+    label: 'Ambient lattice grid'
+  },
+  {
+    src: 'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+    tags: ['parserator', 'blueprint'],
+    siteCodes: ['clear-seas', 'parserator', 'css-web-master'],
+    label: 'Parserator lattice overlay'
+  },
+  {
+    src: 'assets/file_0000000054a06230817873012865d150.png',
+    tags: ['parserator', 'blueprint'],
+    siteCodes: ['clear-seas', 'parserator', 'css-web-master'],
+    label: 'Parserator stage render'
+  },
+  {
+    src: 'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+    tags: ['vib3code', 'waveform'],
+    siteCodes: ['clear-seas', 'vib3code', 'css-web-master'],
+    label: 'VIB3Code waveform scaffolding'
+  },
+  {
+    src: 'assets/image_8 (1).png',
+    tags: ['vib3code', 'waveform'],
+    siteCodes: ['clear-seas', 'vib3code', 'css-web-master'],
+    label: 'Immersive volumetric sweep'
+  }
+];
+
+const sharedVideoRotation = [
+  {
+    src: '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+    tags: ['hero', 'glow'],
+    siteCodes: ['clear-seas', 'parserator', 'css-web-master'],
+    label: 'Neon Blossom Transformation'
+  },
+  {
+    src: '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+    tags: ['ambient', 'noir'],
+    siteCodes: ['clear-seas', 'css-web-master'],
+    label: 'Noir Filament Mystery'
+  },
+  {
+    src: '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+    tags: ['ambient', 'gemstone'],
+    siteCodes: ['clear-seas', 'vib3code', 'css-web-master'],
+    label: 'Gemstone Coral Transformation – Remix A'
+  },
+  {
+    src: '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+    tags: ['ambient', 'gemstone'],
+    siteCodes: ['clear-seas', 'vib3code', 'css-web-master'],
+    label: 'Gemstone Coral Transformation – Remix B'
+  },
+  {
+    src: '1746496560073.mp4',
+    tags: ['ambient', 'signal'],
+    siteCodes: ['clear-seas', 'css-web-master'],
+    label: 'Signal lattice burst'
+  },
+  {
+    src: '1746500614769.mp4',
+    tags: ['ambient', 'signal'],
+    siteCodes: ['clear-seas', 'css-web-master'],
+    label: 'Spectral corridor drift'
+  },
+  {
+    src: '1746576068221.mp4',
+    tags: ['ambient', 'signal'],
+    siteCodes: ['clear-seas', 'css-web-master'],
+    label: 'Telemetry bloom pulse'
+  }
+];
+
+const baseManifest = {
+  [DEFAULT_MANIFEST_KEY]: {
+    label: 'Clear Seas Core',
+    tags: ['clear-seas', 'css-web-master'],
+    images: sharedImageRotation,
+    videos: sharedVideoRotation
+  },
+  'clear-seas': {
+    extends: 'default',
+    tags: ['clear-seas']
+  },
+  parserator: {
+    extends: 'default',
+    tags: ['parserator'],
+    images: [
+      sharedImageRotation[5],
+      sharedImageRotation[6]
+    ],
+    videos: [sharedVideoRotation[0]]
+  },
+  vib3code: {
+    extends: 'default',
+    tags: ['vib3code'],
+    images: [
+      sharedImageRotation[7],
+      sharedImageRotation[8]
+    ],
+    videos: [
+      sharedVideoRotation[2],
+      sharedVideoRotation[3]
+    ]
+  }
+};
+
+const manifest = Object.create(null);
+
+function normaliseKey(key) {
+  return String(key || '')
+    .trim()
+    .toLowerCase();
+}
+
+function normaliseTokenList(value) {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter(Boolean)
+      .map((entry) => entry.toLowerCase());
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .map((entry) => entry.toLowerCase());
+  }
+  return [];
+}
+
+function normaliseAssetCollection(input, fallback = { list: [], meta: {} }) {
+  const list = [];
+  const meta = { ...(fallback.meta || {}) };
+
+  const ensureMeta = (src) => {
+    if (!meta[src]) {
+      meta[src] = {
+        tags: [],
+        siteCodes: [],
+        label: null,
+        weight: null
+      };
+    }
+    return meta[src];
+  };
+
+  const append = (item) => {
+    if (!item) {
+      return;
+    }
+    if (typeof item === 'string') {
+      const src = item.trim();
+      if (!src) {
+        return;
+      }
+      list.push(src);
+      ensureMeta(src);
+      return;
+    }
+    if (typeof item === 'object') {
+      const src = typeof item.src === 'string' ? item.src.trim() : typeof item.path === 'string' ? item.path.trim() : '';
+      if (!src) {
+        return;
+      }
+      list.push(src);
+      const entryMeta = ensureMeta(src);
+      const tags = normaliseTokenList(item.tags || item.tag);
+      const siteCodes = normaliseTokenList(item.siteCodes || item.siteCode || item.sites || item.site);
+      if (tags.length) {
+        const set = new Set(entryMeta.tags.map((tag) => tag.toLowerCase()));
+        tags.forEach((tag) => set.add(tag));
+        entryMeta.tags = Array.from(set);
+      }
+      if (siteCodes.length) {
+        const set = new Set(entryMeta.siteCodes.map((code) => code.toLowerCase()));
+        siteCodes.forEach((code) => set.add(code));
+        entryMeta.siteCodes = Array.from(set);
+      }
+      if (typeof item.label === 'string' && item.label.trim()) {
+        entryMeta.label = item.label.trim();
+      }
+      if (Number.isFinite(item.weight)) {
+        entryMeta.weight = Number(item.weight);
+      }
+      return;
+    }
+  };
+
+  if (Array.isArray(input)) {
+    input.forEach((item) => append(item));
+  } else if (input != null) {
+    append(input);
+  }
+
+  return { list, meta };
+}
+
+function mergeEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return;
+  }
+  const key = normaliseKey(entry.key || entry.siteCode || entry.id || entry.name);
+  if (!key) {
+    return;
+  }
+  const existing = manifest[key] || {
+    images: [],
+    videos: [],
+    imagesMeta: {},
+    videosMeta: {},
+    extends: null,
+    tags: []
+  };
+  const next = { ...existing };
+
+  if (Object.prototype.hasOwnProperty.call(entry, 'extends')) {
+    const extendsKey = normaliseKey(entry.extends);
+    next.extends = extendsKey && extendsKey !== key ? extendsKey : null;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(entry, 'tags')) {
+    next.tags = normaliseTokenList(entry.tags);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(entry, 'images')) {
+    const { list, meta } = normaliseAssetCollection(entry.images);
+    next.images = list;
+    next.imagesMeta = meta;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(entry, 'videos')) {
+    const { list, meta } = normaliseAssetCollection(entry.videos);
+    next.videos = list;
+    next.videosMeta = meta;
+  }
+
+  manifest[key] = next;
+}
+
+export function mergeAssetManifest(source) {
+  if (!source || typeof source !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(source)) {
+    source.forEach((entry) => mergeAssetManifest(entry));
+    return;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(source, 'key') ||
+    Object.prototype.hasOwnProperty.call(source, 'siteCode') ||
+    Object.prototype.hasOwnProperty.call(source, 'id') ||
+    Object.prototype.hasOwnProperty.call(source, 'name')
+  ) {
+    mergeEntry(source);
+    return;
+  }
+
+  Object.entries(source).forEach(([key, value]) => {
+    if (value && typeof value === 'object') {
+      mergeEntry({ key, ...value });
+    }
+  });
+}
+
+function resolveManifestKey(requestedKey) {
+  const visited = new Set();
+  let token = normaliseKey(requestedKey) || DEFAULT_MANIFEST_KEY;
+  if (!manifest[token]) {
+    token = DEFAULT_MANIFEST_KEY;
+  }
+
+  let currentToken = token;
+  let entry = manifest[currentToken] || manifest[DEFAULT_MANIFEST_KEY] || { images: [], videos: [], extends: null };
+  const chain = [];
+
+  while (entry && !visited.has(currentToken)) {
+    visited.add(currentToken);
+    chain.push({ token: currentToken, entry });
+
+    const nextToken = normaliseKey(entry.extends);
+    if (!nextToken || nextToken === currentToken) {
+      break;
+    }
+
+    currentToken = manifest[nextToken] ? nextToken : DEFAULT_MANIFEST_KEY;
+    entry = manifest[currentToken];
+  }
+
+  const defaultEntry = manifest[DEFAULT_MANIFEST_KEY] || {
+    images: [],
+    videos: [],
+    imagesMeta: {},
+    videosMeta: {}
+  };
+  let images = [];
+  let videos = [];
+  let imagesMeta = {};
+  let videosMeta = {};
+
+  for (let i = 0; i < chain.length; i += 1) {
+    const layer = chain[i].entry;
+    if (!images.length && Array.isArray(layer.images) && layer.images.length) {
+      images = [...layer.images];
+      imagesMeta = { ...(layer.imagesMeta || {}) };
+    }
+    if (!videos.length && Array.isArray(layer.videos) && layer.videos.length) {
+      videos = [...layer.videos];
+      videosMeta = { ...(layer.videosMeta || {}) };
+    }
+  }
+
+  if (!images.length) {
+    images = [...(defaultEntry.images || [])];
+    imagesMeta = { ...(defaultEntry.imagesMeta || {}) };
+  }
+  if (!videos.length) {
+    videos = [...(defaultEntry.videos || [])];
+    videosMeta = { ...(defaultEntry.videosMeta || {}) };
+  }
+
+  const resolvedKey = chain.length ? chain[0].token : DEFAULT_MANIFEST_KEY;
+
+  const filterBySite = (list, meta) => {
+    if (!requestedKey) {
+      return list;
+    }
+    const token = normaliseKey(requestedKey);
+    if (!token) {
+      return list;
+    }
+    const filtered = list.filter((src) => {
+      const entryMeta = meta[src];
+      if (!entryMeta) {
+        return true;
+      }
+      if (!Array.isArray(entryMeta.siteCodes) || entryMeta.siteCodes.length === 0) {
+        return true;
+      }
+      return entryMeta.siteCodes.some((code) => normaliseKey(code) === token);
+    });
+    return filtered.length ? filtered : list;
+  };
+
+  const filteredImages = filterBySite(images, imagesMeta);
+  const filteredVideos = filterBySite(videos, videosMeta);
+
+  return {
+    key: resolvedKey,
+    images: filteredImages,
+    videos: filteredVideos,
+    meta: {
+      images: imagesMeta,
+      videos: videosMeta
+    }
+  };
+}
+
+export function resolveBrandAssets(siteCode) {
+  return resolveManifestKey(siteCode);
+}
+
+export function getAssetManifestSnapshot() {
+  const snapshot = {};
+  Object.entries(manifest).forEach(([key, entry]) => {
+    snapshot[key] = {
+      extends: entry.extends || null,
+      tags: Array.isArray(entry.tags) ? [...entry.tags] : [],
+      images: [...(entry.images || [])],
+      videos: [...(entry.videos || [])],
+      meta: {
+        images: { ...(entry.imagesMeta || {}) },
+        videos: { ...(entry.videosMeta || {}) }
+      }
+    };
+  });
+  return snapshot;
+}
+
+mergeAssetManifest(baseManifest);
+
+export { DEFAULT_MANIFEST_KEY };

--- a/styles/consolidated-styles.css
+++ b/styles/consolidated-styles.css
@@ -11,99 +11,13 @@
  * =================================================================================================
  */
 
+@import url('./css-web-master-tokens.css');
+
 /* ==========================================================================
    1. ROOT VARIABLES & DESIGN TOKENS
    ========================================================================== */
 :root {
-    /* Typography Scale - Fluid & Responsive */
-    --font-family-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    --font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
-    
-    --font-size-xs: clamp(0.75rem, 0.5vw + 0.5rem, 0.875rem);
-    --font-size-sm: clamp(0.875rem, 1vw + 0.5rem, 1rem);
-    --font-size-base: clamp(1rem, 1.5vw + 0.5rem, 1.125rem);
-    --font-size-lg: clamp(1.125rem, 2vw + 0.5rem, 1.25rem);
-    --font-size-xl: clamp(1.25rem, 2.5vw + 0.5rem, 1.5rem);
-    --font-size-2xl: clamp(1.5rem, 3vw + 1rem, 2rem);
-    --font-size-3xl: clamp(1.875rem, 4vw + 1rem, 2.5rem);
-    --font-size-4xl: clamp(2.25rem, 5vw + 1rem, 3.5rem);
-    --font-size-5xl: clamp(3rem, 6vw + 1rem, 4.5rem);
-    --font-size-6xl: clamp(4rem, 7vw + 1rem, 6rem);
-    
-    /* Color System - Polytopal Projection Theme */
-    --bg-primary: #0a0b0d;
-    --bg-secondary: #141619;
-    --bg-tertiary: #1f2128;
-    --surface-primary: rgba(255, 255, 255, 0.02);
-    --surface-secondary: rgba(255, 255, 255, 0.05);
-    --surface-accent: rgba(255, 255, 255, 0.12);
-    
-    --text-primary: #ffffff;
-    --text-secondary: rgba(255, 255, 255, 0.8);
-    --text-tertiary: rgba(255, 255, 255, 0.6);
-    --text-quaternary: rgba(255, 255, 255, 0.4);
-    
-    --border-primary: rgba(255, 255, 255, 0.1);
-    --border-secondary: rgba(255, 255, 255, 0.15);
-    --border-accent: rgba(255, 255, 255, 0.2);
-    
-    /* VIB34D Theme Colors */
-    --theme-primary: #00d4ff;      /* Cyan */
-    --theme-secondary: #ff006e;    /* Magenta */
-    --theme-tertiary: #ff3300;     /* Red */
-    --theme-quaternary: #33ff00;   /* Green */
-    --theme-primary-dark: #0099cc;
-    --theme-primary-light: #66e6ff;
-    --theme-secondary-dark: #cc0055;
-    --theme-secondary-light: #ff66a3;
-    
-    /* Glassmorphism & Advanced Effects */
-    --glass-bg: rgba(16, 18, 27, 0.4);
-    --glass-border: rgba(255, 255, 255, 0.1);
-    --glass-shadow: rgba(0, 0, 0, 0.3);
-    --blur-amount: 20px;
-    --blur-subtle: 10px;
-    --blur-intense: 40px;
-    
-    /* Neoskeuomorphic Shadows */
-    --neo-shadow-light: rgba(40, 40, 60, 0.5);
-    --neo-shadow-dark: rgba(0, 0, 0, 0.3);
-    --neo-highlight: rgba(255, 255, 255, 0.1);
-    
-    /* Animation System */
-    --duration-instant: 0.1s;
-    --duration-fast: 0.2s;
-    --duration-normal: 0.4s;
-    --duration-slow: 0.8s;
-    --duration-slower: 1.2s;
-    --duration-cinematic: 2s;
-    
-    --ease-in: cubic-bezier(0.4, 0, 1, 1);
-    --ease-out: cubic-bezier(0, 0, 0.2, 1);
-    --ease-in-out: cubic-bezier(0.42, 0, 0.58, 1);
-    --ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
-    --ease-cinematic: cubic-bezier(0.25, 0.46, 0.45, 0.94);
-    
-    /* 3D & Perspective System */
-    --perspective: 2000px;
-    --pop-out-scale: 1.1;
-    --pop-out-translate-z: 120px;
-    --tilt-max: 15deg;
-    
-    /* Responsive Breakpoints */
-    --breakpoint-mobile: 768px;
-    --breakpoint-tablet: 1024px;
-    --breakpoint-desktop: 1200px;
-    --breakpoint-wide: 1440px;
-    
-    /* Z-Index Scale */
-    --z-underground: -1;
-    --z-default: 0;
-    --z-elevated: 10;
-    --z-overlay: 100;
-    --z-modal: 1000;
-    --z-toast: 9999;
-    
+    /* Base typography, color, and motion tokens are defined in css-web-master-tokens.css */
     /* CSS Variables Updated by JavaScript */
     --scroll-y: 0px;
     --scroll-progress: 0;

--- a/styles/css-web-master-tokens.css
+++ b/styles/css-web-master-tokens.css
@@ -1,0 +1,181 @@
+/*
+ * CSS-Web-Master neutral design tokens
+ * These tokens provide site-agnostic typography, color, and motion defaults
+ * so each property can override them without editing downstream stylesheets.
+ */
+
+:root {
+    /* Typography */
+    --csswm-font-family-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --csswm-font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+    --csswm-font-size-xs: clamp(0.75rem, 0.5vw + 0.5rem, 0.875rem);
+    --csswm-font-size-sm: clamp(0.875rem, 1vw + 0.5rem, 1rem);
+    --csswm-font-size-base: clamp(1rem, 1.5vw + 0.5rem, 1.125rem);
+    --csswm-font-size-lg: clamp(1.125rem, 2vw + 0.5rem, 1.25rem);
+    --csswm-font-size-xl: clamp(1.25rem, 2.5vw + 0.5rem, 1.5rem);
+    --csswm-font-size-2xl: clamp(1.5rem, 3vw + 1rem, 2rem);
+    --csswm-font-size-3xl: clamp(1.875rem, 4vw + 1rem, 2.5rem);
+    --csswm-font-size-4xl: clamp(2.25rem, 5vw + 1rem, 3.5rem);
+    --csswm-font-size-5xl: clamp(3rem, 6vw + 1rem, 4.5rem);
+    --csswm-font-size-6xl: clamp(4rem, 7vw + 1rem, 6rem);
+
+    /* Core colors */
+    --csswm-color-bg-primary: #0a0b0d;
+    --csswm-color-bg-secondary: #141619;
+    --csswm-color-bg-tertiary: #1f2128;
+
+    --csswm-color-surface-primary: rgba(255, 255, 255, 0.02);
+    --csswm-color-surface-secondary: rgba(255, 255, 255, 0.05);
+    --csswm-color-surface-accent: rgba(255, 255, 255, 0.12);
+
+    --csswm-color-text-primary: #ffffff;
+    --csswm-color-text-secondary: rgba(255, 255, 255, 0.8);
+    --csswm-color-text-tertiary: rgba(255, 255, 255, 0.6);
+    --csswm-color-text-quaternary: rgba(255, 255, 255, 0.4);
+
+    --csswm-color-border-primary: rgba(255, 255, 255, 0.1);
+    --csswm-color-border-secondary: rgba(255, 255, 255, 0.15);
+    --csswm-color-border-accent: rgba(255, 255, 255, 0.2);
+
+    /* Motion + timing */
+    --csswm-duration-instant: 0.1s;
+    --csswm-duration-fast: 0.2s;
+    --csswm-duration-normal: 0.4s;
+    --csswm-duration-slow: 0.8s;
+    --csswm-duration-slower: 1.2s;
+    --csswm-duration-cinematic: 2s;
+
+    --csswm-ease-in: cubic-bezier(0.4, 0, 1, 1);
+    --csswm-ease-out: cubic-bezier(0, 0, 0.2, 1);
+    --csswm-ease-in-out: cubic-bezier(0.42, 0, 0.58, 1);
+    --csswm-ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    --csswm-ease-cinematic: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+    /* Highlight palette */
+    --csswm-theme-primary: #00d4ff;
+    --csswm-theme-secondary: #ff006e;
+    --csswm-theme-tertiary: #ff3300;
+    --csswm-theme-quaternary: #33ff00;
+    --csswm-theme-primary-dark: #0099cc;
+    --csswm-theme-primary-light: #66e6ff;
+    --csswm-theme-secondary-dark: #cc0055;
+    --csswm-theme-secondary-light: #ff66a3;
+
+    /* Glass + depth */
+    --csswm-glass-background: rgba(16, 18, 27, 0.4);
+    --csswm-glass-border: rgba(255, 255, 255, 0.1);
+    --csswm-glass-shadow: rgba(0, 0, 0, 0.3);
+    --csswm-blur-amount: 20px;
+    --csswm-blur-subtle: 10px;
+    --csswm-blur-intense: 40px;
+
+    /* Shadows */
+    --csswm-shadow-light: rgba(40, 40, 60, 0.5);
+    --csswm-shadow-dark: rgba(0, 0, 0, 0.3);
+    --csswm-shadow-highlight: rgba(255, 255, 255, 0.1);
+
+    /* Perspective */
+    --csswm-perspective: 2000px;
+    --csswm-pop-out-scale: 1.1;
+    --csswm-pop-out-translate-z: 120px;
+    --csswm-tilt-max: 15deg;
+
+    /* Breakpoints */
+    --csswm-breakpoint-mobile: 768px;
+    --csswm-breakpoint-tablet: 1024px;
+    --csswm-breakpoint-desktop: 1200px;
+    --csswm-breakpoint-wide: 1440px;
+
+    /* Z-index ladder */
+    --csswm-z-underground: -1;
+    --csswm-z-default: 0;
+    --csswm-z-elevated: 10;
+    --csswm-z-overlay: 100;
+    --csswm-z-modal: 1000;
+    --csswm-z-toast: 9999;
+}
+
+:root {
+    /* Map neutral tokens into legacy Clear Seas variables */
+    --font-family-primary: var(--csswm-font-family-primary);
+    --font-family-mono: var(--csswm-font-family-mono);
+
+    --font-size-xs: var(--csswm-font-size-xs);
+    --font-size-sm: var(--csswm-font-size-sm);
+    --font-size-base: var(--csswm-font-size-base);
+    --font-size-lg: var(--csswm-font-size-lg);
+    --font-size-xl: var(--csswm-font-size-xl);
+    --font-size-2xl: var(--csswm-font-size-2xl);
+    --font-size-3xl: var(--csswm-font-size-3xl);
+    --font-size-4xl: var(--csswm-font-size-4xl);
+    --font-size-5xl: var(--csswm-font-size-5xl);
+    --font-size-6xl: var(--csswm-font-size-6xl);
+
+    --bg-primary: var(--csswm-color-bg-primary);
+    --bg-secondary: var(--csswm-color-bg-secondary);
+    --bg-tertiary: var(--csswm-color-bg-tertiary);
+
+    --surface-primary: var(--csswm-color-surface-primary);
+    --surface-secondary: var(--csswm-color-surface-secondary);
+    --surface-accent: var(--csswm-color-surface-accent);
+
+    --text-primary: var(--csswm-color-text-primary);
+    --text-secondary: var(--csswm-color-text-secondary);
+    --text-tertiary: var(--csswm-color-text-tertiary);
+    --text-quaternary: var(--csswm-color-text-quaternary);
+
+    --border-primary: var(--csswm-color-border-primary);
+    --border-secondary: var(--csswm-color-border-secondary);
+    --border-accent: var(--csswm-color-border-accent);
+
+    --duration-instant: var(--csswm-duration-instant);
+    --duration-fast: var(--csswm-duration-fast);
+    --duration-normal: var(--csswm-duration-normal);
+    --duration-slow: var(--csswm-duration-slow);
+    --duration-slower: var(--csswm-duration-slower);
+    --duration-cinematic: var(--csswm-duration-cinematic);
+
+    --ease-in: var(--csswm-ease-in);
+    --ease-out: var(--csswm-ease-out);
+    --ease-in-out: var(--csswm-ease-in-out);
+    --ease-spring: var(--csswm-ease-spring);
+    --ease-cinematic: var(--csswm-ease-cinematic);
+
+    --theme-primary: var(--csswm-theme-primary);
+    --theme-secondary: var(--csswm-theme-secondary);
+    --theme-tertiary: var(--csswm-theme-tertiary);
+    --theme-quaternary: var(--csswm-theme-quaternary);
+    --theme-primary-dark: var(--csswm-theme-primary-dark);
+    --theme-primary-light: var(--csswm-theme-primary-light);
+    --theme-secondary-dark: var(--csswm-theme-secondary-dark);
+    --theme-secondary-light: var(--csswm-theme-secondary-light);
+
+    --glass-bg: var(--csswm-glass-background);
+    --glass-border: var(--csswm-glass-border);
+    --glass-shadow: var(--csswm-glass-shadow);
+    --blur-amount: var(--csswm-blur-amount);
+    --blur-subtle: var(--csswm-blur-subtle);
+    --blur-intense: var(--csswm-blur-intense);
+
+    --neo-shadow-light: var(--csswm-shadow-light);
+    --neo-shadow-dark: var(--csswm-shadow-dark);
+    --neo-highlight: var(--csswm-shadow-highlight);
+
+    --perspective: var(--csswm-perspective);
+    --pop-out-scale: var(--csswm-pop-out-scale);
+    --pop-out-translate-z: var(--csswm-pop-out-translate-z);
+    --tilt-max: var(--csswm-tilt-max);
+
+    --breakpoint-mobile: var(--csswm-breakpoint-mobile);
+    --breakpoint-tablet: var(--csswm-breakpoint-tablet);
+    --breakpoint-desktop: var(--csswm-breakpoint-desktop);
+    --breakpoint-wide: var(--csswm-breakpoint-wide);
+
+    --z-underground: var(--csswm-z-underground);
+    --z-default: var(--csswm-z-default);
+    --z-elevated: var(--csswm-z-elevated);
+    --z-overlay: var(--csswm-z-overlay);
+    --z-modal: var(--csswm-z-modal);
+    --z-toast: var(--csswm-z-toast);
+}

--- a/tests/html_smoke_test.py
+++ b/tests/html_smoke_test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Load each top-level HTML file and capture console/page errors."""
+import asyncio
+import json
+import sys
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from playwright.async_api import (
+    Error as PlaywrightError,
+    TimeoutError as PlaywrightTimeout,
+    async_playwright,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML_FILES = sorted(
+    [p for p in ROOT.glob("*.html") if p.is_file()]
+)
+
+
+class SilentHTTPRequestHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        # Silence the default stdout logging from each asset fetch.
+        return
+
+    def handle(self) -> None:
+        try:
+            super().handle()
+        except (ConnectionResetError, BrokenPipeError):
+            # Ignore disconnect noise when headless browsers tear down early.
+            pass
+
+
+def start_static_server(root: Path) -> Tuple[ThreadingHTTPServer, str]:
+    handler = partial(SilentHTTPRequestHandler, directory=str(root))
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    host, port = httpd.server_address
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd, f"http://{host}:{port}"
+
+
+async def audit_file(context, base_url: str, html_path: Path) -> Dict[str, Any]:
+    page = await context.new_page()
+    console_events: List[Dict[str, Any]] = []
+    page_errors: List[str] = []
+    request_failures: List[Dict[str, str]] = []
+    response_errors: List[Dict[str, Any]] = []
+
+    def handle_console(msg):
+        if msg.type == "error":
+            console_events.append(
+                {
+                    "type": msg.type,
+                    "text": msg.text,
+                }
+            )
+
+    page.on("console", handle_console)
+    page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+    page.on(
+        "requestfailed",
+        lambda request: request_failures.append(
+            {
+                "url": request.url,
+                "failure": request.failure,  # type: ignore[arg-type]
+            }
+        ),
+    )
+    page.on(
+        "response",
+        lambda response: response.status >= 400
+        and response_errors.append(
+            {
+                "url": response.url,
+                "status": response.status,
+                "status_text": response.status_text,
+            }
+        ),
+    )
+
+    file_url = f"{base_url}/{html_path.name}"
+    navigation_error = None
+    try:
+        await page.goto(file_url, wait_until="load", timeout=20000)
+        try:
+            await page.wait_for_load_state("networkidle", timeout=10000)
+        except PlaywrightTimeout:
+            # networkidle frequently times out on static pages; only treat as warning
+            pass
+        except PlaywrightError as load_err:
+            navigation_error = f"load-state: {load_err}"
+        await page.wait_for_timeout(2000)
+    except PlaywrightError as nav_err:
+        navigation_error = str(nav_err)
+    finally:
+        await page.close()
+
+    return {
+        "file": html_path.name,
+        "console_errors": console_events,
+        "page_errors": page_errors,
+        "navigation_error": navigation_error,
+        "request_failures": request_failures,
+        "response_errors": response_errors,
+    }
+
+
+async def main() -> None:
+    httpd, base_url = start_static_server(ROOT)
+    try:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch()
+            context = await browser.new_context()
+            results = []
+            for html_path in HTML_FILES:
+                print(f"Auditing {html_path.name}...", file=sys.stderr)
+                results.append(await audit_file(context, base_url, html_path))
+            await browser.close()
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tools/validate-asset-manifest.mjs
+++ b/tools/validate-asset-manifest.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { DEFAULT_MANIFEST_KEY, getAssetManifestSnapshot } from '../scripts/site-asset-manifest.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+async function fileExists(relativePath) {
+  try {
+    await access(path.resolve(repoRoot, relativePath));
+    return true;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function normaliseKey(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase();
+}
+
+async function main() {
+  const snapshot = getAssetManifestSnapshot();
+  const knownKeys = new Set(Object.keys(snapshot).map((key) => normaliseKey(key)));
+  knownKeys.add(normaliseKey(DEFAULT_MANIFEST_KEY));
+  knownKeys.add('css-web-master');
+
+  const missingFiles = [];
+  const untaggedSiteAssets = [];
+  const unknownSiteCodes = [];
+
+  for (const [key, entry] of Object.entries(snapshot)) {
+    const normalisedKey = normaliseKey(key);
+    for (const type of ['images', 'videos']) {
+      const assets = Array.isArray(entry[type]) ? entry[type] : [];
+      for (const src of assets) {
+        const assetPath = typeof src === 'string' ? src.trim() : '';
+        if (!assetPath) {
+          continue;
+        }
+        const exists = await fileExists(assetPath);
+        if (!exists) {
+          missingFiles.push({ key, type, src: assetPath });
+        }
+        const meta = entry.meta?.[type]?.[assetPath] || {};
+        const siteCodes = Array.isArray(meta.siteCodes) ? meta.siteCodes : [];
+        if (normalisedKey !== normaliseKey(DEFAULT_MANIFEST_KEY) && assets.length) {
+          if (!siteCodes.length || !siteCodes.some((code) => normaliseKey(code) === normalisedKey)) {
+            untaggedSiteAssets.push({ key, type, src: assetPath });
+          }
+        }
+        siteCodes.forEach((code) => {
+          const normalised = normaliseKey(code);
+          if (normalised && !knownKeys.has(normalised)) {
+            unknownSiteCodes.push({ key, type, src: assetPath, code });
+          }
+        });
+      }
+    }
+  }
+
+  if (!missingFiles.length && !untaggedSiteAssets.length && !unknownSiteCodes.length) {
+    console.log('✅ Asset manifest looks good — all files exist and site tags are aligned.');
+    return;
+  }
+
+  if (missingFiles.length) {
+    console.error('\n❌ Missing asset files:');
+    missingFiles.forEach((issue) => {
+      console.error(`  • [${issue.key}] ${issue.type.slice(0, -1)} → ${issue.src}`);
+    });
+  }
+
+  if (untaggedSiteAssets.length) {
+    console.warn('\n⚠️ Site-specific entries without matching siteCodes:');
+    untaggedSiteAssets.forEach((issue) => {
+      console.warn(`  • [${issue.key}] ${issue.type.slice(0, -1)} → ${issue.src}`);
+    });
+  }
+
+  if (unknownSiteCodes.length) {
+    console.warn('\n⚠️ Unknown site codes referenced in metadata:');
+    unknownSiteCodes.forEach((issue) => {
+      console.warn(`  • [${issue.key}] ${issue.type.slice(0, -1)} → ${issue.src} (tagged as "${issue.code}")`);
+    });
+  }
+
+  if (missingFiles.length) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('❌ Asset manifest validation failed unexpectedly:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- soften the shared motion bus tilt targets so cards respond to focus without shifting entire grids
- clamp scroll-driven warp and tilt strength for a calmer index experience
- extend the smoke test report with a per-page upgrade checklist for every HTML build

## Testing
- python tests/html_smoke_test.py > /tmp/html_smoke_results.json

------
https://chatgpt.com/codex/tasks/task_e_68d6a51e3e488329a6d2962f9509cdad