### PR TITLE
Add static orchestrator mode and rebalance global tilt

### DIFF
--- a/1-index.html
+++ b/1-index.html
@@ -1164,5 +1164,7 @@
             });
         });
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/10-pr-4.html
+++ b/10-pr-4.html
@@ -346,5 +346,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/11-pr-5.html
+++ b/11-pr-5.html
@@ -443,5 +443,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
-  </body>
+  
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
+</body>
 </html>

--- a/12-pr-6.html
+++ b/12-pr-6.html
@@ -386,5 +386,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/13-pr-7.html
+++ b/13-pr-7.html
@@ -2110,5 +2110,7 @@
         });
         
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/14-pr-8.html
+++ b/14-pr-8.html
@@ -381,5 +381,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/15-pr-9.html
+++ b/15-pr-9.html
@@ -361,5 +361,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/16-pr-10.html
+++ b/16-pr-10.html
@@ -334,5 +334,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/17-pr-11.html
+++ b/17-pr-11.html
@@ -338,5 +338,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/18-pr-12.html
+++ b/18-pr-12.html
@@ -157,5 +157,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/19-pr-13.html
+++ b/19-pr-13.html
@@ -344,5 +344,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/2-index-optimized.html
+++ b/2-index-optimized.html
@@ -645,5 +645,7 @@
     });
   </script>
 
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/20-pr-14.html
+++ b/20-pr-14.html
@@ -185,5 +185,7 @@
     </footer>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/21-pr-15.html
+++ b/21-pr-15.html
@@ -767,5 +767,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/22-pr-16.html
+++ b/22-pr-16.html
@@ -319,5 +319,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/23-pr-17.html
+++ b/23-pr-17.html
@@ -298,5 +298,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/24-pr-18.html
+++ b/24-pr-18.html
@@ -310,5 +310,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/25-orthogonal-depth-progression.html
+++ b/25-orthogonal-depth-progression.html
@@ -388,5 +388,7 @@
         });
     </script>
 
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/25-pr-19.html
+++ b/25-pr-19.html
@@ -299,5 +299,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/26-pr-20.html
+++ b/26-pr-20.html
@@ -662,5 +662,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/27-pr-21.html
+++ b/27-pr-21.html
@@ -561,5 +561,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/28-pr-22.html
+++ b/28-pr-22.html
@@ -859,5 +859,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/29-pr-23.html
+++ b/29-pr-23.html
@@ -846,5 +846,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/3-index-fixed.html
+++ b/3-index-fixed.html
@@ -201,5 +201,7 @@
         
         console.log('🔥 Clear Seas FIXED System - Preset lab removed, proper VIB34D URLs');
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/30-pr-24.html
+++ b/30-pr-24.html
@@ -861,5 +861,7 @@
     </noscript>
 
     <script src="scripts/clear-seas-ai.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/4-index-unified.html
+++ b/4-index-unified.html
@@ -223,5 +223,7 @@
         
         console.log('🧪 Clear Seas Unified System - Test page loaded');
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/5-index-vib34d-integrated.html
+++ b/5-index-vib34d-integrated.html
@@ -379,5 +379,7 @@
             }
         })();
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/6-index-totalistic.html
+++ b/6-index-totalistic.html
@@ -961,5 +961,7 @@
             }
         });
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html><!-- GitHub Pages deployment trigger Thu Sep  4 11:46:16 EDT 2025 -->

--- a/7-pr-1.html
+++ b/7-pr-1.html
@@ -267,5 +267,7 @@
     </footer>
 
     <script src="scripts/clear-seas-home.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/8-pr-2.html
+++ b/8-pr-2.html
@@ -240,5 +240,7 @@
     </div>
 
     <script src="scripts/orbital-field.js" defer></script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/9-pr-3.html
+++ b/9-pr-3.html
@@ -262,5 +262,7 @@
             }
         });
     </script>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
-🌊 Clear Seas Solutions - Multi-Version Deployment Complete
+🌐 **CSS-Web-Master System** _(formerly the Clear Seas Draft showcase)_
 
-✅ **DEPLOYMENT SUMMARY:**
-- **6 Main HTML Versions**: Complete website variations
-- **13 PR Branch Versions**: Latest meaningful iterations (PRs 1, 12-24)
-- **Total**: 19+ unique versions for comparison
-- **Supporting Assets**: All styles, scripts, and resources included
+The repository now serves as the **CSS-Web-Master** control surface for the Clear Seas family of properties. It retains every
+historical Clear Seas Draft experience while layering documentation, orchestration guides, and asset registries so new landing
+pages—like **paraerator.com**, **vib3code.com**, and future CSS destinations—can inherit the same choreography with minimal
+duplication.
 
-## 🎯 **ACCESS ALL VERSIONS:**
-Visit the **[Master Index](https://domusgpt.github.io/Clear-Seas-Draft/)** to explore all versions.
+### ✅ Deployment Snapshot
+- **6 Main HTML Versions**: Baseline production-ready experiences.
+- **13 PR Branch Versions**: Themed explorations sourced from the showcase (PRs #1, #4–#24).
+- **Total**: 19+ HTML builds ready to be remixed into site-specific stacks.
+- **Supporting Assets**: Shared scripts, orchestrators, style systems, and uploaded video/logo packs.
 
-## 📋 **VERSION CATEGORIES:**
+### 🎯 Access Everything
+Use the **[Master Index](https://domusgpt.github.io/Clear-Seas-Draft/)** to browse every build. The index now highlights where
+modules overlap so you can pick the correct starting point for each CSS family site.
+
+---
+
+## 📋 Version Collections
 
 ### Core HTML Versions (1-6):
 1. **Production** - Main website (index.html)
@@ -36,6 +44,20 @@ Visit the **[Master Index](https://domusgpt.github.io/Clear-Seas-Draft/)** to ex
 - **30-pr-24** - Amplified reactive background and card choreography
 
 🚀 **Every version is fully functional with complete assets and dependencies.**
+
+### Motion choreography docs
+
+The shared motion bus, CSS variables, and integration guidance are documented in
+[`docs/global-motion-reference.md`](docs/global-motion-reference.md).
+
+Additional CSS-Web-Master documentation is tracked in:
+
+- [`docs/css-web-master-system-overview.md`](docs/css-web-master-system-overview.md) – explains the multi-site orchestration
+  model, shared registries, and how to extend the system for new CSS properties.
+- [`docs/css-web-master-gap-analysis.md`](docs/css-web-master-gap-analysis.md) – outlines Clear Seas-specific assumptions to
+  generalize before production rollouts on paraerator.com or vib3code.com.
+- [`docs/dev-updates/2025-05-07-css-web-master-transition.md`](docs/dev-updates/2025-05-07-css-web-master-transition.md) –
+  developer log detailing the latest transition steps and recommended next moves.
 
 ---
 © 2025 Paul Phillips - Clear Seas Solutions LLC

--- a/ULTIMATE-clear-seas-holistic-system.html
+++ b/ULTIMATE-clear-seas-holistic-system.html
@@ -872,5 +872,7 @@
         });
     </script>
 
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/docs/brand-asset-overrides.md
+++ b/docs/brand-asset-overrides.md
@@ -1,0 +1,66 @@
+# Brand Asset Overrides
+
+The Clear Seas orchestrator, contained card system, and VIB34D contained visualizers now share the same brand override pipeline. Overrides can be applied in two complementary ways:
+
+1. **Per-card data attributes** – add attributes directly to any card element.
+2. **Runtime configuration** – populate `window.__CLEAR_SEAS_CARD_BRAND_OVERRIDES` before the orchestrator runs.
+
+Both approaches are normalized by `window.__CLEAR_SEAS_BRAND_OVERRIDE_API`, so the same rules automatically flow into every card controller.
+
+## Supported data attributes
+
+Attach one or more of the following attributes to any element detected as a card (`[data-visualizer-card]`, `[data-card]`, `.global-visualizer-card`, etc.). All attributes are optional; supply only what you need.
+
+| Attribute | Description |
+|-----------|-------------|
+| `data-brand-mode="video | image | auto"` | Forces the primary asset type. `auto` keeps the original heuristic. |
+| `data-brand-images="img1.png, img2.png"` | Comma or newline separated list of image sources to rotate through. |
+| `data-brand-videos="clip1.mp4, clip2.mp4"` | Comma or newline separated list of video sources. |
+| `data-brand-image-src` / `data-brand-video-src` | Shorthand for a single image or video. |
+| `data-brand-palette="concept"` | Overrides the palette token used for CSS theming. |
+| `data-brand-overlay-blend`, `data-brand-overlay-filter`, `data-brand-overlay-opacity`, `data-brand-overlay-rotate`, `data-brand-overlay-depth` | Per-card overlay styling. |
+| `data-card-canvas-scale`, `data-card-canvas-depth` | Adjusts visualizer canvas scaling/depth. |
+| `data-brand-seed-offset` | Integer offset added to the rotation seed for this card. |
+| `data-brand-cycle="focus,click"` | Comma separated triggers that advance to the next asset. Supported triggers: `focus`, `click`, `interaction`. |
+| `data-brand-cycle-on-focus`, `data-brand-cycle-on-click` | Boolean shortcuts for cycling on a specific trigger. |
+| `data-brand-cycle-step` | Numeric increment applied when cycling; defaults to `1`. |
+
+## Runtime configuration
+
+Provide an array of override descriptors before the orchestrator script executes:
+
+```html
+<script>
+window.__CLEAR_SEAS_CARD_BRAND_OVERRIDES = [
+  {
+    selector: '.mission-card',
+    mode: 'video',
+    videos: ['assets/missions/loop-01.mp4', 'assets/missions/loop-02.mp4'],
+    palette: 'immersive',
+    overlay: {
+      blend: 'color-dodge',
+      opacity: 1.2
+    },
+    cycle: ['focus', 'click']
+  }
+];
+</script>
+```
+
+Keys mirror the data attributes and accept the same value shapes. The orchestrator merges all matching descriptors (ordered as provided), then layers data attributes on top.
+
+## Updating overrides at runtime
+
+When overrides change after the orchestrator has initialised, call the shared refresh helper to keep every card system in sync:
+
+```js
+window.__CLEAR_SEAS_BRAND_OVERRIDE_API?.refresh({ reason: 'hot-swap' });
+```
+
+The call recomputes global overrides, resets per-card asset cycles, and dispatches the `clear-seas:brand-overrides-changed` event. All orchestrated cards, the legacy initializer, and the VIB34D contained system listen for that event and immediately reapply overlays, canvases, and brand media.
+
+## Behaviour
+
+* Asset rotation respects a shared `assetCycle` counter so focus or click interactions can advance to the next override asset without affecting the global rotation for other cards.
+* Overrides cascade to the legacy `card-system-initializer.js` and the VIB34D contained system, so contained visualizers, standard cards, and global orchestrated cards all honor the same configuration.
+* When no overrides are supplied, the previous behaviour is unchanged.

--- a/docs/css-web-master-gap-analysis.md
+++ b/docs/css-web-master-gap-analysis.md
@@ -1,0 +1,46 @@
+# CSS-Web-Master Gap Analysis
+
+This checklist captures the Clear Seas-specific assumptions that still live in the codebase. Addressing each item will make the
+CSS-Web-Master platform production-ready for paraerator.com, vib3code.com, and future CSS family properties.
+
+## Naming & Branding
+
+- **Global variables & events** still use the `clear-seas` prefix (`window.__CLEAR_SEAS_GLOBAL_MOTION`, `clear-seas:motion-updated`).
+  - *Action:* Introduce aliases or a namespace bridge (e.g., `window.__CSS_WEB_MASTER`) so downstream integrations can migrate
+    without breaking existing builds.
+- **Dataset attributes** applied by `global-page-orchestrator` are `data-global-page-family/layout`. Confirm if new properties
+  require additional tags (e.g., `data-site-code`).
+
+## Page Profile Registry
+
+- Profiles currently reference Clear Seas-specific copy and brand asset packages.
+  - *Action:* Split palette metadata from marketing copy to allow new sites to opt into the same colors without inheriting copy.
+- Filename heuristics prioritize `index`/`pr` naming. Define detection patterns for future site URLs or configure explicit
+  overrides.
+
+## Asset Management
+
+- The brand override registry expects assets in `/assets/` with Clear Seas naming conventions.
+  - *Action:* Add configuration hooks (JSON or module exports) so each site can define its own asset manifest without editing the
+    orchestrator.
+- Uploaded mp4 overlays are catalogued but not yet grouped by campaign/site.
+  - *Action:* Tag assets by site or theme within the registry for deterministic rotation.
+
+## Styling Systems
+
+- `styles/clear-seas-ai.css` includes marketing copy classes and iconography unique to the Clear Seas mission deck.
+  - *Action:* Extract generic motion/visualizer styles into a neutral stylesheet and let each site layer its own typography.
+- `styles/consolidated-styles.css` references fonts and color tokens specific to Clear Seas.
+  - *Action:* Externalize font stacks and color tokens into CSS variables so sites can swap values without duplicating files.
+
+## Documentation
+
+- The Master Index references Clear Seas experiences throughout.
+  - *Action:* Update hero copy per site launch, or create property-specific indexes that reuse the same component grid.
+- Add runbooks for deploying to each production host (paraerator.com, vib3code.com) once the orchestration pattern is finalized.
+
+## Tooling Wishlist
+
+- **Configuration schema:** Provide a JSON/YAML schema for declaring site families, asset packs, and motion tuning.
+- **CLI or scripts:** Automate copying a base template into a new `site-name.html` with the correct dataset tags and doc stubs.
+- **Visualizer presets:** Document recommended shader parameter ranges per site to keep brand experiences consistent.

--- a/docs/css-web-master-system-overview.md
+++ b/docs/css-web-master-system-overview.md
@@ -1,0 +1,63 @@
+# CSS-Web-Master System Overview
+
+The CSS-Web-Master system elevates the original Clear Seas Draft showcase into a multi-site orchestration platform. It keeps the
+legacy builds intact while introducing shared registries, motion buses, and styling primitives that future CSS-family properties
+can reuse without rewriting motion logic or asset loading rules.
+
+## Core Goals
+
+1. **Unify shared infrastructure.** Global scripts (`global-page-orchestrator`, `page-profile-registry`) centralize brand
+   palettes, asset rotation, and CSS variable broadcasting so each site inherits the same reactive scaffolding.
+2. **Scale across properties.** paraerator.com, vib3code.com, and other CSS launches can point at the same orchestrator and
+   stylesheet bundle, then layer site-specific copy or modules on top.
+3. **Preserve creative experimentation.** Every HTML build remains available as a reference implementation, letting teams remix
+   existing choreography patterns instead of starting from scratch.
+
+## Architecture Snapshot
+
+| Layer | Purpose | Key Files |
+| ----- | ------- | --------- |
+| **Registry** | Detects the active page family, palette, and layout metadata. | `scripts/page-profile-registry.js` |
+| **Orchestrator** | Applies profile data, injects shared CSS variables, and broadcasts motion telemetry. | `scripts/global-page-orchestrator.js` |
+| **Card Systems** | Provides synchronized card bending, tilt, and overlay management. | `scripts/card-system-initializer.js`, `scripts/vib34d-contained-card-system.js` |
+| **Synergy Stylesheets** | Consumes the broadcast variables to animate cards, overlays, and canvases in unison. | `styles/global-card-synergy.css`, `styles/clear-seas-ai.css`, `styles/consolidated-styles.css` |
+| **Visualizer Engines** | Render holographic canvases, overscan assets, and 4D rotations. | `src/holograms/HolographicVisualizer.js`, `src/core/CanvasManager.js` |
+
+### Multi-Site Workflow
+
+1. **Choose a baseline template** from the Master Index based on the desired experience (e.g., Immersive AI deck, Blueprint lab,
+   Totalistic showcase).
+2. **Set the page profile** using `data-page-collection` or filename conventions so the orchestrator loads the correct palette
+   and asset set.
+3. **Register brand assets** through the shared brand override registry or by dropping new media into `assets/` and referencing
+   them within the profile metadata.
+4. **Customize copy and modules** while leaving the orchestrator hooks in place so focus, pointer, and scroll telemetry continue
+   to propagate to canvases, overlays, and videos.
+5. **Document site-specific adjustments** in the `/docs` folder to keep the control surface accurate for each deployment.
+
+## Shared Asset Strategy
+
+- **Brand overrides**: Use `docs/brand-asset-overrides.md` as the canonical guide. New logo treatments, translucent overlays, or
+  short-form mp4 loops can be registered once and consumed across every card system.
+- **Uploaded media**: Recent additions (e.g., `20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4`,
+  `20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4`) are ready for rotation within the
+  orchestrator-managed palettes.
+- **Overscan defaults**: Canvas overscan is now managed globally, ensuring holographic visuals always bleed past card edges while
+  respecting tilt and bend cues supplied by motion telemetry.
+
+## Extending to New Sites
+
+- **paraerator.com**: Start from a PR-series immersive deck to reuse mission-axis navigation. Update the profile registry with a
+  `paraerator` family that swaps in the new logos/videos and adjust copy modules accordingly.
+- **vib3code.com**: Leverage the VIB34D-integrated builds for continuity with the existing visualizer engines. Register
+  additional shader parameters if new interaction types are required.
+- **Future CSS properties**: Define new families within `page-profile-registry`, point them at shared synergy styles, and create
+  dedicated docs (similar to this overview) to capture any divergent requirements.
+
+## Next Documentation Steps
+
+- Maintain rolling developer updates under `docs/dev-updates/` so every transition is auditable.
+- Expand the gap analysis (see `docs/css-web-master-gap-analysis.md`) as teams discover Clear Seas-specific logic that should be
+  abstracted for broader use.
+- Annotate new palette definitions with the assets they expect, making it easy to substitute brand packages without editing the
+  orchestrator core.

--- a/docs/dev-updates/2025-05-07-css-web-master-transition.md
+++ b/docs/dev-updates/2025-05-07-css-web-master-transition.md
@@ -1,0 +1,25 @@
+# Dev Update – 7 May 2025
+
+## What changed
+
+- Reframed the repository as the **CSS-Web-Master** platform in `README.md`, clarifying how the existing Clear Seas Draft builds
+  seed future CSS-family launches.
+- Authored the **CSS-Web-Master System Overview** documenting the orchestration layers, workflow, and asset strategy for
+  multi-site reuse.
+- Captured a **Gap Analysis** outlining Clear Seas-specific assumptions that need generalization before deploying to
+  paraerator.com, vib3code.com, or other destinations.
+
+## Why it matters
+
+- Teams now have a single source of truth that explains how to extend the orchestrator, card systems, and synergy styles beyond
+  the Clear Seas showcase.
+- The gap analysis exposes remaining work (naming, asset manifests, styling extractions) so follow-up sprints can target the
+  highest-impact refactors.
+
+## Next recommendations
+
+1. Prototype a new page profile (e.g., `paraerator`) in `scripts/page-profile-registry.js` to validate the workflow and confirm
+   asset overrides behave as expected.
+2. Introduce namespace aliases for the global motion object/event to decouple future builds from the `clear-seas` prefix.
+3. Begin extracting neutral typography and color tokens into a shared variables file so each site can ship with its own brand
+   skin while reusing the same motion choreography.

--- a/docs/global-motion-reference.md
+++ b/docs/global-motion-reference.md
@@ -1,0 +1,99 @@
+# Global Motion Telemetry Reference
+
+The `global-page-orchestrator` continuously samples every orchestrated card, smooths the
+results, and emits a shared motion snapshot so all Clear Seas builds can react in
+lockstep. This document lists the fields, CSS variables, and recommended integration
+patterns for downstream systems.
+
+## Runtime snapshot
+
+The orchestrator stores the latest values on `window.__CLEAR_SEAS_GLOBAL_MOTION` and
+dispatches them through the `clear-seas:motion-updated` event (also exported as
+`window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT`). Each dispatch now includes the following
+properties:
+
+| Field | Description |
+|-------|-------------|
+| `focusX`, `focusY` | Smoothed pointer centroid for the currently emphasised cards (0–1).
+| `focusAmount` | Aggregated focus weight across all visible cards (0–1+). |
+| `focusTrend` | Frame-to-frame delta of `focusAmount`, eased to highlight acceleration towards/away from the focus. |
+| `tiltX`, `tiltY` | Global tilt vector derived from pointer position and scroll momentum. |
+| `tiltStrength` | Magnitude of the tilt vector, already clamped to 0–1. |
+| `tiltSkew` | Difference between `tiltX` and `tiltY`, useful for twist/warp treatments. |
+| `bend` | Shared bending intensity that factors focus, synergy, and scroll momentum. |
+| `warp` | Complementary warp component for shader modulation. |
+| `scrollMomentum` | Normalised scroll velocity (can exceed 1 during rapid flicks). |
+| `scrollSpeed` | Smoothed absolute scroll magnitude (0–1). |
+| `scrollDirection` | Directional indicator: `-1` up, `0` idle, `1` down. |
+| `synergy` | Global cohesion score derived from active card groups. |
+| `palette`, `collection` | Active page palette token and collection key. |
+| `timestamp` | High-resolution timestamp for the snapshot. |
+
+Tilt vectors now weight the eased focus centroid, synergy cohesion, and scroll velocity
+so the entire stack leans gracefully around the emphasised card without abrupt jumps.
+Bend intensity inherits the same blend, which keeps overlays, canvases, and support
+elements moving in concert.
+
+Consumers that only need the latest state can read from
+`window.__CLEAR_SEAS_GLOBAL_MOTION`. For reactive experiences, listen for the shared
+event:
+
+```js
+window.addEventListener(window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT, (event) => {
+  const motion = event.detail;
+  // ...update shaders, canvases, analytics, etc.
+});
+```
+
+## CSS variables
+
+`global-page-orchestrator.js` mirrors the snapshot as root-level CSS custom properties.
+The latest release adds four directional helpers:
+
+| CSS variable | Meaning |
+|--------------|---------|
+| `--global-focus-trend` | Signed focus acceleration used to offset backgrounds and glow stacks. |
+| `--global-scroll-speed` | Absolute scroll momentum for blur/glow amplification. |
+| `--global-scroll-direction` | Direction multiplier for directional shadows and parallax. |
+| `--global-tilt-skew` | Horizontal vs. vertical tilt imbalance for twist treatments. |
+
+The shared `global-card-synergy.css` stylesheet consumes these properties so primary and
+support cards can react together. Cards that opt into the motion feed can also copy the
+values onto local variables (`--shared-focus-trend`, etc.) to cascade them into their own
+transforms or shader uniforms.
+
+### Static catalog pages
+
+Set `data-orchestrator-mode="static"` on the `<body>` (or
+`data-disable-global-orchestrator`) when you only need the page profile metadata but want
+to skip heavy observers, canvases, and brand overlays. In static mode the orchestrator
+publishes a neutral motion snapshot, seeds the palette/family metadata, and leaves the
+page free of injected stylesheets so index-style catalogs stay lightweight.
+
+## Card system integration
+
+Both card controller implementations now propagate the extended motion fields:
+
+- `scripts/card-system-initializer.js` applies `--shared-scroll-direction`,
+  `--shared-scroll-speed`, `--shared-focus-trend`, and `--shared-tilt-skew` to each card.
+- `scripts/vib34d-contained-card-system.js` normalises the same fields so contained
+  holographic canvases, overlays, and shader parameters receive consistent inputs even
+  when they are instantiated outside the main orchestrator.
+
+When building a new module, prefer reading these shared custom properties rather than
+attaching bespoke event listeners. This keeps every layer synchronised around the focus
+card and avoids competing easing loops.
+
+## Suggested use cases
+
+1. **Shader uniforms:** Map `focusTrend` or `scrollSpeed` to bloom or particle density so
+   rapid scroll accelerates the visuals while idle states settle gracefully.
+2. **Parallax layers:** Apply `--global-scroll-direction` to background translate values
+   so supporting elements lean in the direction of travel.
+3. **Brand overlays:** Use `--shared-tilt-skew` to counter-rotate logos or frame elements,
+   keeping them visually locked to the card even during aggressive tilts.
+4. **Analytics:** Record motion bursts by observing `focusTrend` spikes without polling
+   pointer events yourself.
+
+By funnelling every reactive surface through this shared snapshot, Clear Seas pages can
+maintain the "everyone moves together" choreography the design direction calls for.

--- a/docs/html-version-groups.md
+++ b/docs/html-version-groups.md
@@ -1,0 +1,84 @@
+# HTML Version Collections
+
+This manifest groups every published HTML experience by the layout framework, shared stylesheets, and JavaScript orchestration they rely on. Use it as a quick map when deciding which builds to compare or extend together.
+
+## Core System Foundation (1–6)
+These flagship builds establish the production-ready stack, moving from the launch deck through unified and totalistic orchestration layers.
+
+- **`1-index.html` – AI Innovation Portfolio**  
+  *Stack:* `scripts/vib34d-contained-card-system.js`.  
+  *Focus:* Flagship trading-card portfolio with the contained VIB34D card system.
+- **`2-index-optimized.html` – Performance Enhanced Core**  
+  *Stack:* `styles/consolidated-styles.css` + `scripts/enhanced-master-conductor.js`, `scripts/main.js`, `scripts/mobile-navigation-injector.js`, `scripts/unified-experience-engine.js`, `scripts/vib34d-contained-card-system.js`, `scripts/zone-visualizers.js`.  
+  *Focus:* Speed-tuned navigation with synchronized canvas zones.
+- **`3-index-fixed.html` – Stabilized System**  
+  *Stack:* `styles/consolidated-styles.css` + `scripts/polytopal-reactivity-json.js`.  
+  *Focus:* Hardens the fixed-layout controls and reactivity JSON pipeline.
+- **`4-index-unified.html` – Unified Architecture**  
+  *Stack:* `styles/consolidated-styles.css` + `scripts/polytopal-reactivity-json.js`, `scripts/preset-laboratory.js`.  
+  *Focus:* Brings disparate modules under a single preset lab configuration.
+- **`5-index-vib34d-integrated.html` – Advanced VIB34D Integration**  
+  *Stack:* layered base/animations/reactivity styles with `js/audio/audio-engine.js`, `js/controls/ui-handlers.js`, `js/core/url-params.js`, `js/gallery/gallery-manager.js`, `js/interactions/device-tilt.js`.  
+  *Focus:* Full VIB34D integration with audio, gallery, and tilt controls.
+- **`6-index-totalistic.html` – Totalistic Experience**  
+  *Stack:* `styles/consolidated-styles.css` + `scripts/core-engine.js`, `scripts/polytopal-reactivity-json.js`, `scripts/unified-experience-engine.js`, `scripts/vib34d-contained-card-system.js`.  
+  *Focus:* Total-system choreography that threads every engine together.
+
+## Immersive AI Command Deck Collection (PR #4–#24)
+All of these prototypes load `styles/clear-seas-ai.css` and `scripts/clear-seas-ai.js`, delivering the mission-axis navigation, translucent orb canvases, and scroll-synced scene choreography used across the modern marketing journey. Iterate within this collection to explore copy, choreography, and module density without changing the underlying framework.
+
+- **Launch Arc (PR #4–#6):** `10-pr-4.html`, `11-pr-5.html`, `12-pr-6.html`.
+- **Experience Refinements (PR #8–#14):** `14-pr-8.html`, `15-pr-9.html`, `16-pr-10.html`, `17-pr-11.html`, `18-pr-12.html`, `19-pr-13.html`, `20-pr-14.html`.
+- **Blueprint & Deck Explorations (PR #15–#18):** `21-pr-15.html`, `22-pr-16.html`, `23-pr-17.html`, `24-pr-18.html`.
+- **Holographic Depth Studies (PR #19–#24):** `25-pr-19.html`, `26-pr-20.html`, `27-pr-21.html`, `28-pr-22.html`, `29-pr-23.html`, `30-pr-24.html` (adds `scripts/immersive-experience-actualizer.js` for amplified choreography).
+
+## Concept Labs & Special Studies
+These builds experiment with alternative canvases, typography systems, or research tooling outside of the shared AI stack.
+
+- **`7-pr-1.html` – Polytopal Home Experience:** Combines `styles/clear-seas-home.css` & `styles/main.css` with `scripts/clear-seas-home.js` to keep the original particle field and narrative-led navigation.
+- **`8-pr-2.html` – Avant-garde AI Landing:** Uses `styles/avant-garde.css` with `scripts/orbital-field.js` for a cinematic orbiting hero.
+- **`9-pr-3.html` – Clear Seas Intelligence Homepage:** Blends `styles/clear-seas-ai.css` with `styles/main.css` for a hybrid presentation that bridges the home and mission-axis directions.
+- **`13-pr-7.html` – Visual Codex Gallery:** Inline neon codex with 4D polytopal backgrounds and crystalline gallery narration.
+- **`25-orthogonal-depth-progression.html` – Orthogonal Depth Lab:** Couples `scripts/orthogonal-depth-progression.js` with `scripts/vib34d-geometric-tilt-system.js` to map scroll to holographic tilt.
+- **`ULTIMATE-clear-seas-holistic-system.html` – Ultimate Holistic System:** Runs the `scripts/ultimate-holistic-vib34d-system.js` choreography for a maximal VIB34D showcase.
+
+## Meta
+- **`index.html`** now surfaces these collections with descriptive section copy, meta chips, and lab highlights so teams can jump directly into comparable builds.
+
+## Brand Palette Synchronization
+
+The `global-page-orchestrator` now detects which collection a page belongs to and shares that profile through `window.__CLEAR_SEAS_PAGE_PROFILE`. The four active palettes are:
+
+- **Meta Index (`meta-index`)** – used for the overview map.
+- **Core Foundation (`core-foundation`)** – powers the 1–6 flagship builds.
+- **Immersive AI (`immersive-ai`)** – covers PR #4–#24 experiences.
+- **Concept Labs (`concept-labs`)** – all experimental lab studies.
+
+Each palette drives:
+
+- Unique brand overlay blends, hues, and depth offsets.
+- Canvas overscan/tilt scaling so holograms always clear card edges.
+- Deterministic brand asset rotation (images & mp4 overlays) so every build receives a distinct mix of the uploaded footage.
+- Conditional script preloads (e.g., immersive pages auto-load `immersive-experience-actualizer.js`).
+
+Any custom page can opt into a palette by setting `data-page-collection` or `data-showcase-theme` on `<html>`/`<body>` before loading the orchestrator.
+
+### Page Profile Registry
+
+The new `scripts/page-profile-registry.js` module exposes these group definitions so other scripts can reference them without duplicating logic. It exports a lightweight API:
+
+- `list()` – returns the available profile keys plus their family, palette, and layout metadata.
+- `resolve()` – matches the active document against filenames, dataset tags, and title tokens to pick the correct profile.
+- `apply()` – applies dataset attributes (`data-global-page-family`, `data-global-page-layout`) and CSS variables (e.g., `--global-brand-accent`) that downstream styles consume.
+
+`global-page-orchestrator.js` now imports the registry directly, ensuring every HTML build shares the same grouping, accent colors, and overlay depth heuristics.
+
+## Global Motion Telemetry
+
+The shared orchestrator now publishes frame-smoothed motion data so satellite scripts and inline styles can react in unison:
+
+- **CSS variables:** `--global-bend-intensity`, `--global-tilt-x`, `--global-tilt-y`, `--global-tilt-strength`, and `--global-warp` join the existing focus/scroll values on `:root`. The latest refresh also adds directional helpers (`--global-focus-trend`, `--global-scroll-speed`, `--global-scroll-direction`, `--global-tilt-skew`) that let cards echo scroll direction and focus acceleration without reimplementing easing.
+- **Runtime object:** `window.__CLEAR_SEAS_GLOBAL_MOTION` mirrors the latest focus, tilt, bend, scroll, and synergy readings for JavaScript consumers. Read-only access lets visualizer engines or analytics tap into the same smoothed signals without reimplementing observers.
+- **Browser event:** `clear-seas:motion-updated` (also exposed as `window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT`) dispatches whenever the shared motion snapshot shifts. Card systems can subscribe once and receive normalized `focus`, `tilt`, `bend`, `warp`, `scrollMomentum`, and `synergy` values instead of polling.
+
+Tie new modules or shader parameters into these shared signals instead of duplicating interaction listeners to keep every layer phase-aligned.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Clear Seas Solutions - All Versions (30 Total)</title>
+    <title>CSS-Web-Master Control Surface – Clear Seas Draft Library</title>
     <style>
         * {
             margin: 0;
@@ -59,6 +59,34 @@
 
         .section {
             margin-bottom: 40px;
+        }
+
+        .section-header {
+            margin-bottom: 25px;
+        }
+
+        .section-intro {
+            margin-top: 12px;
+            font-size: 0.95rem;
+            line-height: 1.7;
+            color: rgba(255, 255, 255, 0.85);
+        }
+
+        .section-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 18px;
+        }
+
+        .meta-chip {
+            padding: 6px 14px;
+            border-radius: 999px;
+            font-size: 0.72rem;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            background: rgba(255, 255, 255, 0.12);
+            border: 1px solid rgba(255, 255, 255, 0.24);
         }
 
         .section-title {
@@ -153,6 +181,12 @@
             color: #93c5fd;
         }
 
+        .lab-version .status-badge {
+            background: rgba(236, 72, 153, 0.18);
+            border: 1px solid rgba(244, 114, 182, 0.35);
+            color: #f9a8d4;
+        }
+
         .footer {
             text-align: center;
             margin-top: 40px;
@@ -173,18 +207,21 @@
         }
     </style>
 </head>
-<body>
+<body data-orchestrator-mode="static">
     <div class="container">
         <div class="header">
-            <div class="logo">🌊 Clear Seas Solutions</div>
-            <div class="subtitle">Complete Multi-Version Deployment System</div>
-            <div class="count">30 Total Versions • 6 Main + 24 PR Branches</div>
-            <p>Explore different iterations and compare approaches side-by-side</p>
+            <div class="logo">🧭 CSS-Web-Master Control Surface</div>
+            <div class="subtitle">Powered by the Clear Seas Draft multi-version library</div>
+            <div class="count">32 Experiences • 6 Core + 24 PR Branches + 2 Labs</div>
+            <p>Use this library to seed future CSS-family launches (paraerator.com, vib3code.com, and beyond).</p>
         </div>
 
         <!-- MAIN HTML VERSIONS (1-6) -->
         <div class="section">
-            <div class="section-title">Core HTML Versions (1-6)</div>
+            <div class="section-header">
+                <div class="section-title">Core HTML Versions (1-6)</div>
+                <p class="section-intro">Flagship builds that establish the production architecture, performance tuning, unified layouts, VIB34D integration, and the fully orchestrated totalistic experience.</p>
+            </div>
             <div class="version-grid">
                 <div class="version-card main-version">
                     <div class="version-number">01</div>
@@ -248,30 +285,18 @@
             </div>
         </div>
 
-        <!-- PR BRANCH VERSIONS (8-30) -->
+        <!-- IMMERSIVE AI COMMAND DECK COLLECTION -->
         <div class="section">
-            <div class="section-title">PR Branch Versions (8-30)</div>
+            <div class="section-header">
+                <div class="section-title">Immersive AI Command Deck Collection (PR 4–24)</div>
+                <p class="section-intro">Interlinked prototypes that share the Clear Seas AI mission-axis layout, translucent orb fields, and synchronized scroll choreography. Use this collection to compare how narrative emphasis, staging density, and conversion flows evolve while the underlying CSS and JS stack stays consistent.</p>
+                <div class="section-meta">
+                    <span class="meta-chip">Shared CSS: styles/clear-seas-ai.css</span>
+                    <span class="meta-chip">Shared JS: scripts/clear-seas-ai.js</span>
+                    <span class="meta-chip">PR Variants: #4 – #24 (excludes special labs)</span>
+                </div>
+            </div>
             <div class="version-grid">
-                <div class="version-card pr-version">
-                    <div class="version-number">08</div>
-                    <div class="status-badge">PR #2</div>
-                    <div class="version-title">Avant-garde AI Landing Page</div>
-                    <div class="version-description">
-                        Create avant-garde AI consulting landing page with intelligent design and sophisticated interactions.
-                    </div>
-                    <a href="./8-pr-2.html" class="version-link">Launch Version</a>
-                </div>
-
-                <div class="version-card pr-version">
-                    <div class="version-number">09</div>
-                    <div class="status-badge">PR #3</div>
-                    <div class="version-title">Clear Seas Intelligence Homepage</div>
-                    <div class="version-description">
-                        Design new Clear Seas Intelligence AI consulting homepage with advanced geometric cognition features.
-                    </div>
-                    <a href="./9-pr-3.html" class="version-link">Launch Version</a>
-                </div>
-
                 <div class="version-card pr-version">
                     <div class="version-number">10</div>
                     <div class="status-badge">PR #4</div>
@@ -300,16 +325,6 @@
                         Create immersive Clear Seas AI experience with advanced geometric processing and holographic elements.
                     </div>
                     <a href="./12-pr-6.html" class="version-link">Launch Version</a>
-                </div>
-
-                <div class="version-card pr-version">
-                    <div class="version-number">13</div>
-                    <div class="status-badge">PR #7</div>
-                    <div class="version-title">Clear Seas AI Consulting</div>
-                    <div class="version-description">
-                        Create Clear Seas AI consulting experience with refined visual codex and navigation systems.
-                    </div>
-                    <a href="./13-pr-7.html" class="version-link">Launch Version</a>
                 </div>
 
                 <div class="version-card pr-version">
@@ -351,7 +366,6 @@
                     </div>
                     <a href="./17-pr-11.html" class="version-link">Launch Version</a>
                 </div>
-
 
                 <div class="version-card pr-version">
                     <div class="version-number">18</div>
@@ -485,11 +499,85 @@
             </div>
         </div>
 
+        <!-- DISTINCT CONCEPT LABS & SPECIAL STUDIES -->
+        <div class="section">
+            <div class="section-header">
+                <div class="section-title">Concept Labs &amp; Special Studies</div>
+                <p class="section-intro">Exploratory builds that diverge from the mission-axis system to investigate alternate visual systems, stacked canvases, and high-energy holographic research environments.</p>
+                <div class="section-meta">
+                    <span class="meta-chip">Unique frameworks outside the shared AI stack</span>
+                </div>
+            </div>
+            <div class="version-grid">
+                <div class="version-card pr-version lab-version">
+                    <div class="version-number">07</div>
+                    <div class="status-badge">PR #1</div>
+                    <div class="version-title">Polytopal Home Experience</div>
+                    <div class="version-description">
+                        Canvas-driven homepage that pairs clear narrative lanes with the original polytopal particle field and responsive navigation.
+                    </div>
+                    <a href="./7-pr-1.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card pr-version lab-version">
+                    <div class="version-number">08</div>
+                    <div class="status-badge">PR #2</div>
+                    <div class="version-title">Avant-garde AI Landing Page</div>
+                    <div class="version-description">
+                        Create avant-garde AI consulting landing page with intelligent design and sophisticated interactions.
+                    </div>
+                    <a href="./8-pr-2.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card pr-version lab-version">
+                    <div class="version-number">09</div>
+                    <div class="status-badge">PR #3</div>
+                    <div class="version-title">Clear Seas Intelligence Homepage</div>
+                    <div class="version-description">
+                        Design new Clear Seas Intelligence AI consulting homepage with advanced geometric cognition features.
+                    </div>
+                    <a href="./9-pr-3.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card pr-version lab-version">
+                    <div class="version-number">13</div>
+                    <div class="status-badge">PR #7</div>
+                    <div class="version-title">Visual Codex Gallery</div>
+                    <div class="version-description">
+                        Fixed-layout neon codex that experiments with 4D polytopal backgrounds, crystalline palettes, and gallery-style narration.
+                    </div>
+                    <a href="./13-pr-7.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card lab-version">
+                    <div class="version-number">L1</div>
+                    <div class="status-badge">LAB</div>
+                    <div class="version-title">Orthogonal Depth Progression</div>
+                    <div class="version-description">
+                        Experimental camera lab that maps orthogonal scroll momentum into layered holographic tilt systems.
+                    </div>
+                    <a href="./25-orthogonal-depth-progression.html" class="version-link">Launch Version</a>
+                </div>
+
+                <div class="version-card lab-version">
+                    <div class="version-number">L2</div>
+                    <div class="status-badge">LAB</div>
+                    <div class="version-title">Ultimate Holistic System</div>
+                    <div class="version-description">
+                        Unified VIB34D showcase that activates the ultimate holistic choreography script across canvases and overlays.
+                    </div>
+                    <a href="./ULTIMATE-clear-seas-holistic-system.html" class="version-link">Launch Version</a>
+                </div>
+            </div>
+        </div>
+
         <div class="footer">
-            <p><strong>Clear Seas Solutions Multi-Version Deployment</strong></p>
-            <p>Compare approaches • Test interactions • Evaluate different design directions</p>
+            <p><strong>CSS-Web-Master – Clear Seas Draft Foundation</strong></p>
+            <p>Compare approaches • Sync choreography • Spin up site-specific experiences</p>
             <p style="margin-top: 15px; opacity: 0.5;">© 2025 Paul Phillips - Clear Seas Solutions LLC</p>
         </div>
     </div>
+
+    <script type="module" src="scripts/global-page-orchestrator.js"></script>
 </body>
 </html>

--- a/scripts/card-specific-vib34d-visualizer.js
+++ b/scripts/card-specific-vib34d-visualizer.js
@@ -512,13 +512,31 @@ class CardSpecificVIB34DVisualizer {
       const rect = this.cardElement.getBoundingClientRect();
       const x = (e.clientX - rect.left) / rect.width;
       const y = (e.clientY - rect.top) / rect.height;
-      
-      this.updateInteraction(x, y, 0.5);
-      
+
+      const tiltX = (0.5 - y) * 2;
+      const tiltY = (x - 0.5) * 2;
+      const pointerMagnitude = Math.min(1.2, Math.hypot(tiltX, tiltY));
+      const bendStrength = Math.min(1, 0.18 + pointerMagnitude * 0.6);
+      const bendTiltX = -tiltX * 12 * bendStrength;
+      const bendTiltY = tiltY * 14 * bendStrength;
+      const bendSkewX = -tiltY * 6 * bendStrength;
+      const bendSkewY = tiltX * 5 * bendStrength;
+      const bendTwist = tiltX * tiltY * 16 * bendStrength;
+      const bendDepth = bendStrength * 28;
+
+      this.updateInteraction(x, y, bendStrength);
+
       // Update CSS custom properties for card transforms
       this.cardElement.style.setProperty('--mouse-x', (x * 100) + '%');
       this.cardElement.style.setProperty('--mouse-y', (y * 100) + '%');
-      this.cardElement.style.setProperty('--bend-intensity', this.mouseIntensity);
+      this.cardElement.style.setProperty('--bend-intensity', bendStrength.toFixed(3));
+      this.cardElement.style.setProperty('--bend-tilt-x-deg', `${bendTiltX.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-tilt-y-deg', `${bendTiltY.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-skew-x-deg', `${bendSkewX.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-skew-y-deg', `${bendSkewY.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-twist-deg', `${bendTwist.toFixed(3)}deg`);
+      this.cardElement.style.setProperty('--bend-depth', `${bendDepth.toFixed(3)}px`);
+      this.cardElement.style.setProperty('--visualizer-bend-depth', `${(bendDepth * 0.6).toFixed(3)}px`);
     });
     
     // Click interactions
@@ -540,11 +558,18 @@ class CardSpecificVIB34DVisualizer {
       this.cardElement.classList.remove('visualizer-active');
       this.reactivity = 1.0;
       this.mouseIntensity *= 0.8; // Gradual fade
-      
+
       // Reset CSS transforms
       this.cardElement.style.setProperty('--mouse-x', '50%');
       this.cardElement.style.setProperty('--mouse-y', '50%');
       this.cardElement.style.setProperty('--bend-intensity', '0');
+      this.cardElement.style.setProperty('--bend-tilt-x-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-tilt-y-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-skew-x-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-skew-y-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-twist-deg', '0deg');
+      this.cardElement.style.setProperty('--bend-depth', '0px');
+      this.cardElement.style.setProperty('--visualizer-bend-depth', '0px');
     });
   }
   

--- a/scripts/card-system-initializer.js
+++ b/scripts/card-system-initializer.js
@@ -4,6 +4,44 @@
  * Manages canvas creation/destruction and performance optimization
  */
 
+const BRAND_OVERRIDE_EVENT = window.__CLEAR_SEAS_BRAND_OVERRIDE_EVENT || 'clear-seas:brand-overrides-changed';
+
+const fallbackBrandOverrideApi = {
+  collect: () => null,
+  mergeOverlaySettings: (base) => ({ ...(base || {}) }),
+  mergeCanvasSettings: (base) => ({ ...(base || {}) }),
+  resolveMode: (_overrides, fallback) => fallback,
+  pickAsset: (_overrides, _type, index, fallback) => (typeof fallback === 'function' ? fallback(index) : null),
+  shouldCycle: () => false,
+  nextCycleIndex: (_overrides, current) => (Number.isFinite(current) ? current + 1 : 1),
+  applyPalette: (overrides, fallback) => (overrides?.palette || fallback || 'foundation'),
+  hasAssetList: (overrides, type) => {
+    const key = type === 'videos' ? 'videos' : 'images';
+    return Array.isArray(overrides?.[key]) && overrides[key].length > 0;
+  },
+  refresh: (detail) => {
+    const eventDetail = {
+      reason: detail && typeof detail === 'object' && detail.reason ? detail.reason : 'manual-refresh',
+      timestamp: Date.now()
+    };
+    if (detail && typeof detail === 'object') {
+      Object.keys(detail).forEach((key) => {
+        if (key === 'reason') {
+          return;
+        }
+        eventDetail[key] = detail[key];
+      });
+    }
+    window.dispatchEvent(new CustomEvent(BRAND_OVERRIDE_EVENT, { detail: eventDetail }));
+    return [];
+  },
+  eventName: BRAND_OVERRIDE_EVENT
+};
+
+function useBrandOverrideApi() {
+  return window.__CLEAR_SEAS_BRAND_OVERRIDE_API || fallbackBrandOverrideApi;
+}
+
 class CardSystemController {
   constructor() {
     this.visualizerManager = null;
@@ -13,7 +51,86 @@ class CardSystemController {
       maxVisualizers: 6,
       performanceMode: 'auto'
     };
-    
+
+    this.brandOverrideEvent = (useBrandOverrideApi().eventName) || BRAND_OVERRIDE_EVENT;
+    this.globalMotionEvent = window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT || 'clear-seas:motion-updated';
+    this.globalMotionState = {
+      focusAmount: 0,
+      synergy: 0,
+      tiltX: 0,
+      tiltY: 0,
+      tiltStrength: 0,
+      bend: 0,
+      warp: 0,
+      scrollMomentum: 0,
+      scrollDirection: 0,
+      scrollSpeed: 0,
+      focusTrend: 0,
+      tiltSkew: 0,
+      timestamp: performance.now()
+    };
+    this.handleBrandOverridesChanged = () => {
+      const overridesApi = useBrandOverrideApi();
+      this.cards.forEach((cardData) => {
+        if (!cardData || !cardData.element) {
+          return;
+        }
+        cardData.brandOverrides = overridesApi.collect(cardData.element);
+        cardData.assetCycle = 0;
+        this.refreshBrandAssets(cardData, { keepOverrides: true });
+      });
+    };
+    window.addEventListener(this.brandOverrideEvent, this.handleBrandOverridesChanged);
+    this.handleGlobalMotionUpdate = (event) => {
+      const detail = event?.detail || {};
+      this.globalMotionState = {
+        focusAmount: Number(detail.focusAmount) || 0,
+        synergy: Number(detail.synergy) || 0,
+        tiltX: Number(detail.tiltX) || 0,
+        tiltY: Number(detail.tiltY) || 0,
+        tiltStrength: Number(detail.tiltStrength) || 0,
+        bend: Number(detail.bend) || 0,
+        warp: Number(detail.warp) || 0,
+        scrollMomentum: Number(detail.scrollMomentum) || 0,
+        scrollDirection: Number(detail.scrollDirection) || 0,
+        scrollSpeed: Number(detail.scrollSpeed) || 0,
+        focusTrend: Number(detail.focusTrend) || 0,
+        tiltSkew: Number(detail.tiltSkew) || 0,
+        timestamp: typeof detail.timestamp === 'number' ? detail.timestamp : performance.now()
+      };
+
+      this.cards.forEach((cardData) => {
+        if (!cardData?.element) {
+          return;
+        }
+        cardData.element.style.setProperty('--shared-focus-amount', this.globalMotionState.focusAmount.toFixed(4));
+        cardData.element.style.setProperty('--shared-synergy', this.globalMotionState.synergy.toFixed(4));
+        cardData.element.style.setProperty('--shared-tilt-x', this.globalMotionState.tiltX.toFixed(4));
+        cardData.element.style.setProperty('--shared-tilt-y', this.globalMotionState.tiltY.toFixed(4));
+        cardData.element.style.setProperty('--shared-tilt-strength', this.globalMotionState.tiltStrength.toFixed(4));
+        cardData.element.style.setProperty('--shared-bend', this.globalMotionState.bend.toFixed(4));
+        cardData.element.style.setProperty('--shared-warp', this.globalMotionState.warp.toFixed(4));
+        cardData.element.style.setProperty('--shared-scroll', this.globalMotionState.scrollMomentum.toFixed(4));
+        cardData.element.style.setProperty('--shared-scroll-direction', this.globalMotionState.scrollDirection.toFixed(0));
+        cardData.element.style.setProperty('--shared-scroll-speed', this.globalMotionState.scrollSpeed.toFixed(4));
+        cardData.element.style.setProperty('--shared-focus-trend', this.globalMotionState.focusTrend.toFixed(4));
+        cardData.element.style.setProperty('--shared-tilt-skew', this.globalMotionState.tiltSkew.toFixed(4));
+      });
+    };
+    window.addEventListener(this.globalMotionEvent, this.handleGlobalMotionUpdate);
+
+    this.pageProfile = window.__CLEAR_SEAS_PAGE_PROFILE || {
+      key: 'core-foundation',
+      palette: 'foundation',
+      imageSeed: 0,
+      videoSeed: 0,
+      overlay: {},
+      canvas: {},
+      videoPattern: null,
+      imageOrder: null,
+      videoOrder: null
+    };
+
     this.cardConfigs = {
       'hero-section': {
         roles: ['background'],
@@ -41,7 +158,54 @@ class CardSystemController {
         colorScheme: 'portfolio'
       }
     };
-    
+
+    const fallbackBrandAssets = {
+      images: [
+        'assets/Screenshot_20250430-141821.png',
+        'assets/Screenshot_20241012-073718.png',
+        'assets/Screenshot_20250430-142024~2.png',
+        'assets/Screenshot_20250430-142002~2.png',
+        'assets/Screenshot_20250430-142032~2.png',
+        'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+        'assets/file_0000000054a06230817873012865d150.png',
+        'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+        'assets/image_8 (1).png'
+      ],
+      videos: [
+        '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+        '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+        '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+        '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+        '1746496560073.mp4',
+        '1746500614769.mp4',
+        '1746576068221.mp4'
+      ]
+    };
+
+    const sharedBrandAssets = window.__CLEAR_SEAS_BRAND_ASSETS;
+    const sharedImages = Array.isArray(sharedBrandAssets?.images) && sharedBrandAssets.images.length
+      ? sharedBrandAssets.images
+      : fallbackBrandAssets.images;
+    const sharedVideos = Array.isArray(sharedBrandAssets?.videos) && sharedBrandAssets.videos.length
+      ? sharedBrandAssets.videos
+      : fallbackBrandAssets.videos;
+
+    this.brandAssets = {
+      images: [...sharedImages],
+      videos: [...sharedVideos]
+    };
+
+    this.brandAssignmentIndex = 0;
+    this.assetCursor = { images: 0, videos: 0 };
+    this.scrollTilt = 0;
+    this.scrollTiltTarget = 0;
+    this.scrollTiltRaf = null;
+    this.scrollMomentum = 0;
+
+    this.ensureBrandStyles();
+    this.setupScrollTiltSync();
+    this.applyScrollTiltToCards(this.scrollTilt);
+
     console.log('🎨 Card System Controller initialized');
   }
   
@@ -75,12 +239,34 @@ class CardSystemController {
       console.warn(`⚠️ Card element not found: ${cardId}`);
       return;
     }
-    
+
+    const overridesApi = useBrandOverrideApi();
+    const brandOverrides = overridesApi.collect(cardElement);
+
     const cardData = {
       element: cardElement,
       config: config,
       visualizers: new Map(),
-      active: false
+      active: false,
+      focusIntensity: 0,
+      clickPulse: 0,
+      pointer: {
+        rawX: 0.5,
+        rawY: 0.5,
+        smoothX: 0.5,
+        smoothY: 0.5,
+        bendTarget: 0.12,
+        bendSmooth: 0.12,
+        twistTarget: 0,
+        twistSmooth: 0
+      },
+      layers: {
+        overlay: null,
+        video: null
+      },
+      reactiveElements: [],
+      brandOverrides,
+      assetCycle: 0
     };
     
     // Create visualizers for each role
@@ -108,8 +294,12 @@ class CardSystemController {
     
     // Setup card-specific interactions
     this.setupCardInteractions(cardElement, cardData);
-    
+    this.decorateCard(cardElement, cardData);
+    this.registerReactiveElements(cardData);
+    this.startCardSynergyLoop(cardData);
+
     this.cards.set(cardId, cardData);
+    this.applyScrollTiltToCards(this.scrollTilt);
   }
   
   applyCardConfiguration(visualizer, config, role) {
@@ -149,6 +339,738 @@ class CardSystemController {
       visualizer.roleParams.intensity *= roleIntensityMods[role];
     }
   }
+
+  decorateCard(cardElement, cardData) {
+    if (!cardElement || cardElement.dataset.brandDecorated === 'true') return;
+
+    cardElement.dataset.brandDecorated = 'true';
+    cardElement.classList.add('card-brand-enhanced');
+    const overridesApi = useBrandOverrideApi();
+    const overrides = cardData.brandOverrides;
+    const overlaySettings = overridesApi.mergeOverlaySettings(this.pageProfile.overlay || {}, overrides ? overrides.overlay : null);
+    const canvasSettings = overridesApi.mergeCanvasSettings(this.pageProfile.canvas || {}, overrides ? overrides.canvas : null);
+    const palette = overridesApi.applyPalette(overrides, this.pageProfile.palette || 'foundation');
+    cardElement.dataset.brandPalette = palette;
+    cardElement.style.setProperty('--brand-overlay-opacity', overlaySettings.opacity != null ? String(overlaySettings.opacity) : '1');
+    cardElement.style.setProperty('--brand-overlay-filter', overlaySettings.filter || 'brightness(1)');
+    cardElement.style.setProperty('--brand-overlay-blend', overlaySettings.blend || 'screen');
+    cardElement.style.setProperty('--brand-overlay-rotate', overlaySettings.rotate || '0deg');
+    cardElement.style.setProperty('--brand-overlay-depth', overlaySettings.depth || '0px');
+    if (canvasSettings.scale != null) {
+      cardElement.style.setProperty('--card-canvas-scale', String(canvasSettings.scale));
+    }
+    if (canvasSettings.depth) {
+      cardElement.style.setProperty('--card-canvas-depth', canvasSettings.depth);
+    }
+    cardElement.dataset.focusState = cardElement.dataset.focusState || 'idle';
+    cardElement.style.setProperty('--scroll-tilt', this.scrollTilt.toFixed(4));
+    cardElement.style.setProperty('--visualizer-scroll-tilt', this.scrollTilt.toFixed(4));
+    cardElement.style.setProperty('--scroll-tilt-deg', `${(this.scrollTilt * 12).toFixed(2)}deg`);
+    cardElement.style.setProperty('--scroll-momentum', this.scrollMomentum.toFixed(4));
+
+    const targetContainer =
+      cardElement.querySelector('.visualization-container') ||
+      cardElement.querySelector('.card-preview') ||
+      cardElement.querySelector('.card-visual') ||
+      cardElement;
+
+    cardData.brandContainer = targetContainer;
+
+    if (targetContainer && !['relative', 'absolute', 'fixed'].includes(getComputedStyle(targetContainer).position)) {
+      targetContainer.style.position = 'relative';
+    }
+
+    this.expandCanvasBounds(targetContainer);
+    this.insertBrandOverlay(targetContainer, cardData);
+
+    const observer = new MutationObserver(() => {
+      this.expandCanvasBounds(targetContainer);
+      this.insertBrandOverlay(targetContainer, cardData);
+      this.registerReactiveElements(cardData);
+    });
+
+    observer.observe(targetContainer, { childList: true, subtree: true });
+
+    const previousCleanup = cardData.cleanup;
+    cardData.cleanup = () => {
+      observer.disconnect();
+      if (typeof previousCleanup === 'function') {
+        previousCleanup();
+      }
+    };
+
+    this.registerReactiveElements(cardData);
+  }
+
+  expandCanvasBounds(container) {
+    if (!container) return;
+    const canvases = container.querySelectorAll('canvas');
+    canvases.forEach(canvas => this.styleVisualizerCanvas(canvas));
+  }
+
+  styleVisualizerCanvas(canvas) {
+    if (!canvas || canvas.dataset.brandExpanded === 'true') return;
+
+    canvas.dataset.brandExpanded = 'true';
+    canvas.dataset.focusReactive = 'true';
+    canvas.style.position = 'absolute';
+    canvas.style.top = '50%';
+    canvas.style.left = '50%';
+    canvas.style.width = '135%';
+    canvas.style.height = '135%';
+    canvas.style.transform = 'translate(-50%, -50%) scale(1.05)';
+    canvas.style.transformOrigin = 'center';
+    canvas.style.pointerEvents = 'none';
+    canvas.style.borderRadius = '20px';
+    canvas.style.willChange = 'transform, filter';
+  }
+
+  insertBrandOverlay(container, cardData, options = {}) {
+    if (!container) return;
+
+    const force = options.force === true;
+    const existingOverlay = container.querySelector('.card-brand-overlay');
+    const existingVideo = container.querySelector('.card-brand-video');
+
+    if (!force && existingOverlay && existingVideo) {
+      return;
+    }
+
+    const overridesApi = options.overridesApi || useBrandOverrideApi();
+    const overrides = options.overrides !== undefined ? options.overrides : cardData?.brandOverrides;
+    const overlaySettings = overridesApi.mergeOverlaySettings(this.pageProfile.overlay || {}, overrides ? overrides.overlay : null);
+    const palette = overridesApi.applyPalette(overrides, this.pageProfile.palette || 'foundation');
+
+    const baseVideoPreference = this.shouldDecorateWithVideo(cardData);
+    const preferVideo = overridesApi.resolveMode(overrides, baseVideoPreference);
+    const allowOverlay = force || !existingOverlay;
+    const allowVideo = (force || !existingVideo) && (preferVideo || baseVideoPreference);
+    const cycleIndex = this.brandAssignmentIndex + (cardData?.assetCycle || 0);
+
+    let cachedVideo;
+    let cachedImage;
+    const getVideoCandidate = () => {
+      if (cachedVideo === undefined) {
+        cachedVideo = overridesApi.pickAsset(overrides, 'videos', cycleIndex, (index) => this.selectAssetWithType(this.brandAssets.videos, this.brandAssignmentIndex, 'videos'));
+      }
+      return cachedVideo;
+    };
+    const getImageCandidate = () => {
+      if (cachedImage === undefined) {
+        cachedImage = overridesApi.pickAsset(overrides, 'images', cycleIndex, (index) => this.selectAssetWithType(this.brandAssets.images, this.brandAssignmentIndex, 'images'));
+      }
+      return cachedImage;
+    };
+
+    let videoSrc = null;
+    let imageSrc = null;
+
+    if (preferVideo && allowVideo) {
+      videoSrc = getVideoCandidate();
+    }
+    if (!videoSrc && allowOverlay) {
+      imageSrc = getImageCandidate();
+    }
+    if (!videoSrc && allowVideo) {
+      videoSrc = getVideoCandidate();
+    }
+    if (!imageSrc && allowOverlay) {
+      imageSrc = getImageCandidate();
+    }
+
+    let assetApplied = false;
+
+    if (allowOverlay && imageSrc) {
+      const overlay = document.createElement('div');
+      overlay.className = 'card-brand-overlay';
+      overlay.style.setProperty('--brand-rotation', `${(Math.random() * 12 - 6).toFixed(2)}deg`);
+      overlay.style.backgroundImage = `url('${this.getMediaPath(imageSrc)}')`;
+      overlay.setAttribute('aria-hidden', 'true');
+      overlay.dataset.focusReactive = 'true';
+      overlay.dataset.brandPalette = palette;
+      overlay.style.setProperty('--brand-overlay-opacity', overlaySettings.opacity != null ? String(overlaySettings.opacity) : '1');
+      overlay.style.setProperty('--brand-overlay-filter', overlaySettings.filter || 'brightness(1)');
+      overlay.style.setProperty('--brand-overlay-blend', overlaySettings.blend || 'screen');
+      overlay.style.setProperty('--brand-overlay-rotate', overlaySettings.rotate || '0deg');
+      overlay.style.setProperty('--brand-overlay-depth', overlaySettings.depth || '0px');
+      container.appendChild(overlay);
+      if (cardData) {
+        cardData.layers.overlay = overlay;
+      }
+      assetApplied = true;
+    }
+
+    if (allowVideo && videoSrc) {
+      const video = document.createElement('video');
+      video.className = 'card-brand-video';
+      video.muted = true;
+      video.loop = true;
+      video.autoplay = true;
+      video.playsInline = true;
+      video.preload = 'metadata';
+      video.src = this.getMediaPath(videoSrc);
+      video.style.setProperty('--brand-rotation', `${(Math.random() * 10 - 5).toFixed(2)}deg`);
+      video.setAttribute('aria-hidden', 'true');
+      video.dataset.focusReactive = 'true';
+      video.dataset.brandPalette = palette;
+      video.style.setProperty('--brand-overlay-opacity', overlaySettings.opacity != null ? String(overlaySettings.opacity) : '1');
+      video.style.setProperty('--brand-overlay-filter', overlaySettings.filter || 'brightness(1)');
+      video.style.setProperty('--brand-overlay-blend', overlaySettings.blend || 'screen');
+      video.style.setProperty('--brand-overlay-rotate', overlaySettings.rotate || '0deg');
+      video.style.setProperty('--brand-overlay-depth', overlaySettings.depth || '0px');
+      video.addEventListener('error', () => {
+        if (video.parentElement) {
+          video.remove();
+        }
+        if (cardData) {
+          cardData.layers.video = null;
+          if (cardData.brandVideo === video) {
+            delete cardData.brandVideo;
+          }
+          this.registerReactiveElements(cardData);
+        }
+      });
+      video.addEventListener('loadeddata', () => {
+        video.play().catch(() => {});
+        if (cardData) {
+          this.registerReactiveElements(cardData);
+        }
+      });
+      if (existingOverlay && !force) {
+        container.insertBefore(video, existingOverlay);
+      } else {
+        container.appendChild(video);
+      }
+
+      if (cardData) {
+        cardData.brandVideo = video;
+        cardData.layers.video = video;
+      }
+      assetApplied = true;
+    }
+
+    if (assetApplied) {
+      this.brandAssignmentIndex++;
+      if (cardData) {
+        this.registerReactiveElements(cardData);
+      }
+    }
+  }
+
+  refreshBrandAssets(cardData, options = {}) {
+    if (!cardData) return;
+    const { keepOverrides = false } = options || {};
+    const overridesApi = useBrandOverrideApi();
+    if (!keepOverrides) {
+      cardData.brandOverrides = overridesApi.collect(cardData.element);
+    }
+    const overrides = cardData.brandOverrides;
+    const container = cardData.brandContainer ||
+      cardData.element.querySelector('.visualization-container') ||
+      cardData.element.querySelector('.card-preview') ||
+      cardData.element.querySelector('.card-visual') ||
+      cardData.element;
+    if (!container) {
+      return;
+    }
+    if (cardData.layers?.overlay?.parentElement) {
+      cardData.layers.overlay.remove();
+      cardData.layers.overlay = null;
+    }
+    if (cardData.layers?.video?.parentElement) {
+      cardData.layers.video.remove();
+      cardData.layers.video = null;
+    }
+    if (cardData.brandVideo) {
+      try {
+        cardData.brandVideo.pause();
+      } catch (error) {
+        // ignore pause errors
+      }
+      cardData.brandVideo = null;
+    }
+    this.insertBrandOverlay(container, cardData, { force: true, overridesApi, overrides });
+  }
+
+  advanceCardBrandCycle(cardData, trigger) {
+    if (!cardData) return;
+    const overridesApi = useBrandOverrideApi();
+    if (!overridesApi.shouldCycle(cardData.brandOverrides, trigger)) {
+      return;
+    }
+    cardData.assetCycle = overridesApi.nextCycleIndex(cardData.brandOverrides, cardData.assetCycle);
+    this.refreshBrandAssets(cardData);
+  }
+
+  registerReactiveElements(cardData) {
+    if (!cardData?.element) return;
+
+    const selectors = [
+      '.card-frame',
+      '.card-shell',
+      '.card-wrapper',
+      '.card-content',
+      '.card-foreground',
+      '.card-background',
+      '.card-visual',
+      '.visualization-container',
+      '.card-preview',
+      '.card-title',
+      '.card-subtitle',
+      '.card-description',
+      '.card-meta',
+      'img',
+      'video',
+      'canvas'
+    ];
+
+    const reactiveSet = new Set(cardData.reactiveElements || []);
+
+    selectors.forEach(selector => {
+      cardData.element.querySelectorAll(selector).forEach(el => {
+        if (el !== cardData.element) {
+          reactiveSet.add(el);
+        }
+      });
+    });
+
+    if (cardData.layers.overlay) {
+      reactiveSet.add(cardData.layers.overlay);
+    }
+    if (cardData.layers.video) {
+      reactiveSet.add(cardData.layers.video);
+    }
+
+    const reactiveElements = Array.from(reactiveSet).filter(el => el && el.isConnected);
+    reactiveElements.forEach(el => {
+      el.dataset.focusReactive = 'true';
+    });
+
+    cardData.reactiveElements = reactiveElements;
+  }
+
+  startCardSynergyLoop(cardData) {
+    if (!cardData?.element) return;
+
+    const animate = () => {
+      const targetFocus = cardData.active ? 1 : 0;
+      cardData.focusIntensity += (targetFocus - cardData.focusIntensity) * 0.12;
+
+      if (cardData.clickPulse > 0.001) {
+        cardData.clickPulse *= 0.92;
+      } else {
+        cardData.clickPulse = 0;
+      }
+
+      const pointer = cardData.pointer;
+      pointer.smoothX += (pointer.rawX - pointer.smoothX) * 0.18;
+      pointer.smoothY += (pointer.rawY - pointer.smoothY) * 0.18;
+      pointer.bendSmooth += ((pointer.bendTarget ?? 0.12) - (pointer.bendSmooth ?? 0.12)) * 0.16;
+      pointer.twistSmooth += ((pointer.twistTarget ?? 0) - (pointer.twistSmooth ?? 0)) * 0.2;
+
+      const tiltX = (pointer.smoothY - 0.5) * 2;
+      const tiltY = (pointer.smoothX - 0.5) * 2;
+
+      cardData.currentTilt = { x: tiltX, y: tiltY };
+
+      this.applyCardSynergy(cardData, tiltX, tiltY);
+
+      cardData.synergyRaf = requestAnimationFrame(animate);
+    };
+
+    animate();
+
+    const previousCleanup = cardData.cleanup;
+    cardData.cleanup = () => {
+      if (cardData.synergyRaf) {
+        cancelAnimationFrame(cardData.synergyRaf);
+        cardData.synergyRaf = null;
+      }
+      if (typeof previousCleanup === 'function') {
+        previousCleanup();
+      }
+    };
+  }
+
+  applyCardSynergy(cardData, tiltX, tiltY) {
+    if (!cardData?.element) return;
+
+    const focus = Math.max(0, Math.min(1, cardData.focusIntensity));
+    const momentum = this.scrollMomentum || 0;
+    const sharedMotion = this.globalMotionState || {};
+    const sharedFocusAmount = Math.max(0, Math.min(1, sharedMotion.focusAmount || 0));
+    const sharedSynergy = Math.max(0, Math.min(1.2, sharedMotion.synergy || 0));
+    const sharedTiltX = sharedMotion.tiltX || 0;
+    const sharedTiltY = sharedMotion.tiltY || 0;
+    const sharedTiltStrength = Math.max(0, sharedMotion.tiltStrength || 0);
+    const sharedBend = Math.max(0, sharedMotion.bend || 0);
+    const sharedWarp = sharedMotion.warp || 0;
+    const sharedScroll = sharedMotion.scrollMomentum || 0;
+
+    const tiltBlendRatio = 0.35 + sharedTiltStrength * 0.25;
+    const fusedTiltX = tiltX + sharedTiltY * tiltBlendRatio + sharedScroll * 0.16;
+    const fusedTiltY = tiltY + sharedTiltX * tiltBlendRatio - sharedScroll * 0.12;
+    const synergyLift = sharedSynergy * 0.35 + sharedFocusAmount * 0.25;
+
+    const parallaxStrength = 26 + focus * 24 + synergyLift * 18;
+    const parallaxX = fusedTiltY * parallaxStrength;
+    const parallaxY = fusedTiltX * -parallaxStrength;
+    const depthBase = focus * 60 + Math.abs(momentum) * 80 + synergyLift * 30 + sharedBend * 32;
+
+    cardData.element.style.setProperty('--focus-intensity', focus.toFixed(4));
+    cardData.element.style.setProperty('--focus-tilt-x-deg', `${(-fusedTiltX * 14).toFixed(2)}deg`);
+    cardData.element.style.setProperty('--focus-tilt-y-deg', `${(fusedTiltY * 18).toFixed(2)}deg`);
+    cardData.element.style.setProperty('--focus-parallax-x', `${parallaxX.toFixed(3)}px`);
+    cardData.element.style.setProperty('--focus-parallax-y', `${parallaxY.toFixed(3)}px`);
+    cardData.element.style.setProperty('--focus-depth', `${depthBase.toFixed(2)}px`);
+    cardData.element.style.setProperty('--focus-pulse', cardData.clickPulse.toFixed(3));
+    cardData.element.style.setProperty('--shared-focus-amount', sharedFocusAmount.toFixed(4));
+    cardData.element.style.setProperty('--shared-synergy', sharedSynergy.toFixed(4));
+    cardData.element.style.setProperty('--shared-tilt-x', sharedTiltX.toFixed(4));
+    cardData.element.style.setProperty('--shared-tilt-y', sharedTiltY.toFixed(4));
+    cardData.element.style.setProperty('--shared-tilt-strength', sharedTiltStrength.toFixed(4));
+    cardData.element.style.setProperty('--shared-bend', sharedBend.toFixed(4));
+    cardData.element.style.setProperty('--shared-warp', sharedWarp.toFixed(4));
+    cardData.element.style.setProperty('--shared-scroll', sharedScroll.toFixed(4));
+
+    const overlay = cardData.layers.overlay;
+    if (overlay) {
+      overlay.style.opacity = '';
+    }
+
+    if (cardData.brandVideo) {
+      const playbackRate = 0.85 + focus * 0.5 + Math.abs(momentum + sharedScroll) * 0.25 + synergyLift * 0.12;
+      cardData.brandVideo.playbackRate = Math.max(0.75, Math.min(1.8, playbackRate));
+    }
+
+    const sharedTiltTarget = this.scrollTilt + fusedTiltY * 0.45 + sharedTiltY * 0.35;
+    cardData.visualizers.forEach(visualizer => {
+      if (!visualizer) return;
+      const baseXW = visualizer.variantParams?.rot4dXW || 0;
+      const baseYW = visualizer.variantParams?.rot4dYW || 0;
+      const baseZW = visualizer.variantParams?.rot4dZW || 0;
+      const focusEnergy = focus * 0.6 + synergyLift * 0.35;
+
+      if (visualizer.externalRotations) {
+        visualizer.externalRotations.xw = baseXW + (-fusedTiltX * 0.55 + (momentum + sharedScroll) * 0.4) * focusEnergy;
+        visualizer.externalRotations.yw = baseYW + (fusedTiltY * 0.65 + (momentum + sharedScroll) * -0.35) * focusEnergy;
+        visualizer.externalRotations.zw = baseZW + (fusedTiltX * 0.35 + fusedTiltY * 0.25 + sharedWarp * 0.3) * focusEnergy;
+      }
+
+      if (typeof visualizer.scrollTiltTarget === 'number') {
+        visualizer.scrollTiltTarget = sharedTiltTarget;
+      }
+    });
+
+    const pointerState = cardData.pointer || {};
+    const bendProgress = Math.max(0, Math.min(1, pointerState.bendSmooth ?? 0.12));
+    const pointerMagnitude = Math.min(1.25, Math.hypot(fusedTiltX, fusedTiltY));
+    const focusBoost = focus * 0.35;
+    const momentumBoost = Math.min(0.4, Math.abs(momentum) * 0.22);
+    const synergyBoost = Math.min(0.5, synergyLift * 0.6 + sharedBend * 0.45);
+    const bendIntensity = Math.min(0.95,
+      0.08 + bendProgress * 0.7 + pointerMagnitude * 0.26 + focusBoost + momentumBoost + synergyBoost
+    );
+    const bendTiltX = -fusedTiltX * 12 * bendIntensity;
+    const bendTiltY = fusedTiltY * 14 * bendIntensity;
+    const bendSkewX = -(fusedTiltY + sharedTiltY * 0.2) * 6 * bendIntensity;
+    const bendSkewY = (fusedTiltX + sharedTiltX * 0.2) * 5 * bendIntensity;
+    const bendTwist = (pointerState.twistSmooth ?? 0) * 18 * bendIntensity;
+    const bendDepth = bendIntensity * 28 + focus * 18 + Math.abs(momentum + sharedScroll) * 16 + synergyLift * 20;
+    const visualizerDepth = bendDepth * 0.6 + bendIntensity * 12 + sharedBend * 12;
+
+    cardData.element.style.setProperty('--bend-intensity', bendIntensity.toFixed(3));
+    cardData.element.style.setProperty('--bend-tilt-x-deg', `${bendTiltX.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-tilt-y-deg', `${bendTiltY.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-skew-x-deg', `${bendSkewX.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-skew-y-deg', `${bendSkewY.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-twist-deg', `${bendTwist.toFixed(3)}deg`);
+    cardData.element.style.setProperty('--bend-depth', `${bendDepth.toFixed(3)}px`);
+    cardData.element.style.setProperty('--visualizer-bend-depth', `${visualizerDepth.toFixed(3)}px`);
+
+    cardData.reactiveElements?.forEach(el => {
+      if (!el.isConnected) return;
+      el.style.setProperty('--focus-intensity', focus.toFixed(4));
+      el.style.setProperty('--shared-focus-amount', sharedFocusAmount.toFixed(4));
+      el.style.setProperty('--shared-synergy', sharedSynergy.toFixed(4));
+      el.style.setProperty('--shared-tilt-x', sharedTiltX.toFixed(4));
+      el.style.setProperty('--shared-tilt-y', sharedTiltY.toFixed(4));
+      el.style.setProperty('--shared-bend', sharedBend.toFixed(4));
+      el.style.setProperty('--shared-scroll', sharedScroll.toFixed(4));
+    });
+  }
+
+  shouldDecorateWithVideo(cardData) {
+    const element = cardData?.element;
+    if (!element) return false;
+    if (element.dataset.brandVideo === 'true') return true;
+    if (element.dataset.brandVideo === 'false') return false;
+    if (element.classList.contains('brand-video-card')) return true;
+    const pattern = Array.isArray(this.pageProfile.videoPattern) ? this.pageProfile.videoPattern : null;
+    if (pattern && pattern.length) {
+      const index = this.brandAssignmentIndex % pattern.length;
+      return Boolean(pattern[index]);
+    }
+    return this.brandAssignmentIndex % 3 === 0;
+  }
+
+  selectAsset(list, index) {
+    return this.selectAssetWithType(list, index, 'images');
+  }
+
+  selectAssetWithType(list, index, typeHint) {
+    if (!Array.isArray(list) || list.length === 0) return null;
+    const cursorKey = typeHint === 'videos' ? 'videos' : 'images';
+    if (!this.assetCursor) {
+      this.assetCursor = { images: 0, videos: 0 };
+    }
+    const cursor = this.assetCursor[cursorKey] || 0;
+    const order = cursorKey === 'videos' ? this.pageProfile.videoOrder : this.pageProfile.imageOrder;
+    const seed = cursorKey === 'videos' ? (this.pageProfile.videoSeed || 0) : (this.pageProfile.imageSeed || 0);
+    let assetIndex;
+    if (Array.isArray(order) && order.length) {
+      const orderIndex = (seed + cursor) % order.length;
+      assetIndex = order[orderIndex % order.length] % list.length;
+    } else {
+      assetIndex = (seed + cursor) % list.length;
+    }
+    this.assetCursor[cursorKey] = cursor + 1;
+    return list[assetIndex];
+  }
+
+  getMediaPath(assetPath) {
+    if (!assetPath) return '';
+    const trimmed = assetPath.trim();
+    if (trimmed.startsWith('http')) {
+      return trimmed;
+    }
+    if (trimmed.startsWith('assets/')) {
+      return encodeURI(trimmed);
+    }
+    return encodeURI(`./${trimmed}`);
+  }
+
+  ensureBrandStyles() {
+    if (document.getElementById('card-brand-enhancements')) return;
+
+    const style = document.createElement('style');
+    style.id = 'card-brand-enhancements';
+    style.textContent = `
+      .card-brand-enhanced {
+        position: relative;
+        --scroll-tilt: 0;
+        --visualizer-scroll-tilt: 0;
+        --scroll-momentum: 0;
+        --focus-intensity: 0;
+        --focus-tilt-x-deg: 0deg;
+        --focus-tilt-y-deg: 0deg;
+        --focus-parallax-x: 0px;
+        --focus-parallax-y: 0px;
+        --focus-depth: 0px;
+        --focus-pulse: 0;
+        --shared-focus-signal: var(--shared-focus-amount, var(--global-focus-amount, 0));
+        --shared-synergy-signal: var(--shared-synergy, var(--global-synergy-glow, 0));
+        --shared-tilt-x-signal: var(--shared-tilt-x, var(--global-tilt-x, 0));
+        --shared-tilt-y-signal: var(--shared-tilt-y, var(--global-tilt-y, 0));
+        --shared-bend-signal: var(--shared-bend, var(--global-bend-intensity, 0));
+        --shared-scroll-signal: var(--shared-scroll, var(--global-scroll-momentum, 0));
+        --shared-warp-signal: var(--shared-warp, var(--global-warp, 0));
+      }
+
+      .card-brand-enhanced .visualization-container,
+      .card-brand-enhanced .card-preview,
+      .card-brand-enhanced .card-visual {
+        overflow: visible !important;
+        transform-style: preserve-3d;
+      }
+
+      .card-brand-enhanced [data-focus-reactive="true"] {
+        position: relative;
+        transition:
+          transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+          filter 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+          opacity 0.6s ease,
+          box-shadow 0.6s ease;
+        transform:
+          perspective(1400px)
+          rotateX(calc(var(--focus-tilt-x-deg) + var(--shared-tilt-y-signal) * -12deg))
+          rotateY(calc(var(--focus-tilt-y-deg) + var(--shared-tilt-x-signal) * 12deg))
+          translate3d(
+            calc(var(--focus-parallax-x) * 0.45 + var(--shared-scroll-signal) * -8px),
+            calc(var(--focus-parallax-y) * 0.45 + var(--shared-scroll-signal) * 10px),
+            calc(var(--focus-depth) + var(--shared-bend-signal) * 18px)
+          );
+        filter:
+          saturate(calc(1 + var(--focus-intensity) * 0.2 + var(--shared-synergy-signal) * 0.2))
+          brightness(calc(1 + var(--focus-intensity) * 0.15 + var(--shared-focus-signal) * 0.12));
+        will-change: transform, filter, opacity;
+      }
+
+      .card-brand-enhanced[data-focus-state="active"] [data-focus-reactive="true"],
+      .card-brand-enhanced[data-focus-state="selected"] [data-focus-reactive="true"] {
+        box-shadow:
+          0 0 calc(18px + 22px * var(--focus-intensity)) rgba(0, 255, 255, 0.25),
+          0 0 calc(28px + 24px * var(--focus-intensity)) rgba(255, 0, 255, 0.22);
+      }
+
+      .card-brand-enhanced canvas,
+      .card-brand-enhanced .visualizer-canvas {
+        will-change: transform, filter;
+      }
+
+      .card-brand-enhanced canvas.card-visualizer-canvas,
+      .card-brand-enhanced canvas.visualizer-canvas,
+      .card-brand-enhanced canvas[data-visualizer],
+      .card-brand-enhanced canvas[data-webgl] {
+        position: absolute !important;
+        top: 50% !important;
+        left: 50% !important;
+        width: 135% !important;
+        height: 135% !important;
+        transform: translate(-50%, -50%) scale(1.12)
+          rotateX(calc(var(--visualizer-scroll-tilt, 0) * -6deg + var(--focus-tilt-x-deg) + var(--shared-tilt-y-signal) * -12deg))
+          rotateY(calc(var(--visualizer-scroll-tilt, 0) * 3deg + var(--focus-tilt-y-deg) + var(--shared-tilt-x-signal) * 12deg))
+          translateZ(calc(var(--focus-depth, 0px) * 0.32 + var(--scroll-momentum) * 22px + var(--shared-bend-signal) * 24px + var(--shared-focus-signal) * 14px));
+        transform-origin: center;
+        pointer-events: none;
+        border-radius: 20px;
+        filter: saturate(calc(1.08 + var(--focus-intensity) * 0.18 + var(--shared-synergy-signal) * 0.22))
+          brightness(calc(1.04 + var(--focus-intensity) * 0.22 + var(--shared-focus-signal) * 0.15));
+        box-shadow:
+          0 0 calc(45px + 35px * var(--focus-intensity)) rgba(0, 255, 255, 0.22),
+          0 0 calc(85px + 35px * var(--focus-intensity)) rgba(255, 0, 255, 0.18);
+      }
+
+      .card-brand-overlay {
+        position: absolute;
+        inset: -25%;
+        background-position: center;
+        background-size: contain;
+        background-repeat: no-repeat;
+        opacity: calc((0.24 + var(--focus-intensity) * 0.28 + var(--focus-pulse) * 0.18 + var(--shared-synergy-signal) * 0.18 + var(--shared-focus-signal) * 0.12) * var(--brand-overlay-opacity, 1));
+        mix-blend-mode: var(--brand-overlay-blend, screen);
+        pointer-events: none;
+        transform:
+          rotate(var(--brand-rotation, 0deg))
+          translate3d(
+            calc(var(--focus-parallax-x) * -0.35 + var(--scroll-momentum) * -14px + var(--shared-scroll-signal) * -12px),
+            calc(var(--focus-parallax-y) * 0.35 + var(--scroll-momentum) * 18px + var(--shared-scroll-signal) * 16px),
+            calc(var(--focus-depth, 0px) * 0.45 + var(--scroll-momentum) * 28px + var(--shared-bend-signal) * 26px + var(--brand-overlay-depth, 0px))
+          )
+          scale(calc(1.04 + var(--focus-intensity) * 0.08 + var(--focus-pulse) * 0.04 + var(--shared-synergy-signal) * 0.08));
+        animation: cardBrandFloat 18s ease-in-out infinite alternate;
+        filter:
+          saturate(calc(1.2 + var(--focus-intensity) * 0.25 + var(--shared-synergy-signal) * 0.25))
+          drop-shadow(0 0 calc(25px + 25px * var(--focus-intensity) + var(--shared-synergy-signal) * 18px) rgba(0, 255, 255, 0.25))
+          var(--brand-overlay-filter, brightness(1));
+      }
+
+      .card-brand-video {
+        position: absolute;
+        inset: -30%;
+        object-fit: cover;
+        opacity: calc((0.22 + var(--focus-intensity) * 0.35 + var(--focus-pulse) * 0.22 + var(--shared-synergy-signal) * 0.2) * var(--brand-overlay-opacity, 1));
+        mix-blend-mode: var(--brand-overlay-blend, lighten);
+        pointer-events: none;
+        border-radius: 28px;
+        transform:
+          rotate(var(--brand-rotation, 0deg))
+          translate3d(
+            calc(var(--focus-parallax-x) * -0.28 + var(--scroll-momentum) * -10px + var(--shared-scroll-signal) * -12px),
+            calc(var(--focus-parallax-y) * 0.28 + var(--scroll-momentum) * 20px + var(--shared-scroll-signal) * 18px),
+            calc(var(--focus-depth, 0px) * 0.65 + var(--scroll-momentum) * 36px + var(--shared-bend-signal) * 32px + var(--brand-overlay-depth, 0px))
+          )
+          scale(calc(1.05 + var(--focus-intensity) * 0.08 + var(--shared-synergy-signal) * 0.1));
+        filter:
+          saturate(calc(1.2 + var(--focus-intensity) * 0.3 + var(--shared-synergy-signal) * 0.25))
+          contrast(calc(1.05 + var(--focus-intensity) * 0.2 + var(--shared-focus-signal) * 0.14))
+          blur(0.2px)
+          var(--brand-overlay-filter, brightness(1));
+        animation: cardBrandDrift 24s ease-in-out infinite;
+      }
+
+      @keyframes cardBrandFloat {
+        0% { transform: rotate(var(--brand-rotation, 0deg)) translate3d(-5%, -5%, 0); }
+        50% { transform: rotate(calc(var(--brand-rotation, 0deg) + 4deg)) translate3d(6%, 4%, 10px); }
+        100% { transform: rotate(calc(var(--brand-rotation, 0deg) - 3deg)) translate3d(-4%, 6%, -6px); }
+      }
+
+      @keyframes cardBrandDrift {
+        0% { transform: rotate(var(--brand-rotation, 0deg)) scale(1.02); opacity: 0.18; }
+        50% { transform: rotate(calc(var(--brand-rotation, 0deg) + 2deg)) scale(1.08); opacity: 0.33; }
+        100% { transform: rotate(calc(var(--brand-rotation, 0deg) - 2deg)) scale(1.04); opacity: 0.22; }
+      }
+    `;
+
+    document.head.appendChild(style);
+  }
+
+  setupScrollTiltSync() {
+    const wheelHandler = (event) => {
+      const delta = Math.max(-200, Math.min(200, event.deltaY || 0));
+      const normalized = delta / 160;
+      this.scrollTiltTarget += normalized;
+      this.scrollTiltTarget = Math.max(-3, Math.min(3, this.scrollTiltTarget));
+
+      if (!this.scrollTiltRaf) {
+        this.scrollTiltRaf = requestAnimationFrame(() => this.updateScrollTiltAnimation());
+      }
+    };
+
+    window.addEventListener('wheel', wheelHandler, { passive: true });
+
+    window.addEventListener('scroll', () => {
+      if (!this.scrollTiltRaf) {
+        this.scrollTiltRaf = requestAnimationFrame(() => this.updateScrollTiltAnimation());
+      }
+    }, { passive: true });
+  }
+
+  updateScrollTiltAnimation() {
+    this.scrollTilt += (this.scrollTiltTarget - this.scrollTilt) * 0.2;
+    this.scrollTiltTarget *= 0.88;
+    const momentumDelta = this.scrollTiltTarget - this.scrollTilt;
+    this.scrollMomentum = this.scrollMomentum * 0.82 + momentumDelta * 0.35;
+
+    if (Math.abs(this.scrollTilt) < 0.0005) {
+      this.scrollTilt = 0;
+    }
+
+    this.applyScrollTiltToCards(this.scrollTilt);
+
+    if (Math.abs(this.scrollTilt) > 0.001 || Math.abs(this.scrollTiltTarget) > 0.001) {
+      this.scrollTiltRaf = requestAnimationFrame(() => this.updateScrollTiltAnimation());
+    } else {
+      this.scrollTiltRaf = null;
+      this.scrollTilt = 0;
+      this.scrollTiltTarget = 0;
+      this.scrollMomentum = 0;
+      this.applyScrollTiltToCards(this.scrollTilt);
+    }
+  }
+
+  applyScrollTiltToCards(tiltValue) {
+    const clamped = Math.max(-2, Math.min(2, tiltValue));
+    const tiltString = clamped.toFixed(4);
+
+    document.documentElement.style.setProperty('--scroll-tilt', tiltString);
+    document.documentElement.style.setProperty('--visualizer-scroll-tilt', tiltString);
+    document.documentElement.style.setProperty('--scroll-tilt-deg', `${(clamped * 12).toFixed(2)}deg`);
+    document.documentElement.style.setProperty('--scroll-momentum', this.scrollMomentum.toFixed(4));
+
+    this.cards.forEach(cardData => {
+      if (cardData?.element) {
+        cardData.element.style.setProperty('--scroll-tilt', tiltString);
+        cardData.element.style.setProperty('--visualizer-scroll-tilt', tiltString);
+        cardData.element.style.setProperty('--scroll-tilt-deg', `${(clamped * 12).toFixed(2)}deg`);
+        cardData.element.style.setProperty('--scroll-momentum', this.scrollMomentum.toFixed(4));
+      }
+    });
+
+    window.dispatchEvent(new CustomEvent('visualizer-scroll-tilt', {
+      detail: { tilt: clamped }
+    }));
+  }
   
   setupCardInteractions(cardElement, cardData) {
     let isHovered = false;
@@ -157,27 +1079,48 @@ class CardSystemController {
     // Enhanced mouse tracking
     const handleMouseMove = (e) => {
       if (!isHovered) return;
-      
+
       const rect = cardElement.getBoundingClientRect();
       mouseX = (e.clientX - rect.left) / rect.width;
       mouseY = (e.clientY - rect.top) / rect.height;
-      
-      // Update all visualizers for this card
+      mouseX = Math.max(0, Math.min(1, mouseX));
+      mouseY = Math.max(0, Math.min(1, mouseY));
+
+      const offsetX = mouseX - 0.5;
+      const offsetY = 0.5 - mouseY;
+      const pointerDistance = Math.min(Math.hypot(offsetX, offsetY) * 1.35, 1.1);
+      const dynamicMomentum = Math.abs(this.scrollMomentum || 0);
+      const bendTarget = Math.min(1, 0.18 + pointerDistance * 1.1 + dynamicMomentum * 0.28);
+      const twistTarget = offsetX * offsetY * 1.2;
+
+      // Update all visualizers for this card with bend-aware intensity
       for (const visualizer of cardData.visualizers.values()) {
-        visualizer.updateInteraction(mouseX, mouseY, 1.0);
+        visualizer.updateInteraction(mouseX, mouseY, bendTarget);
       }
-      
+
       // Update CSS custom properties for card transforms
       cardElement.style.setProperty('--mouse-x', (mouseX * 100) + '%');
       cardElement.style.setProperty('--mouse-y', (mouseY * 100) + '%');
-      cardElement.style.setProperty('--bend-intensity', '1');
+      cardElement.style.setProperty('--bend-intensity', bendTarget.toFixed(3));
+
+      cardData.pointer.rawX = mouseX;
+      cardData.pointer.rawY = mouseY;
+      cardData.pointer.bendTarget = bendTarget;
+      cardData.pointer.twistTarget = twistTarget;
     };
-    
+
     const handleMouseEnter = () => {
       isHovered = true;
       cardData.active = true;
       cardElement.classList.add('visualizer-active');
-      
+      cardElement.dataset.focusState = 'active';
+
+      this.advanceCardBrandCycle(cardData, 'focus');
+
+      cardData.pointer.bendTarget = Math.max(cardData.pointer.bendTarget || 0, 0.24);
+      cardData.pointer.twistTarget = cardData.pointer.twistTarget || 0;
+      cardElement.style.setProperty('--bend-intensity', cardData.pointer.bendTarget.toFixed(3));
+
       // Boost reactivity for all visualizers
       for (const visualizer of cardData.visualizers.values()) {
         visualizer.reactivity = 1.5;
@@ -190,32 +1133,53 @@ class CardSystemController {
       isHovered = false;
       cardData.active = false;
       cardElement.classList.remove('visualizer-active');
-      
+      cardElement.dataset.focusState = 'idle';
+
       // Reset visualizers
       for (const visualizer of cardData.visualizers.values()) {
         visualizer.reactivity = 1.0;
         visualizer.mouseIntensity *= 0.8;
       }
-      
+
       // Reset CSS transforms
       cardElement.style.setProperty('--mouse-x', '50%');
       cardElement.style.setProperty('--mouse-y', '50%');
       cardElement.style.setProperty('--bend-intensity', '0');
+      cardElement.style.setProperty('--bend-tilt-x-deg', '0deg');
+      cardElement.style.setProperty('--bend-tilt-y-deg', '0deg');
+      cardElement.style.setProperty('--bend-skew-x-deg', '0deg');
+      cardElement.style.setProperty('--bend-skew-y-deg', '0deg');
+      cardElement.style.setProperty('--bend-twist-deg', '0deg');
+      cardElement.style.setProperty('--bend-depth', '0px');
+      cardElement.style.setProperty('--visualizer-bend-depth', '0px');
+
+      cardData.pointer.rawX = 0.5;
+      cardData.pointer.rawY = 0.5;
+      cardData.pointer.bendTarget = 0.12;
+      cardData.pointer.twistTarget = 0;
     };
-    
+
     const handleClick = (e) => {
       const rect = cardElement.getBoundingClientRect();
       const clickX = (e.clientX - rect.left) / rect.width;
       const clickY = (e.clientY - rect.top) / rect.height;
-      
+
+      this.advanceCardBrandCycle(cardData, 'click');
+
       // Trigger click effect on all visualizers
       for (const visualizer of cardData.visualizers.values()) {
         visualizer.triggerClick(clickX, clickY);
       }
-      
+
+      cardData.clickPulse = 1;
+      cardElement.dataset.focusState = 'selected';
+      setTimeout(() => {
+        cardElement.dataset.focusState = cardData.active ? 'active' : 'idle';
+      }, 420);
+
       console.log(`💥 Card clicked: ${cardElement.id}`);
     };
-    
+
     // Add event listeners
     cardElement.addEventListener('mousemove', handleMouseMove, { passive: true });
     cardElement.addEventListener('mouseenter', handleMouseEnter);
@@ -223,11 +1187,15 @@ class CardSystemController {
     cardElement.addEventListener('click', handleClick);
     
     // Store cleanup functions
+    const previousCleanup = cardData.cleanup;
     cardData.cleanup = () => {
       cardElement.removeEventListener('mousemove', handleMouseMove);
       cardElement.removeEventListener('mouseenter', handleMouseEnter);
       cardElement.removeEventListener('mouseleave', handleMouseLeave);
       cardElement.removeEventListener('click', handleClick);
+      if (typeof previousCleanup === 'function') {
+        previousCleanup();
+      }
     };
   }
   
@@ -349,7 +1317,15 @@ class CardSystemController {
     if (cardData.cleanup) {
       cardData.cleanup();
     }
-    
+
+    if (cardData.brandVideo?.parentElement) {
+      cardData.brandVideo.remove();
+    }
+    const overlay = cardData.element?.querySelector('.card-brand-overlay');
+    if (overlay) {
+      overlay.remove();
+    }
+
     this.cards.delete(cardId);
     console.log(`🗑️ Card destroyed: ${cardId}`);
   }
@@ -378,22 +1354,44 @@ class CardSystemController {
 
 // Global card system instance
 window.cardSystemController = null;
+window.cardSystemStatusInterval = null;
 
-// Initialize when DOM is loaded
-document.addEventListener('DOMContentLoaded', async () => {
+async function bootCardSystem() {
+  if (window.cardSystemController) {
+    return window.cardSystemController;
+  }
+
   // Wait a bit for other scripts to load
-  await new Promise(resolve => setTimeout(resolve, 500));
-  
+  await new Promise(resolve => setTimeout(resolve, 200));
+
   window.cardSystemController = new CardSystemController();
   await window.cardSystemController.initialize();
-  
-  // Debug status logging
-  setInterval(() => {
-    if (window.cardSystemController) {
-      const status = window.cardSystemController.getCardStatus();
-      console.log('🎨 Card System Status:', status);
-    }
-  }, 10000); // Log every 10 seconds
-});
+
+  if (!window.cardSystemStatusInterval) {
+    window.cardSystemStatusInterval = setInterval(() => {
+      if (window.cardSystemController) {
+        const status = window.cardSystemController.getCardStatus();
+        console.log('🎨 Card System Status:', status);
+      }
+    }, 10000); // Log every 10 seconds
+  }
+
+  return window.cardSystemController;
+}
+
+window.bootCardSystem = bootCardSystem;
+
+const handleReady = () => {
+  bootCardSystem().catch(error => {
+    console.error('❌ Failed to boot card system:', error);
+  });
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', handleReady);
+} else {
+  handleReady();
+}
 
 console.log('🎨 Card System Initializer loaded');
+

--- a/scripts/clear-seas-ai.js
+++ b/scripts/clear-seas-ai.js
@@ -1033,6 +1033,89 @@ class BackgroundFieldController {
     }
 }
 
+const BRAND_LIBRARY_DEFAULTS = {
+    overlays: [
+        'assets/Screenshot_20250430-141821.png',
+        'assets/Screenshot_20250430-142002~2.png',
+        'assets/Screenshot_20250430-142024~2.png',
+        'assets/Screenshot_20250430-142032~2.png',
+        'assets/Screenshot_20241012-073718.png',
+        'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+        'assets/file_0000000054a06230817873012865d150.png',
+        'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+        'assets/image_8 (1).png'
+    ],
+    videos: [
+        '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+        '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+        '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+        '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+        '1746496560073.mp4',
+        '1746500614769.mp4',
+        '1746576068221.mp4'
+    ],
+    logos: [
+        'assets/clear-seas-logo-aurora.svg',
+        'assets/clear-seas-monogram.svg'
+    ]
+};
+
+function ensureSharedBrandLibrary() {
+    const mergeUnique = (target, source) => {
+        if (!Array.isArray(source)) {
+            return target;
+        }
+        source.forEach((item) => {
+            if (typeof item === 'string' && !target.includes(item)) {
+                target.push(item);
+            }
+        });
+        return target;
+    };
+
+    const existing = window.ClearSeasBrandLibrary || { overlays: [], videos: [], logos: [], cursor: 0 };
+    mergeUnique(existing.overlays, BRAND_LIBRARY_DEFAULTS.overlays);
+    mergeUnique(existing.videos, BRAND_LIBRARY_DEFAULTS.videos);
+    mergeUnique(existing.logos, BRAND_LIBRARY_DEFAULTS.logos);
+
+    if (!Number.isFinite(existing.cursor)) {
+        existing.cursor = 0;
+    }
+
+    const getPool = (preference) => {
+        const pref = (preference || '').toLowerCase();
+        if (pref.startsWith('video')) {
+            return existing.videos;
+        }
+        if (pref.startsWith('logo')) {
+            return existing.logos.length ? existing.logos : existing.overlays;
+        }
+        if (pref.startsWith('overlay') || pref.startsWith('image') || pref.startsWith('brand')) {
+            return existing.overlays.length ? existing.overlays : existing.logos;
+        }
+        return [...existing.videos, ...existing.overlays, ...existing.logos];
+    };
+
+    const acquire = (preference) => {
+        const pool = getPool(preference);
+        if (!pool.length) {
+            return null;
+        }
+        const index = Math.abs(existing.cursor) % pool.length;
+        existing.cursor += 1;
+        const src = pool[index];
+        const type = typeof src === 'string' && src.toLowerCase().endsWith('.mp4') ? 'video' : 'image';
+        return { src, type };
+    };
+
+    existing.acquire = acquire;
+    window.ClearSeasBrandLibrary = existing;
+    window.clearSeasAcquireBrandAsset = acquire;
+    return existing;
+}
+
+ensureSharedBrandLibrary();
+
 function easeOutCubic(x) {
     return 1 - Math.pow(1 - x, 3);
 }
@@ -1279,26 +1362,79 @@ function initialiseSectionTracking() {
 
 function createTiltController(elements, options = {}) {
     const targets = Array.from(elements);
+    if (!targets.length) {
+        return { enable() {}, disable() {} };
+    }
+
     const defaultStrength = options.strength || 6;
     const handlers = new WeakMap();
+    const scrollState = {
+        y: window.scrollY,
+        velocity: 0,
+        raf: null,
+        pending: false
+    };
+
+    const applyScroll = () => {
+        scrollState.pending = false;
+        const currentY = window.scrollY;
+        const delta = currentY - scrollState.y;
+        scrollState.y = currentY;
+        const normalizedVelocity = (window.innerHeight || 1) > 0 ? delta / window.innerHeight : 0;
+        scrollState.velocity = scrollState.velocity * 0.82 + normalizedVelocity * 0.18;
+
+        const scrollRotation = Math.max(Math.min(scrollState.velocity * (options.scrollStrength || 18), 18), -18);
+        const parallax = Math.max(Math.min(scrollState.velocity * (options.parallaxStrength || 320), 320), -320);
+        const rotXW = scrollRotation * 2.6;
+        const rotYW = scrollRotation * -1.8;
+        const rotZW = scrollRotation * 1.2;
+
+        targets.forEach((element) => {
+            element.style.setProperty('--tilt-scroll', `${scrollRotation.toFixed(3)}deg`);
+            element.style.setProperty('--visualizer-parallax', `${parallax.toFixed(3)}px`);
+            element.style.setProperty('--visualizer-rot-xw', `${rotXW.toFixed(3)}deg`);
+            element.style.setProperty('--visualizer-rot-yw', `${rotYW.toFixed(3)}deg`);
+            element.style.setProperty('--visualizer-rot-zw', `${rotZW.toFixed(3)}deg`);
+            element.style.setProperty('--scroll-velocity', scrollState.velocity.toFixed(4));
+        });
+
+        window.dispatchEvent(new CustomEvent('clear-seas-scroll-tilt', {
+            detail: {
+                rotation: scrollRotation,
+                velocity: scrollState.velocity
+            }
+        }));
+    };
+
+    const scheduleScroll = () => {
+        if (scrollState.pending) {
+            return;
+        }
+        scrollState.pending = true;
+        scrollState.raf = requestAnimationFrame(applyScroll);
+    };
 
     const enable = () => {
         targets.forEach((element) => {
             const strength = Number(element.dataset.tiltStrength || defaultStrength);
             const onMove = (event) => {
                 const rect = element.getBoundingClientRect();
-                const x = (event.clientX - rect.left) / rect.width;
-                const y = (event.clientY - rect.top) / rect.height;
+                const x = rect.width ? (event.clientX - rect.left) / rect.width : 0.5;
+                const y = rect.height ? (event.clientY - rect.top) / rect.height : 0.5;
                 const clampedX = Math.min(Math.max(x, 0), 1);
                 const clampedY = Math.min(Math.max(y, 0), 1);
                 const rotateX = (0.5 - clampedY) * strength;
                 const rotateY = (clampedX - 0.5) * strength;
                 element.style.setProperty('--tilt-x', `${rotateX.toFixed(2)}deg`);
                 element.style.setProperty('--tilt-y', `${rotateY.toFixed(2)}deg`);
+                element.style.setProperty('--tilt-x-value', rotateX.toFixed(4));
+                element.style.setProperty('--tilt-y-value', rotateY.toFixed(4));
             };
             const onLeave = () => {
                 element.style.setProperty('--tilt-x', '0deg');
                 element.style.setProperty('--tilt-y', '0deg');
+                element.style.setProperty('--tilt-x-value', '0');
+                element.style.setProperty('--tilt-y-value', '0');
             };
 
             element.addEventListener('pointermove', onMove);
@@ -1306,6 +1442,9 @@ function createTiltController(elements, options = {}) {
             element.addEventListener('pointerup', onLeave);
             handlers.set(element, { onMove, onLeave });
         });
+
+        window.addEventListener('scroll', scheduleScroll, { passive: true });
+        scheduleScroll();
     };
 
     const disable = () => {
@@ -1319,8 +1458,24 @@ function createTiltController(elements, options = {}) {
             element.removeEventListener('pointerup', entry.onLeave);
             element.style.setProperty('--tilt-x', '0deg');
             element.style.setProperty('--tilt-y', '0deg');
+            element.style.setProperty('--tilt-x-value', '0');
+            element.style.setProperty('--tilt-y-value', '0');
+            element.style.setProperty('--tilt-scroll', '0deg');
+            element.style.setProperty('--visualizer-parallax', '0px');
+            element.style.setProperty('--visualizer-rot-xw', '0deg');
+            element.style.setProperty('--visualizer-rot-yw', '0deg');
+            element.style.setProperty('--visualizer-rot-zw', '0deg');
+            element.style.setProperty('--scroll-velocity', '0');
             handlers.delete(element);
         });
+
+        window.removeEventListener('scroll', scheduleScroll);
+        if (scrollState.raf) {
+            cancelAnimationFrame(scrollState.raf);
+        }
+        scrollState.pending = false;
+        scrollState.raf = null;
+        scrollState.velocity = 0;
     };
 
     return { enable, disable };
@@ -1869,6 +2024,291 @@ function initialiseTimelines() {
     });
 }
 
+function initialiseCardVisualizers() {
+    const selectors = [
+        '.canvas-card',
+        '.stacked-card',
+        '.hero__module',
+        '.flow-step',
+        '.flow-thread',
+        '.system-card',
+        '.variant-card',
+        '.signal-card',
+        '.signal-node',
+        '.resource-card',
+        '.micro-card',
+        '.metric'
+    ];
+
+    const candidates = new Set();
+    selectors.forEach((selector) => {
+        document.querySelectorAll(selector).forEach((element) => candidates.add(element));
+    });
+
+    const cards = Array.from(candidates).filter((card) => card && !card.dataset.visualizerAttached);
+    if (!cards.length) {
+        return;
+    }
+
+    const acquireAsset = typeof window.clearSeasAcquireBrandAsset === 'function'
+        ? window.clearSeasAcquireBrandAsset
+        : () => null;
+
+    const instances = new WeakMap();
+    const observer = 'IntersectionObserver' in window
+        ? new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                const state = instances.get(entry.target);
+                if (!state) {
+                    return;
+                }
+                state.visible = entry.isIntersecting;
+                if (entry.isIntersecting) {
+                    state.startField();
+                    state.targetFocus = Math.max(state.targetFocus, 0.42);
+                } else if (!state.hover) {
+                    state.stopField();
+                    state.targetFocus = Math.min(state.targetFocus, 0.2);
+                }
+            });
+        }, { threshold: 0.25, rootMargin: '-12% 0px -12% 0px' })
+        : null;
+
+    cards.forEach((card, index) => {
+        card.dataset.visualizerAttached = 'true';
+        card.classList.add('visualizer-host');
+
+        const weight = Number(card.dataset.visualizerWeight || card.dataset.visualizerScale || '1.12');
+        const bleed = Number.isFinite(weight) ? Math.max(1.18, weight + 0.22) : 1.28;
+        const scale = bleed + 0.16;
+        card.style.setProperty('--visualizer-bleed', bleed.toFixed(3));
+        card.style.setProperty('--visualizer-scale', scale.toFixed(3));
+        if (!card.style.getPropertyValue('--brand-rotation')) {
+            card.style.setProperty('--brand-rotation', `${(Math.random() * 38 - 19).toFixed(2)}deg`);
+        }
+
+        const shell = document.createElement('div');
+        shell.className = 'visualizer-shell';
+        shell.setAttribute('aria-hidden', 'true');
+
+        const canvas = document.createElement('canvas');
+        canvas.className = 'visualizer-shell__canvas';
+        shell.appendChild(canvas);
+
+        const assetPreference = card.dataset.visualizerAsset || card.dataset.element || (index % 3 === 0 ? 'video' : 'overlay');
+        const asset = acquireAsset(assetPreference);
+
+        let brandHost = null;
+        let brandMedia = null;
+
+        if (asset && asset.src) {
+            brandHost = document.createElement('div');
+            brandHost.className = 'visualizer-shell__brand';
+            brandHost.dataset.brandType = asset.type;
+
+            if (asset.type === 'video') {
+                brandHost.classList.add('visualizer-shell__brand--video');
+                const video = document.createElement('video');
+                video.className = 'visualizer-shell__brand-media';
+                video.src = asset.src;
+                video.muted = true;
+                video.autoplay = true;
+                video.loop = true;
+                video.playsInline = true;
+                video.setAttribute('muted', '');
+                video.setAttribute('playsinline', '');
+                video.addEventListener('loadeddata', () => {
+                    video.play().catch(() => {});
+                }, { once: true });
+                brandHost.appendChild(video);
+                brandMedia = video;
+            } else {
+                brandHost.classList.add('visualizer-shell__brand--image');
+                brandHost.style.setProperty('--brand-image', `url(${asset.src})`);
+            }
+
+            shell.appendChild(brandHost);
+        }
+
+        card.insertBefore(shell, card.firstChild);
+
+        const state = {
+            card,
+            canvas,
+            shell,
+            brandHost,
+            brandMedia,
+            hover: false,
+            visible: false,
+            started: false,
+            focus: 0.18,
+            targetFocus: 0.24,
+            pulse: 0,
+            pointerX: 0.5,
+            pointerY: 0.5,
+            raf: null,
+            fieldController: null,
+            resizeObserver: null
+        };
+
+        const hologram = ReactiveHologramField.create(canvas);
+        if (hologram) {
+            state.fieldController = {
+                start() {
+                    hologram.start();
+                },
+                stop() {
+                    hologram.stop();
+                },
+                update(focusX, focusY, intensity) {
+                    hologram.setPointer(focusX, focusY);
+                    hologram.setFocus(focusX, focusY, intensity);
+                    hologram.setMode(intensity > 0.75 ? 'active' : 'holographic');
+                },
+                destroy() {
+                    hologram.stop();
+                }
+            };
+        } else {
+            const fallback = new OrbitalField(canvas);
+            state.fieldController = {
+                start() {
+                    fallback.start();
+                },
+                stop() {
+                    fallback.stop();
+                },
+                update(_focusX, _focusY, intensity) {
+                    fallback.setIntensity(0.52 + intensity * 0.45);
+                },
+                destroy() {
+                    fallback.stop();
+                }
+            };
+        }
+
+        const updateCanvasResolution = () => {
+            const rect = card.getBoundingClientRect();
+            if (!rect.width || !rect.height) {
+                return;
+            }
+            const dpr = Math.min(window.devicePixelRatio || 1, 2.5);
+            const bleedFactor = Number(card.style.getPropertyValue('--visualizer-bleed')) || bleed;
+            const resolutionScale = bleedFactor + 0.42;
+            const width = Math.max(1, Math.round(rect.width * resolutionScale * dpr));
+            const height = Math.max(1, Math.round(rect.height * resolutionScale * dpr));
+            if (canvas.width !== width) {
+                canvas.width = width;
+            }
+            if (canvas.height !== height) {
+                canvas.height = height;
+            }
+        };
+
+        updateCanvasResolution();
+        state.resizeObserver = new ResizeObserver(updateCanvasResolution);
+        state.resizeObserver.observe(card);
+
+        const startField = () => {
+            if (state.started || !state.fieldController) {
+                return;
+            }
+            state.fieldController.start();
+            state.started = true;
+        };
+
+        const stopField = () => {
+            if (!state.started || !state.fieldController) {
+                return;
+            }
+            state.fieldController.stop();
+            state.started = false;
+        };
+
+        state.startField = startField;
+        state.stopField = stopField;
+
+        const setPointer = (event) => {
+            const rect = card.getBoundingClientRect();
+            const x = rect.width ? (event.clientX - rect.left) / rect.width : 0.5;
+            const y = rect.height ? (event.clientY - rect.top) / rect.height : 0.5;
+            state.pointerX = Math.min(Math.max(x, 0), 1);
+            state.pointerY = Math.min(Math.max(y, 0), 1);
+        };
+
+        const handleMove = (event) => {
+            setPointer(event);
+            state.targetFocus = Math.max(state.targetFocus, 0.92);
+        };
+
+        const handleEnter = () => {
+            state.hover = true;
+            state.targetFocus = Math.max(state.targetFocus, 1.05);
+            startField();
+        };
+
+        const handleLeave = () => {
+            state.hover = false;
+            state.targetFocus = Math.max(0.22, state.visible ? 0.4 : 0.18);
+            if (!state.visible) {
+                stopField();
+            }
+        };
+
+        const handleDown = () => {
+            state.pulse = 1;
+            state.targetFocus = Math.max(state.targetFocus, 1.12);
+            if (state.brandMedia) {
+                state.brandMedia.play().catch(() => {});
+            }
+        };
+
+        card.addEventListener('pointermove', handleMove);
+        card.addEventListener('pointerenter', handleEnter);
+        card.addEventListener('pointerleave', handleLeave);
+        card.addEventListener('pointerdown', handleDown);
+        card.addEventListener('focusin', handleEnter);
+        card.addEventListener('focusout', handleLeave);
+
+        const animate = () => {
+            const baseTarget = state.hover ? 1.05 : state.visible ? 0.45 : 0.2;
+            state.targetFocus += (baseTarget - state.targetFocus) * 0.08;
+            state.focus += (state.targetFocus - state.focus) * 0.14;
+            state.pulse *= 0.9;
+
+            const focusValue = Math.max(0, state.focus);
+            card.style.setProperty('--focus-intensity', focusValue.toFixed(3));
+            card.style.setProperty('--focus-pulse', state.pulse.toFixed(3));
+            card.style.setProperty('--focus-pointer-x', state.pointerX.toFixed(3));
+            card.style.setProperty('--focus-pointer-y', state.pointerY.toFixed(3));
+
+            if (state.fieldController) {
+                state.fieldController.update(state.pointerX, state.pointerY, Math.min(1.4, focusValue + 0.45));
+            }
+
+            if (state.brandMedia && state.brandMedia instanceof HTMLVideoElement) {
+                const scrollVelocity = Number(card.style.getPropertyValue('--scroll-velocity') || 0);
+                const playbackRate = 0.85 + focusValue * 0.45 + Math.abs(scrollVelocity) * 0.2;
+                state.brandMedia.playbackRate = Math.min(1.8, Math.max(0.7, playbackRate));
+            }
+
+            state.raf = requestAnimationFrame(animate);
+        };
+
+        state.raf = requestAnimationFrame(animate);
+
+        instances.set(card, state);
+
+        if (observer) {
+            observer.observe(card);
+        } else {
+            state.visible = true;
+            startField();
+            state.targetFocus = Math.max(state.targetFocus, 0.4);
+        }
+    });
+}
+
 function updateFooterYear() {
     const target = document.querySelector('[data-year]');
     if (target) {
@@ -1896,6 +2336,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    initialiseCardVisualizers();
     initialiseStackedShowcase();
     initialiseParallaxGroups();
     initialiseSparkInteractions();

--- a/scripts/global-page-orchestrator.js
+++ b/scripts/global-page-orchestrator.js
@@ -1,0 +1,1872 @@
+import { resolvePageProfile, applyProfileMetadata } from './page-profile-registry.js';
+
+const BRAND_OVERRIDE_EVENT = window.__CLEAR_SEAS_BRAND_OVERRIDE_EVENT || 'clear-seas:brand-overrides-changed';
+
+const GLOBAL_MOTION_EVENT = window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT || 'clear-seas:motion-updated';
+window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT = GLOBAL_MOTION_EVENT;
+
+const brandAssets = window.__CLEAR_SEAS_BRAND_ASSETS || (window.__CLEAR_SEAS_BRAND_ASSETS = {
+  images: [
+    'assets/Screenshot_20250430-141821.png',
+    'assets/Screenshot_20241012-073718.png',
+    'assets/Screenshot_20250430-142024~2.png',
+    'assets/Screenshot_20250430-142002~2.png',
+    'assets/Screenshot_20250430-142032~2.png',
+    'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+    'assets/file_0000000054a06230817873012865d150.png',
+    'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+    'assets/image_8 (1).png'
+  ],
+  videos: [
+    '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+    '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+    '1746496560073.mp4',
+    '1746500614769.mp4',
+    '1746576068221.mp4'
+  ]
+});
+
+const rootElement = document.documentElement;
+const bodyElement = document.body;
+const orchestratorModeAttr = (bodyElement?.dataset?.orchestratorMode || rootElement?.dataset?.orchestratorMode || '').toLowerCase();
+const orchestratorDisabled = bodyElement?.hasAttribute('data-disable-global-orchestrator') ||
+  rootElement?.hasAttribute('data-disable-global-orchestrator') ||
+  orchestratorModeAttr === 'static' ||
+  orchestratorModeAttr === 'disabled' ||
+  orchestratorModeAttr === 'catalog' ||
+  orchestratorModeAttr === 'index';
+const orchestratorMode = orchestratorDisabled ? 'static' : (orchestratorModeAttr || 'active');
+
+if (rootElement) {
+  rootElement.dataset.globalOrchestrator = orchestratorMode;
+}
+
+window.__CLEAR_SEAS_GLOBAL_ORCHESTRATOR_MODE = orchestratorMode;
+
+const brandOverrideApi = (() => {
+  if (window.__CLEAR_SEAS_BRAND_OVERRIDE_API) {
+    return window.__CLEAR_SEAS_BRAND_OVERRIDE_API;
+  }
+
+  const overlayKeys = new Set(['blend', 'filter', 'opacity', 'rotate', 'depth']);
+  const canvasKeys = new Set(['scale', 'depth']);
+
+  const overrideCache = {
+    source: null,
+    version: 0,
+    marker: 0,
+    signature: null,
+    length: 0,
+    list: []
+  };
+
+  const readArrayMeta = (input) => {
+    if (!input || typeof input !== 'object') {
+      return { version: 0, marker: 0, signature: null };
+    }
+    return {
+      version: Number(input.__version ?? input.version ?? input.__CLEAR_SEAS_VERSION ?? input.__clearSeasVersion ?? 0),
+      marker: Number(input.__clearSeasOverrideMarker ?? 0),
+      signature: typeof input.__signature === 'string' ? input.__signature : null
+    };
+  };
+
+  const computeGlobalOverrides = () => {
+    const source = window.__CLEAR_SEAS_CARD_BRAND_OVERRIDES;
+    if (!Array.isArray(source)) {
+      overrideCache.source = null;
+      overrideCache.version = 0;
+      overrideCache.marker = 0;
+      overrideCache.signature = null;
+      overrideCache.length = 0;
+      overrideCache.list = [];
+      return overrideCache.list;
+    }
+
+    const meta = readArrayMeta(source);
+    if (
+      source !== overrideCache.source ||
+      meta.version !== overrideCache.version ||
+      meta.marker !== overrideCache.marker ||
+      meta.signature !== overrideCache.signature ||
+      source.length !== overrideCache.length
+    ) {
+      overrideCache.list = source.map(normaliseOverrideEntry).filter(Boolean);
+      overrideCache.source = source;
+      overrideCache.version = meta.version;
+      overrideCache.marker = meta.marker;
+      overrideCache.signature = meta.signature;
+      overrideCache.length = source.length;
+    }
+
+    return overrideCache.list;
+  };
+
+  const getGlobalOverrides = () => computeGlobalOverrides();
+
+  const dispatchOverrideEvent = (detail) => {
+    const eventDetail = {
+      reason: detail && typeof detail === 'object' && detail.reason ? detail.reason : 'manual-refresh',
+      timestamp: Date.now()
+    };
+    if (detail && typeof detail === 'object') {
+      Object.keys(detail).forEach((key) => {
+        if (key === 'reason') {
+          return;
+        }
+        eventDetail[key] = detail[key];
+      });
+    }
+    window.dispatchEvent(new CustomEvent(BRAND_OVERRIDE_EVENT, { detail: eventDetail }));
+  };
+
+  const refreshGlobalOverrides = (detail) => {
+    overrideCache.source = null;
+    overrideCache.version = 0;
+    overrideCache.marker = 0;
+    overrideCache.signature = null;
+    overrideCache.length = 0;
+    overrideCache.list = [];
+    const overrides = computeGlobalOverrides();
+    dispatchOverrideEvent(detail);
+    return overrides;
+  };
+
+  const parseList = (value) => {
+    if (!value) {
+      return [];
+    }
+    if (Array.isArray(value)) {
+      return value
+        .map((item) => (typeof item === 'string' ? item.trim() : ''))
+        .filter(Boolean);
+    }
+    return String(value)
+      .split(/[\n,]+/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+  };
+
+  const sanitiseOverlay = (input) => {
+    if (!input || typeof input !== 'object') {
+      return null;
+    }
+    const result = {};
+    overlayKeys.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(input, key)) {
+        const value = input[key];
+        if (value == null || value === '') {
+          return;
+        }
+        if (key === 'opacity') {
+          const numeric = Number(value);
+          if (Number.isFinite(numeric)) {
+            result.opacity = numeric;
+          }
+        } else {
+          result[key] = String(value);
+        }
+      }
+    });
+    return Object.keys(result).length ? result : null;
+  };
+
+  const sanitiseCanvas = (input) => {
+    if (!input || typeof input !== 'object') {
+      return null;
+    }
+    const result = {};
+    canvasKeys.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(input, key)) {
+        const value = input[key];
+        if (value == null || value === '') {
+          return;
+        }
+        if (key === 'scale') {
+          const numeric = Number(value);
+          if (Number.isFinite(numeric)) {
+            result.scale = numeric;
+          }
+        } else {
+          result[key] = String(value);
+        }
+      }
+    });
+    return Object.keys(result).length ? result : null;
+  };
+
+  const normaliseCycleTriggers = (entry) => {
+    const triggers = new Set();
+    const append = (value) => {
+      const key = String(value || '').trim().toLowerCase();
+      if (!key) {
+        return;
+      }
+      if (key === 'focus' || key === 'hover') {
+        triggers.add('focus');
+      } else if (key === 'click' || key === 'press') {
+        triggers.add('click');
+      } else if (key === 'interaction' || key === 'cycle') {
+        triggers.add('interaction');
+      }
+    };
+    if (!entry) {
+      return triggers;
+    }
+    if (Array.isArray(entry)) {
+      entry.forEach(append);
+    } else if (entry instanceof Set) {
+      entry.forEach(append);
+    } else {
+      parseList(entry).forEach(append);
+    }
+    if (entry && typeof entry === 'object') {
+      if (entry.cycleOnFocus) {
+        append('focus');
+      }
+      if (entry.cycleOnClick) {
+        append('click');
+      }
+    }
+    return triggers;
+  };
+
+  const normaliseOverrideEntry = (entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return null;
+    }
+    const normalised = {};
+    if (entry.selector) {
+      normalised.selector = String(entry.selector);
+    }
+    if (entry.exclude || entry.excludes) {
+      normalised.exclude = String(entry.exclude || entry.excludes);
+    }
+    if (typeof entry.mode === 'string') {
+      const mode = entry.mode.trim().toLowerCase();
+      if (mode === 'video' || mode === 'image' || mode === 'auto') {
+        normalised.mode = mode;
+      }
+    }
+    if (entry.palette) {
+      normalised.palette = String(entry.palette);
+    }
+    if (entry.seedOffset != null) {
+      const offset = Number(entry.seedOffset);
+      if (Number.isFinite(offset)) {
+        normalised.seedOffset = Math.trunc(offset);
+      }
+    }
+    const images = parseList(entry.images || entry.image || entry.assets);
+    if (images.length) {
+      normalised.images = images;
+    }
+    const videos = parseList(entry.videos || entry.video);
+    if (videos.length) {
+      normalised.videos = videos;
+    }
+    const overlay = sanitiseOverlay(entry.overlay || entry.brandOverlay);
+    if (overlay) {
+      normalised.overlay = overlay;
+    }
+    const canvas = sanitiseCanvas(entry.canvas || entry.brandCanvas);
+    if (canvas) {
+      normalised.canvas = canvas;
+    }
+    const triggers = normaliseCycleTriggers(entry.cycle || entry.cycles || entry.cycleTriggers);
+    if (triggers.size) {
+      normalised.cycleTriggers = triggers;
+    }
+    if (entry.cycleStep != null) {
+      const step = Number(entry.cycleStep);
+      if (Number.isFinite(step)) {
+        normalised.cycleStep = step;
+      }
+    }
+    return normalised;
+  };
+
+  const mergeOverride = (target, source) => {
+    if (!source) {
+      return target;
+    }
+    if (source.mode) {
+      target.mode = source.mode;
+    }
+    if (source.palette) {
+      target.palette = source.palette;
+    }
+    if (source.seedOffset != null) {
+      target.seedOffset = (target.seedOffset || 0) + source.seedOffset;
+    }
+    if (Array.isArray(source.images) && source.images.length) {
+      target.images = (target.images || []).concat(source.images);
+    }
+    if (Array.isArray(source.videos) && source.videos.length) {
+      target.videos = (target.videos || []).concat(source.videos);
+    }
+    if (source.overlay) {
+      target.overlay = { ...(target.overlay || {}), ...source.overlay };
+    }
+    if (source.canvas) {
+      target.canvas = { ...(target.canvas || {}), ...source.canvas };
+    }
+    if (source.cycleTriggers instanceof Set && source.cycleTriggers.size) {
+      if (!(target.cycleTriggers instanceof Set)) {
+        target.cycleTriggers = new Set();
+      }
+      source.cycleTriggers.forEach((trigger) => target.cycleTriggers.add(trigger));
+    }
+    if (source.cycleStep != null && Number.isFinite(source.cycleStep)) {
+      target.cycleStep = Number(source.cycleStep);
+    }
+    return target;
+  };
+
+  const parseDatasetOverride = (element) => {
+    if (!(element instanceof HTMLElement)) {
+      return null;
+    }
+    const { dataset } = element;
+    if (!dataset) {
+      return null;
+    }
+    const override = {};
+    const modeValue = dataset.brandMode || dataset.brandAssetMode;
+    if (modeValue) {
+      const mode = modeValue.trim().toLowerCase();
+      if (mode === 'video' || mode === 'image' || mode === 'auto') {
+        override.mode = mode;
+      }
+    }
+    if (dataset.brandPalette) {
+      override.palette = dataset.brandPalette.trim();
+    }
+    if (dataset.brandSeedOffset != null || dataset.brandSeed != null) {
+      const offsetValue = dataset.brandSeedOffset ?? dataset.brandSeed;
+      const offset = Number(offsetValue);
+      if (Number.isFinite(offset)) {
+        override.seedOffset = Math.trunc(offset);
+      }
+    }
+    const imageList = parseList(dataset.brandImages || dataset.brandImageSrc || dataset.brandImage);
+    if (imageList.length) {
+      override.images = imageList;
+    }
+    const videoList = parseList(dataset.brandVideos || dataset.brandVideoSrc || dataset.brandVideoUrl);
+    if (videoList.length) {
+      override.videos = videoList;
+    }
+    const overlay = sanitiseOverlay({
+      blend: dataset.brandOverlayBlend,
+      filter: dataset.brandOverlayFilter,
+      opacity: dataset.brandOverlayOpacity,
+      rotate: dataset.brandOverlayRotate,
+      depth: dataset.brandOverlayDepth
+    });
+    if (overlay) {
+      override.overlay = overlay;
+    }
+    const canvas = sanitiseCanvas({
+      scale: dataset.cardCanvasScale,
+      depth: dataset.cardCanvasDepth
+    });
+    if (canvas) {
+      override.canvas = canvas;
+    }
+    const triggers = normaliseCycleTriggers([
+      dataset.brandCycle,
+      dataset.brandCycleOnFocus === 'true' ? 'focus' : '',
+      dataset.brandCycleOnClick === 'true' ? 'click' : ''
+    ]);
+    if (triggers.size) {
+      override.cycleTriggers = triggers;
+    }
+    if (dataset.brandCycleStep != null) {
+      const step = Number(dataset.brandCycleStep);
+      if (Number.isFinite(step)) {
+        override.cycleStep = step;
+      }
+    }
+    const hasContent = Boolean(
+      override.mode ||
+      override.palette ||
+      override.seedOffset != null ||
+      (override.images && override.images.length) ||
+      (override.videos && override.videos.length) ||
+      override.overlay ||
+      override.canvas ||
+      (override.cycleTriggers && override.cycleTriggers.size)
+    );
+    return hasContent ? override : null;
+  };
+
+  const collect = (element) => {
+    if (!(element instanceof HTMLElement)) {
+      return null;
+    }
+    const aggregate = {};
+    const globalOverrides = getGlobalOverrides();
+    globalOverrides.forEach((entry) => {
+      if (entry.selector && !element.matches(entry.selector)) {
+        return;
+      }
+      if (entry.exclude && element.matches(entry.exclude)) {
+        return;
+      }
+      mergeOverride(aggregate, entry);
+    });
+    mergeOverride(aggregate, parseDatasetOverride(element));
+    const hasContent = Boolean(
+      aggregate.mode ||
+      aggregate.palette ||
+      aggregate.seedOffset != null ||
+      (aggregate.images && aggregate.images.length) ||
+      (aggregate.videos && aggregate.videos.length) ||
+      aggregate.overlay ||
+      aggregate.canvas ||
+      (aggregate.cycleTriggers && aggregate.cycleTriggers.size)
+    );
+    if (!hasContent) {
+      return null;
+    }
+    if (aggregate.images) {
+      aggregate.images = Array.from(new Set(aggregate.images));
+    }
+    if (aggregate.videos) {
+      aggregate.videos = Array.from(new Set(aggregate.videos));
+    }
+    return aggregate;
+  };
+
+  const mergeOverlaySettings = (base, override) => {
+    const result = { ...(base || {}) };
+    if (override) {
+      overlayKeys.forEach((key) => {
+        if (Object.prototype.hasOwnProperty.call(override, key) && override[key] != null) {
+          result[key] = override[key];
+        }
+      });
+    }
+    return result;
+  };
+
+  const mergeCanvasSettings = (base, override) => {
+    const result = { ...(base || {}) };
+    if (override) {
+      canvasKeys.forEach((key) => {
+        if (Object.prototype.hasOwnProperty.call(override, key) && override[key] != null) {
+          result[key] = override[key];
+        }
+      });
+    }
+    return result;
+  };
+
+  const resolveMode = (overrides, fallback) => {
+    if (!overrides || !overrides.mode || overrides.mode === 'auto') {
+      return fallback;
+    }
+    if (overrides.mode === 'video') {
+      return true;
+    }
+    if (overrides.mode === 'image') {
+      return false;
+    }
+    return fallback;
+  };
+
+  const applyPalette = (overrides, fallback) => {
+    if (overrides && overrides.palette) {
+      return overrides.palette;
+    }
+    return fallback;
+  };
+
+  const pickAsset = (overrides, type, index, fallback) => {
+    const listKey = type === 'videos' ? 'videos' : 'images';
+    const list = overrides && overrides[listKey];
+    const seedOffset = overrides && overrides.seedOffset ? overrides.seedOffset : 0;
+    const effectiveIndex = Number.isFinite(index) ? index + seedOffset : seedOffset;
+    if (Array.isArray(list) && list.length) {
+      const position = ((effectiveIndex % list.length) + list.length) % list.length;
+      return list[position] || null;
+    }
+    if (typeof fallback === 'function') {
+      return fallback(effectiveIndex);
+    }
+    return null;
+  };
+
+  const shouldCycle = (overrides, trigger) => {
+    if (!overrides || !(overrides.cycleTriggers instanceof Set)) {
+      return false;
+    }
+    const key = trigger === 'hover' ? 'focus' : trigger;
+    return overrides.cycleTriggers.has(key);
+  };
+
+  const nextCycleIndex = (overrides, current) => {
+    const step = overrides && Number.isFinite(overrides.cycleStep) ? overrides.cycleStep : 1;
+    return (Number.isFinite(current) ? current : 0) + step;
+  };
+
+  const hasAssetList = (overrides, type) => {
+    const listKey = type === 'videos' ? 'videos' : 'images';
+    return Array.isArray(overrides?.[listKey]) && overrides[listKey].length > 0;
+  };
+
+  const api = {
+    collect,
+    mergeOverlaySettings,
+    mergeCanvasSettings,
+    resolveMode,
+    pickAsset,
+    shouldCycle,
+    nextCycleIndex,
+    applyPalette,
+    hasAssetList,
+    refresh: refreshGlobalOverrides,
+    eventName: BRAND_OVERRIDE_EVENT
+  };
+
+  window.__CLEAR_SEAS_BRAND_OVERRIDE_EVENT = BRAND_OVERRIDE_EVENT;
+  window.__CLEAR_SEAS_BRAND_OVERRIDE_API = api;
+  return api;
+})();
+
+function detectActivePageProfile() {
+  const resolved = resolvePageProfile();
+  const profile = {
+    key: resolved?.key || 'core-foundation',
+    palette: resolved?.palette || 'foundation',
+    family: resolved?.family || resolved?.key || 'core-foundation',
+    layout: resolved?.layout || 'grid',
+    accent: resolved?.accent || null,
+    videoPattern: resolved?.videoPattern || null,
+    imageOrder: resolved?.imageOrder || null,
+    videoOrder: resolved?.videoOrder || null,
+    overlay: resolved?.overlay || {},
+    canvas: resolved?.canvas || {},
+    scripts: Array.isArray(resolved?.scripts) ? [...resolved.scripts] : [],
+    signature: resolved?.signature || '',
+    seed: resolved?.seed || 0
+  };
+
+  profile.imageSeed = brandAssets.images.length ? profile.seed % brandAssets.images.length : 0;
+  profile.videoSeed = brandAssets.videos.length ? Math.floor(profile.seed / 7) % brandAssets.videos.length : 0;
+
+  if (resolved?.metaName === 'ultimate-clear-seas-holistic-system.html') {
+    profile.scripts.push('scripts/ultimate-holistic-vib34d-system.js');
+  }
+
+  applyProfileMetadata(profile);
+  window.__CLEAR_SEAS_PAGE_PROFILE = profile;
+  return profile;
+}
+
+const activePageProfile = detectActivePageProfile();
+
+function preparePageProfile(profile) {
+  if (!profile) {
+    return;
+  }
+  const overlaySettings = profile.overlay || {};
+  if (overlaySettings.blend) {
+    document.documentElement.style.setProperty('--global-brand-overlay-blend', overlaySettings.blend);
+  }
+  if (Array.isArray(profile.scripts) && profile.scripts.length) {
+    profile.scripts.forEach((src) => ensureScript(src));
+  }
+  if (sharedMotion) {
+    sharedMotion.palette = profile.palette || null;
+    sharedMotion.collection = profile.key || null;
+    sharedMotion.family = profile.family || null;
+    sharedMotion.layout = profile.layout || null;
+  }
+}
+
+const stylesLoaded = new Set();
+const scriptsLoaded = new Map();
+const cardStates = new Map();
+
+function refreshAllCardOverrides(options = {}) {
+  const { resetCycle = false } = options || {};
+  cardStates.forEach((state) => {
+    if (!state || !state.element) {
+      return;
+    }
+    state.overrides = brandOverrideApi.collect(state.element);
+    if (resetCycle) {
+      state.assetCycle = 0;
+    }
+    state.overlay = ensureBrandLayer(state);
+  });
+}
+
+if (!orchestratorDisabled) {
+  window.addEventListener(BRAND_OVERRIDE_EVENT, () => {
+    refreshAllCardOverrides({ resetCycle: true });
+  });
+}
+const groupStates = new Map();
+let activeCardState = null;
+let rafId = null;
+
+const globalState = {
+  scroll: {
+    current: 0,
+    target: 0,
+    lastY: window.scrollY || 0,
+    lastTime: performance.now(),
+    direction: 0,
+    speed: 0
+  },
+  synergy: { current: 0, target: 0 },
+  focus: {
+    currentX: 0.5,
+    currentY: 0.5,
+    currentAmount: 0,
+    targetX: 0.5,
+    targetY: 0.5,
+    targetAmount: 0,
+    trend: 0,
+    lastAmount: 0
+  },
+  tilt: {
+    currentX: 0,
+    currentY: 0,
+    targetX: 0,
+    targetY: 0
+  },
+  bend: { current: 0, target: 0 },
+  warp: { current: 0, target: 0 }
+};
+
+const sharedMotion = window.__CLEAR_SEAS_GLOBAL_MOTION || (window.__CLEAR_SEAS_GLOBAL_MOTION = {
+  focus: { x: 0.5, y: 0.5, amount: 0 },
+  tilt: { x: 0, y: 0, strength: 0 },
+  bend: 0,
+  warp: 0,
+  scroll: 0,
+  scrollDirection: 0,
+  scrollSpeed: 0,
+  focusTrend: 0,
+  tiltSkew: 0,
+  synergy: 0,
+  palette: null,
+  collection: null,
+  family: null,
+  layout: null,
+  updatedAt: performance.now(),
+  eventName: GLOBAL_MOTION_EVENT
+});
+
+const motionEventState = {
+  lastDispatch: 0,
+  lastDetail: null
+};
+
+function shouldDispatchMotionEvent(previous, next) {
+  if (!previous) {
+    return true;
+  }
+
+  const thresholds = {
+    focusX: 0.0012,
+    focusY: 0.0012,
+    focusAmount: 0.0012,
+    focusTrend: 0.0006,
+    tiltX: 0.001,
+    tiltY: 0.001,
+    tiltStrength: 0.001,
+    tiltSkew: 0.001,
+    bend: 0.001,
+    warp: 0.001,
+    scrollMomentum: 0.001,
+    scrollSpeed: 0.001,
+    scrollDirection: 0.51,
+    synergy: 0.001
+  };
+
+  return Object.keys(thresholds).some((key) => {
+    const delta = Math.abs((next[key] || 0) - (previous[key] || 0));
+    return delta > thresholds[key];
+  });
+}
+
+function maybeDispatchGlobalMotionEvent() {
+  const detail = {
+    focusX: sharedMotion.focus.x,
+    focusY: sharedMotion.focus.y,
+    focusAmount: sharedMotion.focus.amount,
+    focusTrend: sharedMotion.focusTrend,
+    tiltX: sharedMotion.tilt.x,
+    tiltY: sharedMotion.tilt.y,
+    tiltStrength: sharedMotion.tilt.strength,
+    tiltSkew: sharedMotion.tiltSkew,
+    bend: sharedMotion.bend,
+    warp: sharedMotion.warp,
+    scrollMomentum: sharedMotion.scroll,
+    scrollSpeed: sharedMotion.scrollSpeed,
+    scrollDirection: sharedMotion.scrollDirection,
+    synergy: sharedMotion.synergy,
+    palette: sharedMotion.palette,
+    collection: sharedMotion.collection,
+    timestamp: sharedMotion.updatedAt
+  };
+
+  const now = detail.timestamp || performance.now();
+  const elapsed = now - motionEventState.lastDispatch;
+
+  if (elapsed < 32 && !shouldDispatchMotionEvent(motionEventState.lastDetail, detail)) {
+    return;
+  }
+
+  if (!shouldDispatchMotionEvent(motionEventState.lastDetail, detail) && elapsed < 120) {
+    return;
+  }
+
+  motionEventState.lastDetail = { ...detail };
+  motionEventState.lastDispatch = now;
+  window.dispatchEvent(new CustomEvent(GLOBAL_MOTION_EVENT, { detail }));
+}
+
+const supportsVisibilityObserver = typeof window !== 'undefined' && 'IntersectionObserver' in window;
+let visibilityObserver = null;
+
+function ensureVisibilityObserver() {
+  if (!supportsVisibilityObserver) {
+    return null;
+  }
+  if (!visibilityObserver) {
+    visibilityObserver = new IntersectionObserver(handleVisibilityEntries, {
+      rootMargin: '15% 0px 15% 0px',
+      threshold: [0, 0.08, 0.2, 0.35, 0.5, 0.75, 0.95]
+    });
+  }
+  return visibilityObserver;
+}
+
+function handleVisibilityEntries(entries) {
+  entries.forEach((entry) => {
+    const { target, intersectionRatio, isIntersecting } = entry;
+    const state = cardStates.get(target);
+    if (!state) {
+      return;
+    }
+    const visibleRatio = Math.max(0, Math.min(1, intersectionRatio));
+    state.visibilityRatio = visibleRatio;
+    const isVisible = isIntersecting && visibleRatio > 0.001;
+    if (isVisible !== state.isVisible) {
+      state.isVisible = isVisible;
+      target.dataset.globalCardVisible = isVisible ? 'true' : 'false';
+      if (!isVisible) {
+        state.pointer.targetX = 0.5;
+        state.pointer.targetY = 0.5;
+        state.focus.target = Math.min(state.focus.target, 0.35);
+        state.twist.target = 0;
+        state.pulse.target = 0;
+        state.support.target = Math.min(state.support.target, 0.02);
+        target.dataset.supportDistance = 'far';
+      }
+      updateSupportTargets(activeCardState);
+      requestTick();
+    }
+    target.style.setProperty('--card-visibility', visibleRatio.toFixed(4));
+  });
+  if (!rafId) {
+    requestTick();
+  }
+}
+
+function ensureStylesheet(href, key) {
+  if (stylesLoaded.has(key)) {
+    return;
+  }
+  if (document.querySelector(`link[data-global-style="${key}"]`)) {
+    stylesLoaded.add(key);
+    return;
+  }
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  link.dataset.globalStyle = key;
+  document.head.appendChild(link);
+  stylesLoaded.add(key);
+}
+
+function ensureScript(src) {
+  if (scriptsLoaded.has(src)) {
+    return scriptsLoaded.get(src);
+  }
+  const existing = Array.from(document.scripts).find(script => script.src && script.src.includes(src));
+  if (existing) {
+    if (existing.dataset.loaded === 'true') {
+      const resolved = Promise.resolve();
+      scriptsLoaded.set(src, resolved);
+      return resolved;
+    }
+    const promise = new Promise((resolve) => {
+      existing.addEventListener('load', () => {
+        existing.dataset.loaded = 'true';
+        resolve();
+      }, { once: true });
+      existing.addEventListener('error', () => resolve(), { once: true });
+    });
+    scriptsLoaded.set(src, promise);
+    return promise;
+  }
+  const promise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = false;
+    script.dataset.globalInjected = 'true';
+    script.addEventListener('load', () => {
+      script.dataset.loaded = 'true';
+      resolve();
+    });
+    script.addEventListener('error', (error) => {
+      console.warn(`⚠️ Failed to load script: ${src}`, error);
+      resolve();
+    });
+    document.head.appendChild(script);
+  });
+  scriptsLoaded.set(src, promise);
+  return promise;
+}
+
+async function ensureCardSystem() {
+  await ensureScript('scripts/card-specific-vib34d-visualizer.js');
+  await ensureScript('scripts/card-system-initializer.js');
+  if (typeof window.bootCardSystem === 'function') {
+    try {
+      await window.bootCardSystem();
+    } catch (error) {
+      console.warn('⚠️ Card system boot failed but continuing with synergy orchestrator.', error);
+    }
+  }
+}
+
+function normalise(value, min, max) {
+  if (max - min === 0) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, (value - min) / (max - min)));
+}
+
+function shouldRegister(element) {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+  if (element.dataset.globalCardSynergy === 'applied') {
+    return false;
+  }
+  if (element.closest('[data-global-card-synergy="applied"]') && element.closest('[data-global-card-synergy="applied"]') !== element) {
+    return false;
+  }
+  if (element.dataset.globalCardIgnore === 'true') {
+    return false;
+  }
+  const rect = element.getBoundingClientRect();
+  if (rect.width < 120 || rect.height < 120) {
+    return false;
+  }
+  const style = getComputedStyle(element);
+  if (style.display === 'inline' || style.visibility === 'hidden' || style.opacity === '0') {
+    return false;
+  }
+  return true;
+}
+
+function resolveAssetIndex(order, seed, offset, length) {
+  if (!length) {
+    return 0;
+  }
+  if (Array.isArray(order) && order.length) {
+    const orderIndex = (seed + offset) % order.length;
+    return order[orderIndex % order.length] % length;
+  }
+  return (seed + offset) % length;
+}
+
+function pickBrandImage(index) {
+  if (!brandAssets.images.length) {
+    return null;
+  }
+  const assetIndex = resolveAssetIndex(activePageProfile.imageOrder, activePageProfile.imageSeed || 0, index, brandAssets.images.length);
+  return brandAssets.images[assetIndex];
+}
+
+function pickBrandVideo(index) {
+  if (!brandAssets.videos.length) {
+    return null;
+  }
+  const assetIndex = resolveAssetIndex(activePageProfile.videoOrder, activePageProfile.videoSeed || 0, index, brandAssets.videos.length);
+  return brandAssets.videos[assetIndex];
+}
+
+function shouldPreferVideo(state) {
+  const element = state?.element;
+  if (!element) {
+    return false;
+  }
+  if (element.dataset.brandVideo === 'true') {
+    return true;
+  }
+  if (element.dataset.brandVideo === 'false') {
+    return false;
+  }
+  if (element.classList.contains('brand-video-card')) {
+    return true;
+  }
+  const pattern = activePageProfile.videoPattern;
+  if (Array.isArray(pattern) && pattern.length) {
+    const cycleIndex = state.index % pattern.length;
+    return Boolean(pattern[cycleIndex]);
+  }
+  return state.index % 3 === 0;
+}
+
+function ensureBrandLayer(state) {
+  const card = state.element;
+  let overlay = card.querySelector(':scope > .global-brand-overlay, :scope > .card-brand-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.className = 'global-brand-overlay';
+    card.appendChild(overlay);
+  } else {
+    overlay.classList.add('global-brand-overlay');
+  }
+  const existingVideo = overlay.querySelector('video');
+  if (existingVideo) {
+    existingVideo.muted = true;
+    existingVideo.loop = true;
+    existingVideo.autoplay = true;
+    existingVideo.playsInline = true;
+    state.brandVideo = existingVideo;
+  }
+
+  const overlaySettings = brandOverrideApi.mergeOverlaySettings(
+    activePageProfile.overlay || {},
+    state.overrides ? state.overrides.overlay : null
+  );
+
+  const canvasSettings = brandOverrideApi.mergeCanvasSettings(
+    activePageProfile.canvas || {},
+    state.overrides ? state.overrides.canvas : null
+  );
+
+  const palette = brandOverrideApi.applyPalette(state.overrides, activePageProfile.palette);
+  card.dataset.brandPalette = palette;
+  card.style.setProperty('--brand-overlay-opacity', overlaySettings.opacity != null ? String(overlaySettings.opacity) : '1');
+  card.style.setProperty('--brand-overlay-filter', overlaySettings.filter || 'brightness(1)');
+  card.style.setProperty('--brand-overlay-blend', overlaySettings.blend || 'screen');
+  card.style.setProperty('--brand-overlay-rotate', overlaySettings.rotate || '0deg');
+  card.style.setProperty('--brand-overlay-depth', overlaySettings.depth || '0px');
+  if (canvasSettings.scale != null) {
+    card.style.setProperty('--card-canvas-scale', String(canvasSettings.scale));
+  }
+  if (canvasSettings.depth) {
+    card.style.setProperty('--card-canvas-depth', canvasSettings.depth);
+  }
+
+  const preferVideo = brandOverrideApi.resolveMode(state.overrides, shouldPreferVideo(state));
+  const cycleIndex = state.index + (state.assetCycle || 0);
+  let videoSource = null;
+  let imageSource = null;
+
+  if (preferVideo) {
+    videoSource = brandOverrideApi.pickAsset(state.overrides, 'videos', cycleIndex, (index) => pickBrandVideo(index));
+    if (!videoSource) {
+      imageSource = brandOverrideApi.pickAsset(state.overrides, 'images', cycleIndex, (index) => pickBrandImage(index));
+    }
+  } else {
+    imageSource = brandOverrideApi.pickAsset(state.overrides, 'images', cycleIndex, (index) => pickBrandImage(index));
+    if (!imageSource) {
+      videoSource = brandOverrideApi.pickAsset(state.overrides, 'videos', cycleIndex, (index) => pickBrandVideo(index));
+    }
+  }
+
+  overlay.dataset.brandIndex = state.index;
+  overlay.dataset.brandPalette = palette;
+  overlay.style.setProperty('--brand-overlay-opacity', overlaySettings.opacity != null ? String(overlaySettings.opacity) : '1');
+  overlay.style.setProperty('--brand-overlay-filter', overlaySettings.filter || 'brightness(1)');
+  overlay.style.setProperty('--brand-overlay-blend', overlaySettings.blend || 'screen');
+  overlay.style.setProperty('--brand-overlay-rotate', overlaySettings.rotate || '0deg');
+  overlay.style.setProperty('--brand-overlay-depth', overlaySettings.depth || '0px');
+
+  if (videoSource) {
+    overlay.style.backgroundImage = 'none';
+    if (!overlay.querySelector('video')) {
+      overlay.innerHTML = '';
+      const video = document.createElement('video');
+      video.src = videoSource;
+      video.autoplay = true;
+      video.loop = true;
+      video.muted = true;
+      video.playsInline = true;
+      video.dataset.globalBrandVideo = 'true';
+      video.addEventListener('canplay', () => {
+        if (state.focus.current > 0.1) {
+          video.play().catch(() => {});
+        }
+      });
+      overlay.appendChild(video);
+      state.brandVideo = video;
+    } else if (state.brandVideo) {
+      if (state.brandVideo.src !== videoSource) {
+        try {
+          state.brandVideo.pause();
+        } catch (error) {
+          // ignore pause failures
+        }
+        state.brandVideo.src = videoSource;
+        state.brandVideo.load();
+      }
+      state.brandVideo.play().catch(() => {});
+    }
+  } else {
+    if (state.brandVideo) {
+      try {
+        state.brandVideo.pause();
+      } catch (error) {
+        // ignore pause failures
+      }
+    }
+    overlay.innerHTML = '';
+    if (imageSource) {
+      overlay.style.backgroundImage = `url('${imageSource}')`;
+    } else {
+      overlay.style.removeProperty('background-image');
+    }
+    state.brandVideo = null;
+  }
+
+  return overlay;
+}
+
+function resolveGroupElement(element) {
+  if (!(element instanceof HTMLElement)) {
+    return null;
+  }
+  const groupSelectors = [
+    '[data-card-group]',
+    '.version-grid',
+    '.card-grid',
+    '.cards-grid',
+    '.cards',
+    '.card-collection',
+    '.visualizer-grid',
+    '.layout-grid',
+    '.module-grid',
+    '.experience-grid',
+    '.card-stack',
+    '.card-list'
+  ];
+  const selector = groupSelectors.join(', ');
+  const matched = element.closest(selector);
+  if (matched) {
+    return matched;
+  }
+  const fallback = element.parentElement;
+  if (fallback && fallback !== document.body && fallback !== document.documentElement) {
+    return fallback;
+  }
+  return null;
+}
+
+function attachToGroup(state) {
+  const group = resolveGroupElement(state.element);
+  if (!group) {
+    return null;
+  }
+  group.dataset.globalCardGroup = 'true';
+  let groupState = groupStates.get(group);
+  if (!groupState) {
+    groupState = {
+      element: group,
+      cards: new Set(),
+      focus: { current: 0, target: 0 },
+      pointer: {
+        currentX: 0.5,
+        currentY: 0.5,
+        targetX: 0.5,
+        targetY: 0.5
+      },
+      synergy: { current: 0, target: 0 },
+      section: null
+    };
+    groupStates.set(group, groupState);
+  }
+  groupState.cards.add(state);
+  state.group = group;
+  return group;
+}
+
+function detachFromGroup(state) {
+  if (!state.group) {
+    return;
+  }
+  const groupState = groupStates.get(state.group);
+  if (!groupState) {
+    state.group = null;
+    return;
+  }
+  groupState.cards.delete(state);
+  if (groupState.cards.size === 0) {
+    const { element, section } = groupState;
+    element.removeAttribute('data-global-card-group');
+    element.removeAttribute('data-global-group-active');
+    element.style.removeProperty('--group-focus-amount');
+    element.style.removeProperty('--group-focus-x');
+    element.style.removeProperty('--group-focus-y');
+    element.style.removeProperty('--group-synergy');
+    if (section) {
+      section.removeAttribute('data-global-group-active');
+      section.style.removeProperty('--section-focus-amount');
+      section.style.removeProperty('--section-synergy');
+    }
+    groupStates.delete(state.group);
+  }
+  state.group = null;
+  state.element.dataset.supportDistance = 'far';
+}
+
+function syncGroupAssociation(state) {
+  const resolvedGroup = resolveGroupElement(state.element);
+  if (resolvedGroup === state.group) {
+    return;
+  }
+  detachFromGroup(state);
+  if (resolvedGroup) {
+    attachToGroup(state);
+  }
+}
+
+function createState(element, index) {
+  element.classList.add('global-visualizer-card');
+  element.dataset.globalCardSynergy = 'applied';
+  const overrides = brandOverrideApi.collect(element);
+  const state = {
+    element,
+    index,
+    overrides,
+    assetCycle: 0,
+    pointer: {
+      targetX: 0.5,
+      targetY: 0.5,
+      smoothX: 0.5,
+      smoothY: 0.5,
+      lastClientX: null,
+      lastClientY: null
+    },
+    focus: { current: 0, target: 0 },
+    support: { current: 0, target: 0 },
+    twist: { current: 0, target: 0 },
+    pulse: { current: 0, target: 0 },
+    scroll: 0,
+    overlay: null,
+    brandVideo: null,
+    group: null,
+    isVisible: true,
+    visibilityRatio: 1,
+    cleanupCallbacks: []
+  };
+  state.overlay = ensureBrandLayer(state);
+  state.element.dataset.supportRole = 'neutral';
+  state.element.dataset.supportDistance = 'far';
+  state.element.dataset.globalCardVisible = 'true';
+  state.element.style.setProperty('--card-visibility', '1');
+  state.group = attachToGroup(state);
+  const observer = ensureVisibilityObserver();
+  if (observer) {
+    observer.observe(element);
+    state.cleanupCallbacks.push(() => observer.unobserve(element));
+  }
+  state.cleanup = () => {
+    while (state.cleanupCallbacks.length) {
+      const callback = state.cleanupCallbacks.shift();
+      try {
+        callback();
+      } catch (error) {
+        console.warn('⚠️ Card cleanup callback failed', error);
+      }
+    }
+  };
+  cardStates.set(element, state);
+  return state;
+}
+
+function updateSupportTargets(activeState) {
+  activeCardState = activeState;
+  const activeGroup = activeState && activeState.group ? activeState.group : null;
+
+  let ambientSynergy = 0;
+  groupStates.forEach((groupState) => {
+    const visibleCount = Array.from(groupState.cards).reduce((count, cardState) => (
+      count + (cardState.isVisible ? 1 : 0)
+    ), 0);
+    const ratio = groupState.cards.size ? visibleCount / groupState.cards.size : 0;
+    ambientSynergy = Math.max(ambientSynergy, ratio * 0.45);
+
+    if (!activeGroup) {
+      groupState.synergy.target = ratio * 0.45;
+      groupState.element.dataset.globalGroupActive = ratio > 0.08 ? 'true' : 'false';
+      return;
+    }
+
+    if (groupState.element === activeGroup) {
+      groupState.synergy.target = 1;
+      groupState.element.dataset.globalGroupActive = 'true';
+    } else {
+      const ambientTarget = Math.max(0.18, ratio * 0.4);
+      groupState.synergy.target = ambientTarget;
+      groupState.element.dataset.globalGroupActive = ambientTarget > 0.12 ? 'true' : 'false';
+    }
+  });
+
+  if (!activeState) {
+    cardStates.forEach((state) => {
+      if (state.isVisible) {
+        state.support.target = 0.06;
+        state.element.dataset.supportRole = 'supporting';
+        state.element.dataset.supportDistance = 'visible';
+      } else {
+        state.support.target = 0;
+        state.element.dataset.supportRole = 'neutral';
+        state.element.dataset.supportDistance = 'far';
+      }
+    });
+    globalState.synergy.target = ambientSynergy;
+    requestTick();
+    return;
+  }
+
+  let orderedGroupCards = [];
+  if (activeGroup) {
+    const activeGroupState = groupStates.get(activeGroup);
+    if (activeGroupState) {
+      orderedGroupCards = Array.from(activeGroupState.cards).sort((a, b) => a.index - b.index);
+    }
+  }
+
+  const activeIndex = orderedGroupCards.length ? orderedGroupCards.indexOf(activeState) : -1;
+
+  cardStates.forEach((state) => {
+    if (state === activeState) {
+      state.support.target = 0.45;
+      state.element.dataset.supportRole = 'primary';
+      state.element.dataset.supportDistance = '0';
+      return;
+    }
+
+    if (activeGroup && state.group === activeGroup && activeIndex !== -1) {
+      const index = orderedGroupCards.indexOf(state);
+      const distance = index === -1 ? 3 : Math.abs(index - activeIndex);
+      state.element.dataset.supportDistance = String(distance);
+      let intensity = -0.02;
+      if (state.isVisible) {
+        if (distance === 1) {
+          intensity = 0.22;
+        } else if (distance === 2) {
+          intensity = 0.1;
+        }
+      }
+      state.support.target = intensity;
+      state.element.dataset.supportRole = 'supporting';
+    } else {
+      state.element.dataset.supportDistance = 'far';
+      state.support.target = state.isVisible ? -0.06 : -0.12;
+      state.element.dataset.supportRole = 'ambient';
+    }
+  });
+
+  globalState.synergy.target = Math.min(1, Math.max(0.85, 0.85 + ambientSynergy * 0.4));
+  requestTick();
+}
+
+function pointerPosition(event, element) {
+  const rect = element.getBoundingClientRect();
+  const x = normalise(event.clientX, rect.left, rect.right);
+  const y = normalise(event.clientY, rect.top, rect.bottom);
+  return { x, y };
+}
+
+function handlePointerEnter(state, event) {
+  if (!state.isVisible) {
+    state.isVisible = true;
+    state.element.dataset.globalCardVisible = 'true';
+    state.visibilityRatio = 1;
+    state.element.style.setProperty('--card-visibility', '1');
+  }
+  const { x, y } = pointerPosition(event, state.element);
+  state.pointer.targetX = x;
+  state.pointer.targetY = y;
+  state.pointer.smoothX = x;
+  state.pointer.smoothY = y;
+  state.focus.target = 1;
+  state.element.dataset.hasFocus = 'true';
+  state.element.dataset.interactionActive = 'true';
+  if (brandOverrideApi.shouldCycle(state.overrides, 'focus')) {
+    state.assetCycle = brandOverrideApi.nextCycleIndex(state.overrides, state.assetCycle);
+    state.overlay = ensureBrandLayer(state);
+  }
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState) {
+      groupState.pointer.targetX = x;
+      groupState.pointer.targetY = y;
+      groupState.focus.target = Math.max(groupState.focus.target, 0.85);
+      groupState.synergy.target = Math.max(groupState.synergy.target, 0.6);
+    }
+  }
+  if (state.brandVideo) {
+    state.brandVideo.play().catch(() => {});
+  }
+  updateSupportTargets(state);
+  requestTick();
+}
+
+function handlePointerMove(state, event) {
+  if (!state.isVisible) {
+    state.isVisible = true;
+    state.element.dataset.globalCardVisible = 'true';
+  }
+  state.visibilityRatio = 1;
+  state.element.style.setProperty('--card-visibility', '1');
+  const { x, y } = pointerPosition(event, state.element);
+  const deltaX = state.pointer.lastClientX !== null ? event.clientX - state.pointer.lastClientX : 0;
+  const deltaY = state.pointer.lastClientY !== null ? event.clientY - state.pointer.lastClientY : 0;
+  state.pointer.lastClientX = event.clientX;
+  state.pointer.lastClientY = event.clientY;
+  state.pointer.targetX = x;
+  state.pointer.targetY = y;
+  state.focus.target = Math.min(1.2, state.focus.target + 0.05);
+  state.twist.target = Math.max(-22, Math.min(22, state.twist.target * 0.6 + deltaX * 0.18 - deltaY * 0.12));
+  state.element.dataset.interactionActive = 'true';
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState) {
+      groupState.pointer.targetX = x;
+      groupState.pointer.targetY = y;
+      groupState.synergy.target = Math.max(groupState.synergy.target, 0.8);
+    }
+  }
+  requestTick();
+}
+
+function handlePointerLeave(state) {
+  state.pointer.targetX = 0.5;
+  state.pointer.targetY = 0.5;
+  state.pointer.lastClientX = null;
+  state.pointer.lastClientY = null;
+  state.focus.target = 0;
+  state.twist.target = 0;
+  state.element.dataset.hasFocus = 'false';
+  state.element.dataset.interactionActive = 'false';
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState && groupState.cards.size <= 1) {
+      groupState.pointer.targetX = 0.5;
+      groupState.pointer.targetY = 0.5;
+      groupState.focus.target = 0;
+      groupState.synergy.target = Math.max(0, groupState.synergy.target - 0.35);
+    }
+  }
+  if (activeCardState === state) {
+    updateSupportTargets(null);
+  }
+  requestTick();
+}
+
+function handleClick(state) {
+  if (brandOverrideApi.shouldCycle(state.overrides, 'click')) {
+    state.assetCycle = brandOverrideApi.nextCycleIndex(state.overrides, state.assetCycle);
+    state.overlay = ensureBrandLayer(state);
+  }
+  state.pulse.target = 1;
+  requestTick();
+}
+
+function handleFocusIn(state) {
+  state.focus.target = 0.85;
+  state.element.dataset.hasFocus = 'true';
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState) {
+      groupState.focus.target = Math.max(groupState.focus.target, 0.85);
+      groupState.synergy.target = Math.max(groupState.synergy.target, 0.7);
+    }
+  }
+  updateSupportTargets(state);
+  requestTick();
+}
+
+function handleFocusOut(state) {
+  state.focus.target = 0;
+  state.element.dataset.hasFocus = 'false';
+  if (state.group) {
+    const groupState = groupStates.get(state.group);
+    if (groupState && groupState.cards.size <= 1) {
+      groupState.focus.target = 0;
+      groupState.synergy.target = Math.max(0, groupState.synergy.target - 0.4);
+    }
+  }
+  if (activeCardState === state) {
+    updateSupportTargets(null);
+  }
+  requestTick();
+}
+
+function attachListeners(state) {
+  const element = state.element;
+  const pointerEnter = (event) => handlePointerEnter(state, event);
+  const pointerMove = (event) => handlePointerMove(state, event);
+  const pointerLeave = () => handlePointerLeave(state);
+  const click = () => handleClick(state);
+  const focusIn = () => handleFocusIn(state);
+  const focusOut = () => handleFocusOut(state);
+
+  element.addEventListener('pointerenter', pointerEnter, { passive: true });
+  element.addEventListener('pointermove', pointerMove, { passive: true });
+  element.addEventListener('pointerleave', pointerLeave, { passive: true });
+  element.addEventListener('click', click, { passive: true });
+  element.addEventListener('focusin', focusIn);
+  element.addEventListener('focusout', focusOut);
+
+  const cleanupCallbacks = Array.isArray(state.cleanupCallbacks)
+    ? state.cleanupCallbacks
+    : (state.cleanupCallbacks = []);
+  cleanupCallbacks.push(() => {
+    element.removeEventListener('pointerenter', pointerEnter);
+    element.removeEventListener('pointermove', pointerMove);
+    element.removeEventListener('pointerleave', pointerLeave);
+    element.removeEventListener('click', click);
+    element.removeEventListener('focusin', focusIn);
+    element.removeEventListener('focusout', focusOut);
+  });
+}
+
+function registerCard(element) {
+  if (!shouldRegister(element)) {
+    return;
+  }
+  const state = createState(element, cardStates.size);
+  attachListeners(state);
+  updateSupportTargets(activeCardState);
+  requestTick();
+}
+
+function collectCandidateElements(root = document) {
+  const selectors = [
+    '[data-visualizer-card]',
+    '[data-card]',
+    '.global-visualizer-card',
+    '.card',
+    '.project-card',
+    '.version-card',
+    '.experience-card',
+    '.portfolio-card',
+    '.innovation-card',
+    '.module-card',
+    '.hero-card',
+    '.focus-card',
+    '.tilt-card',
+    '.holographic-card',
+    '.vib34d-card',
+    '.trading-card',
+    '.clear-seas-card',
+    '.concept-card',
+    '.immersive-card',
+    '.vision-card',
+    '.galaxy-card',
+    '.grid-card',
+    '.quantum-card',
+    '.ai-card',
+    '.story-card',
+    '.lab-card'
+  ];
+  const elements = new Set();
+  selectors.forEach((selector) => {
+    root.querySelectorAll(selector).forEach((element) => elements.add(element));
+  });
+  return Array.from(elements);
+}
+
+function requestTick() {
+  if (rafId) {
+    return;
+  }
+  rafId = requestAnimationFrame(step);
+}
+
+function step() {
+  rafId = null;
+  let continueAnimation = false;
+  let weightedX = 0;
+  let weightedY = 0;
+  let totalFocus = 0;
+  const toRemove = [];
+
+  cardStates.forEach((state, element) => {
+    syncGroupAssociation(state);
+    if (!document.body.contains(element)) {
+      if (state.cleanup) {
+        state.cleanup();
+      }
+      detachFromGroup(state);
+      toRemove.push(element);
+      return;
+    }
+
+    const visibilityFactor = typeof state.visibilityRatio === 'number'
+      ? state.visibilityRatio
+      : (state.isVisible ? 1 : 0);
+
+    if (!state.isVisible) {
+      state.pointer.targetX += (0.5 - state.pointer.targetX) * 0.2;
+      state.pointer.targetY += (0.5 - state.pointer.targetY) * 0.2;
+      state.focus.target *= 0.82;
+      state.twist.target *= 0.6;
+      state.pulse.target *= 0.6;
+      state.scroll *= 0.85;
+    }
+
+    const focusLerp = state.isVisible ? 0.12 : 0.18;
+    const pointerLerp = state.isVisible ? 0.14 : 0.22;
+    const supportLerp = state.isVisible ? 0.1 : 0.16;
+    const twistLerp = state.isVisible ? 0.18 : 0.26;
+    const pulseLerp = state.isVisible ? 0.22 : 0.3;
+
+    state.pointer.smoothX += (state.pointer.targetX - state.pointer.smoothX) * pointerLerp;
+    state.pointer.smoothY += (state.pointer.targetY - state.pointer.smoothY) * pointerLerp;
+    state.focus.current += (state.focus.target - state.focus.current) * focusLerp;
+    state.support.current += (state.support.target - state.support.current) * supportLerp;
+    state.twist.current += (state.twist.target - state.twist.current) * twistLerp;
+    state.pulse.current += (state.pulse.target - state.pulse.current) * pulseLerp;
+    state.pulse.target *= 0.76;
+
+    const focusBase = Math.max(0, Math.min(1.2, state.focus.current));
+    const focusStrength = focusBase * (0.25 + visibilityFactor * 0.75);
+    const supportBase = Math.max(-1, Math.min(1, state.support.current));
+    const supportStrength = supportBase * (0.3 + visibilityFactor * 0.7);
+    const twistDeg = state.twist.current;
+    const pulse = Math.max(0, state.pulse.current);
+
+    element.style.setProperty('--card-focus-x', state.pointer.smoothX.toFixed(4));
+    element.style.setProperty('--card-focus-y', state.pointer.smoothY.toFixed(4));
+    element.style.setProperty('--card-focus-strength', focusStrength.toFixed(4));
+    element.style.setProperty('--card-support-intensity', supportStrength.toFixed(4));
+    element.style.setProperty('--card-twist', `${twistDeg.toFixed(3)}deg`);
+    element.style.setProperty('--card-pulse', pulse.toFixed(4));
+    element.style.setProperty('--card-scroll-momentum', state.scroll.toFixed(4));
+    const rotationPhase =
+      ((state.pointer.smoothX - 0.5) * 0.6) -
+      ((state.pointer.smoothY - 0.5) * 0.5) +
+      state.scroll * 0.28 +
+      supportStrength * 0.16 +
+      globalState.tilt.currentX * 0.2 -
+      globalState.tilt.currentY * 0.18;
+    element.style.setProperty('--card-rotation-phase', rotationPhase.toFixed(4));
+    if (!supportsVisibilityObserver) {
+      element.style.setProperty('--card-visibility', state.isVisible ? '1' : '0');
+    }
+
+    if (focusStrength > 0.05) {
+      const weighting = focusStrength * (0.5 + visibilityFactor * 0.5);
+      weightedX += state.pointer.smoothX * weighting;
+      weightedY += state.pointer.smoothY * weighting;
+      totalFocus += weighting;
+    }
+
+    if (Math.abs(state.pointer.targetX - state.pointer.smoothX) > 0.001 ||
+        Math.abs(state.pointer.targetY - state.pointer.smoothY) > 0.001 ||
+        Math.abs(state.focus.target - state.focus.current) > 0.001 ||
+        Math.abs(state.support.target - state.support.current) > 0.001 ||
+        Math.abs(state.twist.target - state.twist.current) > 0.001 ||
+        state.pulse.current > 0.01 ||
+        (!state.isVisible && (Math.abs(state.pointer.smoothX - 0.5) > 0.001 || Math.abs(state.pointer.smoothY - 0.5) > 0.001))) {
+      continueAnimation = true;
+    }
+  });
+
+  groupStates.forEach((groupState) => {
+    let weightedGroupX = 0;
+    let weightedGroupY = 0;
+    let groupFocus = 0;
+    groupState.cards.forEach((cardState) => {
+      const cardFocus = Math.max(0, Math.min(1.2, cardState.focus.current));
+      if (cardFocus > 0.05) {
+        weightedGroupX += cardState.pointer.smoothX * cardFocus;
+        weightedGroupY += cardState.pointer.smoothY * cardFocus;
+        groupFocus += cardFocus;
+      }
+    });
+
+    groupState.pointer.targetX = groupFocus > 0 ? weightedGroupX / groupFocus : 0.5;
+    groupState.pointer.targetY = groupFocus > 0 ? weightedGroupY / groupFocus : 0.5;
+    groupState.focus.target = Math.min(1, groupFocus);
+
+    groupState.pointer.currentX += (groupState.pointer.targetX - groupState.pointer.currentX) * 0.16;
+    groupState.pointer.currentY += (groupState.pointer.targetY - groupState.pointer.currentY) * 0.16;
+    groupState.focus.current += (groupState.focus.target - groupState.focus.current) * 0.12;
+    groupState.synergy.current += (groupState.synergy.target - groupState.synergy.current) * 0.12;
+
+    const { element, section } = groupState;
+    element.style.setProperty('--group-focus-amount', groupState.focus.current.toFixed(4));
+    element.style.setProperty('--group-focus-x', groupState.pointer.currentX.toFixed(4));
+    element.style.setProperty('--group-focus-y', groupState.pointer.currentY.toFixed(4));
+    element.style.setProperty('--group-synergy', groupState.synergy.current.toFixed(4));
+
+    if (!groupState.section) {
+      groupState.section = element.closest('.section, section, .section-block, .section-wrapper, .group-section') || null;
+    }
+    if (groupState.section) {
+      groupState.section.dataset.globalGroupActive = groupState.synergy.current > 0.05 ? 'true' : 'false';
+      groupState.section.style.setProperty('--section-focus-amount', groupState.focus.current.toFixed(4));
+      groupState.section.style.setProperty('--section-synergy', groupState.synergy.current.toFixed(4));
+    }
+
+    if (Math.abs(groupState.pointer.targetX - groupState.pointer.currentX) > 0.001 ||
+        Math.abs(groupState.pointer.targetY - groupState.pointer.currentY) > 0.001 ||
+        Math.abs(groupState.focus.current - groupState.focus.target) > 0.001 ||
+        Math.abs(groupState.synergy.current - groupState.synergy.target) > 0.001) {
+      continueAnimation = true;
+    }
+  });
+
+  toRemove.forEach((element) => cardStates.delete(element));
+
+  globalState.scroll.current += (globalState.scroll.target - globalState.scroll.current) * 0.12;
+  globalState.scroll.target *= 0.9;
+  if (Math.abs(globalState.scroll.current) > 0.0001 || Math.abs(globalState.scroll.target) > 0.0001) {
+    continueAnimation = true;
+  }
+
+  globalState.synergy.current += (globalState.synergy.target - globalState.synergy.current) * 0.1;
+  if (Math.abs(globalState.synergy.current - globalState.synergy.target) > 0.001) {
+    continueAnimation = true;
+  }
+
+  const focusX = totalFocus > 0 ? weightedX / totalFocus : 0.5;
+  const focusY = totalFocus > 0 ? weightedY / totalFocus : 0.5;
+  const focusAmount = Math.min(1, totalFocus);
+  globalState.focus.targetX = focusX;
+  globalState.focus.targetY = focusY;
+  globalState.focus.targetAmount = focusAmount;
+
+  const focusInfluence = focusAmount * 0.5 + globalState.synergy.current * 0.35;
+  const pointerWeight = 0.55 + focusInfluence * 0.45;
+  const scrollInfluence = globalState.scroll.current * (0.12 + globalState.synergy.current * 0.08);
+  const alignmentDriftX = (globalState.focus.currentX - 0.5) * 0.25;
+  const alignmentDriftY = (0.5 - globalState.focus.currentY) * 0.25;
+
+  globalState.tilt.targetX = ((focusX - 0.5) * pointerWeight) + scrollInfluence + alignmentDriftX;
+  globalState.tilt.targetY = ((0.5 - focusY) * pointerWeight) - scrollInfluence * 0.65 + alignmentDriftY;
+
+  const synergyWeight = globalState.synergy.current * 0.45 + focusAmount * 0.2;
+  const momentumWeight = Math.min(0.5, Math.abs(globalState.scroll.current) * 0.7);
+  globalState.bend.target = Math.min(1, synergyWeight + momentumWeight);
+  globalState.warp.target = Math.max(-1, Math.min(1, (globalState.tilt.targetX - globalState.tilt.targetY) * 0.4));
+
+  globalState.focus.currentX += (globalState.focus.targetX - globalState.focus.currentX) * 0.12;
+  globalState.focus.currentY += (globalState.focus.targetY - globalState.focus.currentY) * 0.12;
+  globalState.focus.currentAmount += (globalState.focus.targetAmount - globalState.focus.currentAmount) * 0.12;
+  globalState.tilt.currentX += (globalState.tilt.targetX - globalState.tilt.currentX) * 0.14;
+  globalState.tilt.currentY += (globalState.tilt.targetY - globalState.tilt.currentY) * 0.14;
+  globalState.bend.current += (globalState.bend.target - globalState.bend.current) * 0.13;
+  globalState.warp.current += (globalState.warp.target - globalState.warp.current) * 0.14;
+
+  const tiltStrength = Math.min(1, Math.sqrt((globalState.tilt.currentX ** 2) + (globalState.tilt.currentY ** 2)) * 1.05 + globalState.bend.current * 0.45);
+
+  const focusDelta = globalState.focus.currentAmount - globalState.focus.lastAmount;
+  globalState.focus.trend += (focusDelta - globalState.focus.trend) * 0.28;
+  globalState.focus.lastAmount = globalState.focus.currentAmount;
+
+  globalState.scroll.speed += (Math.abs(globalState.scroll.current) - globalState.scroll.speed) * 0.25;
+  globalState.scroll.direction = Math.abs(globalState.scroll.current) < 0.0001 ? 0 : (globalState.scroll.current > 0 ? 1 : -1);
+  const scrollDirection = globalState.scroll.direction;
+  const scrollSpeed = Math.min(1, Math.max(0, globalState.scroll.speed));
+  const focusTrend = globalState.focus.trend;
+  const tiltSkew = globalState.tilt.currentX - globalState.tilt.currentY;
+
+  if (
+    Math.abs(globalState.focus.currentX - globalState.focus.targetX) > 0.0008 ||
+    Math.abs(globalState.focus.currentY - globalState.focus.targetY) > 0.0008 ||
+    Math.abs(globalState.focus.currentAmount - globalState.focus.targetAmount) > 0.0008 ||
+    Math.abs(globalState.tilt.currentX - globalState.tilt.targetX) > 0.0008 ||
+    Math.abs(globalState.tilt.currentY - globalState.tilt.targetY) > 0.0008 ||
+    Math.abs(globalState.bend.current - globalState.bend.target) > 0.0008 ||
+    Math.abs(globalState.warp.current - globalState.warp.target) > 0.0008
+  ) {
+    continueAnimation = true;
+  }
+
+  const root = document.documentElement;
+  root.style.setProperty('--global-scroll-momentum', globalState.scroll.current.toFixed(4));
+  root.style.setProperty('--global-scroll-tilt', `${(globalState.scroll.current * 10).toFixed(3)}deg`);
+  root.style.setProperty('--global-synergy-glow', globalState.synergy.current.toFixed(4));
+  root.style.setProperty('--global-focus-x', globalState.focus.currentX.toFixed(4));
+  root.style.setProperty('--global-focus-y', globalState.focus.currentY.toFixed(4));
+  root.style.setProperty('--global-focus-amount', globalState.focus.currentAmount.toFixed(4));
+  root.style.setProperty('--global-bend-intensity', globalState.bend.current.toFixed(4));
+  root.style.setProperty('--global-tilt-x', globalState.tilt.currentX.toFixed(4));
+  root.style.setProperty('--global-tilt-y', globalState.tilt.currentY.toFixed(4));
+  root.style.setProperty('--global-tilt-strength', tiltStrength.toFixed(4));
+  root.style.setProperty('--global-tilt-skew', tiltSkew.toFixed(4));
+  root.style.setProperty('--global-warp', globalState.warp.current.toFixed(4));
+  root.style.setProperty('--global-focus-trend', focusTrend.toFixed(4));
+  root.style.setProperty('--global-scroll-speed', scrollSpeed.toFixed(4));
+  root.style.setProperty('--global-scroll-direction', scrollDirection.toFixed(0));
+
+  sharedMotion.focus.x = globalState.focus.currentX;
+  sharedMotion.focus.y = globalState.focus.currentY;
+  sharedMotion.focus.amount = globalState.focus.currentAmount;
+  sharedMotion.tilt.x = globalState.tilt.currentX;
+  sharedMotion.tilt.y = globalState.tilt.currentY;
+  sharedMotion.tilt.strength = tiltStrength;
+  sharedMotion.bend = globalState.bend.current;
+  sharedMotion.warp = globalState.warp.current;
+  sharedMotion.scroll = globalState.scroll.current;
+  sharedMotion.scrollDirection = scrollDirection;
+  sharedMotion.scrollSpeed = scrollSpeed;
+  sharedMotion.synergy = globalState.synergy.current;
+  sharedMotion.focusTrend = focusTrend;
+  sharedMotion.tiltSkew = tiltSkew;
+  sharedMotion.updatedAt = performance.now();
+
+  maybeDispatchGlobalMotionEvent();
+
+  if (continueAnimation) {
+    requestTick();
+  }
+}
+
+function handleScroll() {
+  const now = performance.now();
+  const deltaY = window.scrollY - globalState.scroll.lastY;
+  const deltaTime = Math.max(16, now - globalState.scroll.lastTime);
+  globalState.scroll.lastY = window.scrollY;
+  globalState.scroll.lastTime = now;
+  const velocity = deltaY / deltaTime;
+  globalState.scroll.target = Math.max(-3, Math.min(3, velocity * 12));
+  if (Math.abs(globalState.scroll.target) > 0.0001) {
+    globalState.scroll.direction = globalState.scroll.target > 0 ? 1 : -1;
+  }
+  cardStates.forEach((state) => {
+    state.scroll += (globalState.scroll.target - state.scroll) * 0.25;
+  });
+  requestTick();
+}
+
+function observeMutations() {
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (!(node instanceof HTMLElement)) {
+          return;
+        }
+        if (shouldRegister(node)) {
+          registerCard(node);
+        }
+        collectCandidateElements(node).forEach((element) => registerCard(element));
+      });
+    });
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+}
+
+function applyStaticMotionSnapshot() {
+  const root = document.documentElement;
+  if (!root) {
+    return;
+  }
+
+  root.classList.add('global-orchestrator-static');
+  if (bodyElement) {
+    bodyElement.classList.add('global-orchestrator-static');
+  }
+
+  const defaults = {
+    '--global-scroll-momentum': '0',
+    '--global-scroll-tilt': '0deg',
+    '--global-synergy-glow': '0',
+    '--global-focus-x': '0.5',
+    '--global-focus-y': '0.5',
+    '--global-focus-amount': '0',
+    '--global-bend-intensity': '0',
+    '--global-tilt-x': '0',
+    '--global-tilt-y': '0',
+    '--global-tilt-strength': '0',
+    '--global-tilt-skew': '0',
+    '--global-warp': '0',
+    '--global-focus-trend': '0',
+    '--global-scroll-speed': '0',
+    '--global-scroll-direction': '0'
+  };
+
+  Object.entries(defaults).forEach(([key, value]) => {
+    root.style.setProperty(key, value);
+  });
+
+  sharedMotion.focus.x = 0.5;
+  sharedMotion.focus.y = 0.5;
+  sharedMotion.focus.amount = 0;
+  sharedMotion.focusTrend = 0;
+  sharedMotion.tilt.x = 0;
+  sharedMotion.tilt.y = 0;
+  sharedMotion.tilt.strength = 0;
+  sharedMotion.tiltSkew = 0;
+  sharedMotion.bend = 0;
+  sharedMotion.warp = 0;
+  sharedMotion.scroll = 0;
+  sharedMotion.scrollSpeed = 0;
+  sharedMotion.scrollDirection = 0;
+  sharedMotion.synergy = 0;
+
+  if (activePageProfile) {
+    sharedMotion.palette = activePageProfile.palette || null;
+    sharedMotion.collection = activePageProfile.key || null;
+    sharedMotion.family = activePageProfile.family || null;
+    sharedMotion.layout = activePageProfile.layout || null;
+  }
+
+  sharedMotion.updatedAt = performance.now();
+  motionEventState.lastDetail = null;
+  motionEventState.lastDispatch = 0;
+  maybeDispatchGlobalMotionEvent();
+}
+
+async function initialise() {
+  preparePageProfile(activePageProfile);
+  ensureStylesheet('styles/global-card-synergy.css', 'global-card-synergy');
+  collectCandidateElements().forEach((element) => registerCard(element));
+  updateSupportTargets(null);
+  observeMutations();
+  window.addEventListener('scroll', handleScroll, { passive: true });
+  let resizeTimeout = null;
+  window.addEventListener('resize', () => {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(() => {
+      collectCandidateElements().forEach((element) => registerCard(element));
+    }, 120);
+  });
+  handleScroll();
+  await ensureCardSystem();
+}
+
+if (orchestratorDisabled) {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyStaticMotionSnapshot, { once: true });
+  } else {
+    applyStaticMotionSnapshot();
+  }
+} else if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initialise, { once: true });
+} else {
+  initialise();
+}

--- a/scripts/page-profile-registry.js
+++ b/scripts/page-profile-registry.js
@@ -1,0 +1,277 @@
+const PROFILE_DEFINITIONS = [
+  {
+    key: 'meta-index',
+    label: 'Meta Index Overview',
+    family: 'meta',
+    layout: 'map',
+    palette: 'meta',
+    accent: '#7ef6ff',
+    fileNames: ['index.html'],
+    tags: ['index', 'meta', 'map', 'directory'],
+    titleTokens: ['all versions', 'collections', 'clear seas solutions'],
+    overlay: {
+      blend: 'screen',
+      opacity: 1.08,
+      filter: 'hue-rotate(18deg) saturate(1.35) brightness(1.1)',
+      rotate: '6deg',
+      depth: '18px'
+    },
+    canvas: {
+      scale: 0.08,
+      depth: '12px'
+    },
+    imageOrder: [2, 3, 4, 0, 1, 5, 6, 7, 8],
+    videoOrder: [4, 5, 6, 0, 1, 2, 3],
+    videoPattern: [0, 1]
+  },
+  {
+    key: 'core-foundation',
+    label: 'Core Foundation Builds',
+    family: 'foundation',
+    layout: 'grid',
+    palette: 'foundation',
+    accent: '#8ddcff',
+    fileNames: [
+      '1-index.html',
+      '2-index-optimized.html',
+      '3-index-fixed.html',
+      '4-index-unified.html',
+      '5-index-vib34d-integrated.html',
+      '6-index-totalistic.html'
+    ],
+    tags: ['core', 'foundation', 'totalistic', 'unified'],
+    titleTokens: ['clear seas solutions', 'totalistic', 'integrated'],
+    overlay: {
+      blend: 'soft-light',
+      opacity: 0.96,
+      filter: 'saturate(1.2) brightness(1.05)',
+      rotate: '2deg',
+      depth: '8px'
+    },
+    canvas: {
+      scale: 0.12,
+      depth: '18px'
+    },
+    imageOrder: [0, 5, 1, 6, 2, 7, 3, 8, 4],
+    videoOrder: [1, 2, 3, 0, 4, 5, 6],
+    videoPattern: [0, 1, 0, 0]
+  },
+  {
+    key: 'immersive-ai',
+    label: 'Immersive AI Journeys',
+    family: 'immersive',
+    layout: 'timeline',
+    palette: 'immersive',
+    accent: '#ffaadf',
+    fileNames: [
+      '10-pr-4.html', '11-pr-5.html', '12-pr-6.html',
+      '14-pr-8.html', '15-pr-9.html', '16-pr-10.html',
+      '17-pr-11.html', '18-pr-12.html', '19-pr-13.html',
+      '20-pr-14.html', '21-pr-15.html', '22-pr-16.html',
+      '23-pr-17.html', '24-pr-18.html', '25-pr-19.html',
+      '26-pr-20.html', '27-pr-21.html', '28-pr-22.html',
+      '29-pr-23.html', '30-pr-24.html'
+    ],
+    tags: ['immersive', 'mission', 'pulse', 'signal', 'pr', 'blueprint'],
+    titleTokens: ['immersive experience', 'mission axis', 'experience blueprint'],
+    overlay: {
+      blend: 'color-dodge',
+      opacity: 1.14,
+      filter: 'hue-rotate(32deg) saturate(1.5) brightness(1.18)',
+      rotate: '9deg',
+      depth: '28px'
+    },
+    canvas: {
+      scale: 0.18,
+      depth: '26px'
+    },
+    imageOrder: [4, 0, 5, 1, 6, 2, 7, 3, 8],
+    videoOrder: [4, 5, 6, 0, 1, 2, 3],
+    videoPattern: [1, 0, 1, 1],
+    scripts: ['scripts/immersive-experience-actualizer.js']
+  },
+  {
+    key: 'concept-labs',
+    label: 'Concept Lab Explorations',
+    family: 'labs',
+    layout: 'gallery',
+    palette: 'concept',
+    accent: '#caa5ff',
+    fileNames: [
+      '7-pr-1.html',
+      '8-pr-2.html',
+      '9-pr-3.html',
+      '13-pr-7.html',
+      '25-orthogonal-depth-progression.html',
+      'ultimate-clear-seas-holistic-system.html'
+    ],
+    tags: ['concept', 'lab', 'gallery', 'codex', 'orthogonal', 'ultimate'],
+    titleTokens: ['visual codex', 'orthogonal depth', 'holistic system'],
+    overlay: {
+      blend: 'lighten',
+      opacity: 1.22,
+      filter: 'hue-rotate(280deg) saturate(1.45) brightness(1.12)',
+      rotate: '-7deg',
+      depth: '32px'
+    },
+    canvas: {
+      scale: 0.22,
+      depth: '34px'
+    },
+    imageOrder: [6, 7, 8, 3, 4, 0, 1, 2, 5],
+    videoOrder: [2, 3, 4, 5, 6, 0, 1],
+    videoPattern: [1, 1, 0, 1]
+  }
+];
+
+function normaliseToken(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase();
+}
+
+function normaliseFileName(name) {
+  if (!name) {
+    return 'index.html';
+  }
+  const trimmed = name.trim().toLowerCase();
+  if (!trimmed) {
+    return 'index.html';
+  }
+  return trimmed.endsWith('.html') ? trimmed : `${trimmed}.html`;
+}
+
+function computeHashSeed(input) {
+  let hash = 0;
+  const source = input || '';
+  for (let i = 0; i < source.length; i += 1) {
+    hash = (hash * 131 + source.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+const normalisedProfiles = PROFILE_DEFINITIONS.map((definition) => ({
+  ...definition,
+  fileNames: new Set((definition.fileNames || []).map(normaliseFileName)),
+  tags: new Set((definition.tags || []).map(normaliseToken)),
+  titleTokens: (definition.titleTokens || []).map(normaliseToken)
+}));
+
+export function listPageProfiles() {
+  return normalisedProfiles.map((profile) => ({
+    key: profile.key,
+    label: profile.label,
+    family: profile.family,
+    layout: profile.layout,
+    palette: profile.palette,
+    accent: profile.accent
+  }));
+}
+
+function readCandidateTokens(docEl, bodyEl) {
+  const tokens = [];
+  if (docEl) {
+    tokens.push(docEl.dataset.pageCollection);
+    tokens.push(docEl.dataset.collection);
+    tokens.push(docEl.dataset.showcaseTheme);
+    tokens.push(docEl.dataset.showcaseCard);
+  }
+  if (bodyEl && bodyEl.dataset) {
+    tokens.push(bodyEl.dataset.pageCollection);
+    tokens.push(bodyEl.dataset.collection);
+  }
+  return tokens.filter(Boolean).map(normaliseToken);
+}
+
+export function resolvePageProfile(context = {}) {
+  const doc = context.document || (typeof document !== 'undefined' ? document : null);
+  const docEl = doc ? doc.documentElement : null;
+  const body = doc ? doc.body : null;
+  const path = context.path || (typeof window !== 'undefined' && window.location ? window.location.pathname : '');
+  const pathToken = path ? path.split('/').filter(Boolean).pop() : '';
+  const metaName = normaliseFileName(pathToken || (docEl && docEl.dataset ? docEl.dataset.pageId : '') || '');
+  const title = normaliseToken(doc ? doc.title : context.title || '');
+  const candidateTokens = readCandidateTokens(docEl, body);
+
+  let matched = normalisedProfiles.find((profile) => profile.fileNames.has(metaName));
+  if (!matched) {
+    matched = normalisedProfiles.find((profile) => candidateTokens.some((token) => profile.tags.has(token)));
+  }
+  if (!matched) {
+    matched = normalisedProfiles.find((profile) => profile.titleTokens.some((token) => title.includes(token)));
+  }
+  if (!matched) {
+    matched = normalisedProfiles.find((profile) => profile.key === 'core-foundation') || normalisedProfiles[0];
+  }
+
+  const signatureParts = [metaName, title].concat(candidateTokens);
+  const signature = signatureParts.filter(Boolean).join('|') || metaName;
+  const seed = computeHashSeed(signature);
+
+  return {
+    key: matched.key,
+    label: matched.label,
+    family: matched.family,
+    layout: matched.layout,
+    palette: matched.palette,
+    accent: matched.accent,
+    overlay: matched.overlay ? { ...matched.overlay } : {},
+    canvas: matched.canvas ? { ...matched.canvas } : {},
+    imageOrder: matched.imageOrder ? [...matched.imageOrder] : null,
+    videoOrder: matched.videoOrder ? [...matched.videoOrder] : null,
+    videoPattern: matched.videoPattern ? [...matched.videoPattern] : null,
+    scripts: matched.scripts ? [...matched.scripts] : [],
+    signature,
+    seed,
+    metaName,
+    candidateTokens
+  };
+}
+
+export function applyProfileMetadata(profile, targetDocument = typeof document !== 'undefined' ? document : null) {
+  if (!profile || !targetDocument) {
+    return;
+  }
+  const docEl = targetDocument.documentElement;
+  const body = targetDocument.body;
+  if (!docEl) {
+    return;
+  }
+  docEl.dataset.globalPageCollection = profile.key;
+  docEl.dataset.globalBrandPalette = profile.palette;
+  docEl.dataset.globalPageFamily = profile.family || profile.key;
+  docEl.dataset.globalPageLayout = profile.layout || 'grid';
+  if (body) {
+    body.dataset.globalPageCollection = profile.key;
+    body.dataset.globalBrandPalette = profile.palette;
+    body.dataset.globalPageFamily = profile.family || profile.key;
+    body.dataset.globalPageLayout = profile.layout || 'grid';
+  }
+  if (profile.accent) {
+    docEl.style.setProperty('--global-brand-accent', profile.accent);
+  }
+  if (profile.palette) {
+    docEl.style.setProperty('--global-brand-palette', profile.palette);
+  }
+  if (profile.overlay?.filter) {
+    docEl.style.setProperty('--global-brand-overlay-filter', profile.overlay.filter);
+  }
+  if (profile.overlay?.opacity != null) {
+    docEl.style.setProperty('--global-brand-overlay-opacity', String(profile.overlay.opacity));
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.__CLEAR_SEAS_PAGE_PROFILE_REGISTRY = {
+    list: listPageProfiles,
+    resolve: resolvePageProfile,
+    apply: applyProfileMetadata
+  };
+}
+
+export default {
+  listPageProfiles,
+  resolvePageProfile,
+  applyProfileMetadata
+};
+

--- a/scripts/vib34d-contained-card-system.js
+++ b/scripts/vib34d-contained-card-system.js
@@ -5,6 +5,131 @@
  * A Paul Phillips Manifestation - Paul@clearseassolutions.com
  */
 
+const BRAND_OVERRIDE_EVENT = window.__CLEAR_SEAS_BRAND_OVERRIDE_EVENT || 'clear-seas:brand-overrides-changed';
+
+const VIB34D_BRAND_LIBRARY_DEFAULTS = {
+  overlays: [
+    'assets/Screenshot_20250430-141821.png',
+    'assets/Screenshot_20250430-142002~2.png',
+    'assets/Screenshot_20250430-142024~2.png',
+    'assets/Screenshot_20250430-142032~2.png',
+    'assets/Screenshot_20241012-073718.png',
+    'assets/file_0000000006fc6230a8336bfa1fcebd89.png',
+    'assets/file_0000000054a06230817873012865d150.png',
+    'assets/file_00000000fc08623085668cf8b5e0a1e5.png',
+    'assets/image_8 (1).png'
+  ],
+  videos: [
+    '20250505_1321_Neon Blossom Transformation_simple_compose_01jtgqf5vjevn8nbrnsx8yd5fs.mp4',
+    '20250505_1726_Noir Filament Mystery_simple_compose_01jth5f1kwe9r9zxqet54bz3q0.mp4',
+    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv071e06vmjd0mn60zm3s.mp4',
+    '20250506_0014_Gemstone Coral Transformation_remix_01jthwv0c4fxk8m0e79ry2t4ke.mp4',
+    '1746496560073.mp4',
+    '1746500614769.mp4',
+    '1746576068221.mp4'
+  ],
+  logos: [
+    'assets/clear-seas-logo-aurora.svg',
+    'assets/clear-seas-monogram.svg'
+  ]
+};
+
+const vibBrandOverrideFallback = {
+  collect: () => null,
+  mergeOverlaySettings: (base) => ({ ...(base || {}) }),
+  mergeCanvasSettings: (base) => ({ ...(base || {}) }),
+  resolveMode: (_overrides, fallback) => fallback,
+  pickAsset: (_overrides, _type, index, fallback) => (typeof fallback === 'function' ? fallback(index) : null),
+  shouldCycle: () => false,
+  nextCycleIndex: (_overrides, current) => (Number.isFinite(current) ? current + 1 : 1),
+  applyPalette: (overrides, fallback) => overrides?.palette || fallback,
+  hasAssetList: (overrides, type) => {
+    const key = type === 'videos' ? 'videos' : 'images';
+    return Array.isArray(overrides?.[key]) && overrides[key].length > 0;
+  },
+  refresh: (detail) => {
+    const eventDetail = {
+      reason: detail && typeof detail === 'object' && detail.reason ? detail.reason : 'manual-refresh',
+      timestamp: Date.now()
+    };
+    if (detail && typeof detail === 'object') {
+      Object.keys(detail).forEach((key) => {
+        if (key === 'reason') {
+          return;
+        }
+        eventDetail[key] = detail[key];
+      });
+    }
+    window.dispatchEvent(new CustomEvent(BRAND_OVERRIDE_EVENT, { detail: eventDetail }));
+    return [];
+  },
+  eventName: BRAND_OVERRIDE_EVENT
+};
+
+const vibBrandOverrideApi = window.__CLEAR_SEAS_BRAND_OVERRIDE_API || vibBrandOverrideFallback;
+
+function ensureVibSharedBrandLibrary() {
+  const mergeUnique = (target, source) => {
+    if (!Array.isArray(source)) return target;
+    source.forEach((item) => {
+      if (typeof item === 'string' && !target.includes(item)) {
+        target.push(item);
+      }
+    });
+    return target;
+  };
+
+  if (window.ClearSeasBrandLibrary && typeof window.clearSeasAcquireBrandAsset === 'function') {
+    mergeUnique(window.ClearSeasBrandLibrary.overlays ||= [], VIB34D_BRAND_LIBRARY_DEFAULTS.overlays);
+    mergeUnique(window.ClearSeasBrandLibrary.videos ||= [], VIB34D_BRAND_LIBRARY_DEFAULTS.videos);
+    mergeUnique(window.ClearSeasBrandLibrary.logos ||= [], VIB34D_BRAND_LIBRARY_DEFAULTS.logos);
+    return window.clearSeasAcquireBrandAsset;
+  }
+
+  const pageProfile = window.__CLEAR_SEAS_PAGE_PROFILE || {};
+  const library = {
+    overlays: [...VIB34D_BRAND_LIBRARY_DEFAULTS.overlays],
+    videos: [...VIB34D_BRAND_LIBRARY_DEFAULTS.videos],
+    logos: [...VIB34D_BRAND_LIBRARY_DEFAULTS.logos],
+    cursor: 0,
+    palette: pageProfile.palette || 'foundation'
+  };
+
+  if (typeof pageProfile.seed === 'number') {
+    const poolSize = Math.max(1, library.overlays.length + library.videos.length + library.logos.length);
+    library.cursor = Math.abs(pageProfile.seed) % poolSize;
+  }
+
+  const getPool = (preference) => {
+    const pref = (preference || '').toLowerCase();
+    if (pref.startsWith('video')) return library.videos;
+    if (pref.startsWith('logo')) return library.logos.length ? library.logos : library.overlays;
+    if (pref.startsWith('overlay') || pref.startsWith('image') || pref.startsWith('brand')) {
+      return library.overlays.length ? library.overlays : [...library.logos, ...library.videos];
+    }
+    return [...library.videos, ...library.overlays, ...library.logos];
+  };
+
+  const acquire = (preference) => {
+    const pool = getPool(preference);
+    if (!pool.length) {
+      return null;
+    }
+    const index = Math.abs(library.cursor) % pool.length;
+    library.cursor += 1;
+    const src = pool[index];
+    const type = typeof src === 'string' && src.toLowerCase().endsWith('.mp4') ? 'video' : 'image';
+    return { src, type };
+  };
+
+  library.acquire = acquire;
+  window.ClearSeasBrandLibrary = library;
+  window.clearSeasAcquireBrandAsset = acquire;
+  return acquire;
+}
+
+const acquireVibBrandAsset = ensureVibSharedBrandLibrary();
+
 class VIB34DContainedCardSystem {
   constructor() {
     this.cardVisualizers = new Map();
@@ -13,6 +138,57 @@ class VIB34DContainedCardSystem {
 
     // Import VIB34D systems
     this.engineClasses = {};
+    this.brandOverrideEvent = vibBrandOverrideApi.eventName || BRAND_OVERRIDE_EVENT;
+    this.globalMotionEvent = window.__CLEAR_SEAS_GLOBAL_MOTION_EVENT || 'clear-seas:motion-updated';
+    this.globalMotionState = {
+      focusAmount: 0,
+      synergy: 0,
+      tiltX: 0,
+      tiltY: 0,
+      tiltStrength: 0,
+      bend: 0,
+      warp: 0,
+      scrollMomentum: 0,
+      scrollDirection: 0,
+      scrollSpeed: 0,
+      focusTrend: 0,
+      tiltSkew: 0,
+      timestamp: performance.now()
+    };
+    this.handleBrandOverridesChanged = () => {
+      this.cardVisualizers.forEach((visualizer) => {
+        if (!visualizer || typeof visualizer.refreshBrandLayer !== 'function') {
+          return;
+        }
+        visualizer.refreshBrandLayer({ recalcOverrides: true, resetCycle: true });
+      });
+    };
+    window.addEventListener(this.brandOverrideEvent, this.handleBrandOverridesChanged);
+    this.handleGlobalMotionUpdate = (event) => {
+      const detail = event?.detail || {};
+      this.globalMotionState = {
+        focusAmount: Number(detail.focusAmount) || 0,
+        synergy: Number(detail.synergy) || 0,
+        tiltX: Number(detail.tiltX) || 0,
+        tiltY: Number(detail.tiltY) || 0,
+        tiltStrength: Number(detail.tiltStrength) || 0,
+        bend: Number(detail.bend) || 0,
+        warp: Number(detail.warp) || 0,
+        scrollMomentum: Number(detail.scrollMomentum) || 0,
+        scrollDirection: Number(detail.scrollDirection) || 0,
+        scrollSpeed: Number(detail.scrollSpeed) || 0,
+        focusTrend: Number(detail.focusTrend) || 0,
+        tiltSkew: Number(detail.tiltSkew) || 0,
+        timestamp: typeof detail.timestamp === 'number' ? detail.timestamp : performance.now()
+      };
+
+      this.cardVisualizers.forEach((visualizer) => {
+        if (visualizer && typeof visualizer.setGlobalMotion === 'function') {
+          visualizer.setGlobalMotion(this.globalMotionState);
+        }
+      });
+    };
+    window.addEventListener(this.globalMotionEvent, this.handleGlobalMotionUpdate);
     this.loadVIB34DSystems();
   }
 
@@ -66,6 +242,9 @@ class VIB34DContainedCardSystem {
 
     // Create contained visualizer instance
     const visualizer = new VIB34DContainedVisualizer(card, systemType, this.engineClasses);
+    if (visualizer && typeof visualizer.setGlobalMotion === 'function') {
+      visualizer.setGlobalMotion(this.globalMotionState);
+    }
     this.cardVisualizers.set(card, visualizer);
 
     console.log(`🎨 Created ${systemType} visualizer for card:`, card.id);
@@ -89,10 +268,13 @@ class VIB34DContainedCardSystem {
   }
 
   destroy() {
+    window.removeEventListener(this.brandOverrideEvent, this.handleBrandOverridesChanged);
+    window.removeEventListener(this.globalMotionEvent, this.handleGlobalMotionUpdate);
     this.cardVisualizers.forEach(visualizer => visualizer.destroy());
     this.cardVisualizers.clear();
     if (this.observer) {
       this.observer.disconnect();
+      this.observer = null;
     }
   }
 }
@@ -120,6 +302,22 @@ class VIB34DContainedVisualizer {
       intensity: 0.7
     };
 
+    this.focusState = {
+      current: 0.28,
+      target: 0.35,
+      pulse: 0,
+      raf: null
+    };
+
+    this.brandHost = null;
+    this.brandMedia = null;
+    this.resizeObserver = null;
+    this.layerCanvases = [];
+
+    this.brandOverrideApi = vibBrandOverrideApi;
+    this.brandOverrides = this.brandOverrideApi.collect ? this.brandOverrideApi.collect(this.card) : null;
+    this.assetCycle = 0;
+
     // VIB34D Parameters - Rich parameter sets based on Paul Phillips' system configurations
     this.parameters = this.getVIB34DParametersForSystem(systemType);
 
@@ -130,107 +328,316 @@ class VIB34DContainedVisualizer {
       rot4dZW: 0
     };
 
+    this.globalMotionState = {
+      focusAmount: 0,
+      synergy: 0,
+      tiltX: 0,
+      tiltY: 0,
+      tiltStrength: 0,
+      bend: 0,
+      warp: 0,
+      scrollMomentum: 0,
+      timestamp: performance.now()
+    };
+
     this.init();
+  }
+
+  setGlobalMotion(motion = {}) {
+    const normalized = {
+      focusAmount: Math.max(0, Math.min(1, Number(motion.focusAmount) || 0)),
+      synergy: Math.max(0, Math.min(1.2, Number(motion.synergy) || 0)),
+      tiltX: Number(motion.tiltX) || 0,
+      tiltY: Number(motion.tiltY) || 0,
+      tiltStrength: Math.max(0, Number(motion.tiltStrength) || 0),
+      bend: Math.max(0, Number(motion.bend) || 0),
+      warp: Number(motion.warp) || 0,
+      scrollMomentum: Number(motion.scrollMomentum) || 0,
+      scrollDirection: Math.max(-1, Math.min(1, Number(motion.scrollDirection) || 0)),
+      scrollSpeed: Math.max(0, Math.min(1, Number(motion.scrollSpeed) || 0)),
+      focusTrend: Number.isFinite(motion.focusTrend) ? motion.focusTrend : 0,
+      tiltSkew: Number.isFinite(motion.tiltSkew) ? motion.tiltSkew : 0,
+      timestamp: typeof motion.timestamp === 'number' ? motion.timestamp : performance.now()
+    };
+
+    this.globalMotionState = normalized;
+
+    if (this.card) {
+      this.card.style.setProperty('--shared-focus-amount', normalized.focusAmount.toFixed(4));
+      this.card.style.setProperty('--shared-synergy', normalized.synergy.toFixed(4));
+      this.card.style.setProperty('--shared-tilt-x', normalized.tiltX.toFixed(4));
+      this.card.style.setProperty('--shared-tilt-y', normalized.tiltY.toFixed(4));
+      this.card.style.setProperty('--shared-tilt-strength', normalized.tiltStrength.toFixed(4));
+      this.card.style.setProperty('--shared-bend', normalized.bend.toFixed(4));
+      this.card.style.setProperty('--shared-warp', normalized.warp.toFixed(4));
+      this.card.style.setProperty('--shared-scroll', normalized.scrollMomentum.toFixed(4));
+      this.card.style.setProperty('--shared-scroll-direction', normalized.scrollDirection.toFixed(0));
+      this.card.style.setProperty('--shared-scroll-speed', normalized.scrollSpeed.toFixed(4));
+      this.card.style.setProperty('--shared-focus-trend', normalized.focusTrend.toFixed(4));
+      this.card.style.setProperty('--shared-tilt-skew', normalized.tiltSkew.toFixed(4));
+    }
   }
 
   init() {
     this.createContainedCanvasSystem();
     this.setupUserInteractions();
     this.createVIB34DEngine();
+    this.startFocusLoop();
     this.start();
   }
 
   createContainedCanvasSystem() {
-    // Create contained canvas system within card boundaries
-    this.canvasContainer = document.createElement('div');
-    this.canvasContainer.className = 'vib34d-card-container';
-    this.canvasContainer.style.cssText = `
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      border-radius: inherit;
-      pointer-events: none;
-      z-index: 1;
-    `;
-
-    // Ensure card is positioned relatively
     if (getComputedStyle(this.card).position === 'static') {
       this.card.style.position = 'relative';
     }
 
-    // Create 5-layer VIB34D canvas system - CONTAINED within card
+    this.card.classList.add('visualizer-host', 'card-brand-enhanced');
+
+    const baseWeight = Number(this.card.dataset.visualizerWeight || '1.1');
+    const bleed = Number.isFinite(baseWeight) ? Math.max(1.22, baseWeight + 0.2) : 1.28;
+    this.card.style.setProperty('--visualizer-bleed', bleed.toFixed(3));
+    this.card.style.setProperty('--visualizer-scale', (bleed + 0.14).toFixed(3));
+    if (!this.card.style.getPropertyValue('--brand-rotation')) {
+      this.card.style.setProperty('--brand-rotation', `${(Math.random() * 36 - 18).toFixed(2)}deg`);
+    }
+
+    this.canvasContainer = document.createElement('div');
+    this.canvasContainer.className = 'visualizer-shell vib34d-card-container';
+    this.canvasContainer.setAttribute('aria-hidden', 'true');
+    this.canvasContainer.style.pointerEvents = 'none';
+
+    const pageProfile = window.__CLEAR_SEAS_PAGE_PROFILE || {};
+    const overlaySettings = this.brandOverrideApi.mergeOverlaySettings(pageProfile.overlay || {}, this.brandOverrides ? this.brandOverrides.overlay : null);
+    const canvasSettings = this.brandOverrideApi.mergeCanvasSettings(pageProfile.canvas || {}, this.brandOverrides ? this.brandOverrides.canvas : null);
+    const palette = this.brandOverrideApi.applyPalette(this.brandOverrides, pageProfile.palette || 'foundation');
+
+    this.card.dataset.brandPalette = palette;
+    this.card.style.setProperty('--brand-overlay-opacity', overlaySettings.opacity != null ? String(overlaySettings.opacity) : '1');
+    this.card.style.setProperty('--brand-overlay-filter', overlaySettings.filter || 'brightness(1)');
+    this.card.style.setProperty('--brand-overlay-blend', overlaySettings.blend || 'screen');
+    this.card.style.setProperty('--brand-overlay-rotate', overlaySettings.rotate || '0deg');
+    this.card.style.setProperty('--brand-overlay-depth', overlaySettings.depth || '0px');
+    if (canvasSettings.scale != null) {
+      this.card.style.setProperty('--card-canvas-scale', String(canvasSettings.scale));
+    }
+    if (canvasSettings.depth) {
+      this.card.style.setProperty('--card-canvas-depth', canvasSettings.depth);
+    }
+
     const layerNames = ['background', 'shadow', 'content', 'highlight', 'accent'];
     const containerId = `vib34d-card-${Math.random().toString(36).substr(2, 9)}`;
+    this.layerCanvases = [];
 
     layerNames.forEach((layerName, index) => {
       const canvas = document.createElement('canvas');
       canvas.id = `${containerId}-${layerName}`;
-      canvas.className = 'vib34d-card-canvas';
-      canvas.style.cssText = `
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        pointer-events: none;
-        z-index: ${index + 1};
-      `;
-
+      canvas.dataset.visualizerLayer = layerName;
+      canvas.className = `visualizer-shell__canvas vib34d-card-layer vib34d-card-layer--${layerName}`;
+      canvas.style.zIndex = String(index + 1);
       this.canvasContainer.appendChild(canvas);
+      this.layerCanvases.push(canvas);
     });
 
-    // Insert as first child so it stays behind card content
+    this.brandHost = this.attachBrandLayer();
+    if (this.brandHost) {
+      this.canvasContainer.appendChild(this.brandHost);
+    }
+
     this.card.insertBefore(this.canvasContainer, this.card.firstChild);
     this.resizeCanvases();
   }
 
   resizeCanvases() {
+    if (!this.canvasContainer) return;
     const rect = this.card.getBoundingClientRect();
-    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const dpr = Math.min(window.devicePixelRatio || 1, 2.5);
+    const bleedFactor = Number(this.card.style.getPropertyValue('--visualizer-bleed')) || 1.28;
+    const resolutionScale = bleedFactor + 0.36;
 
-    const canvases = this.canvasContainer.querySelectorAll('canvas');
+    const canvases = this.layerCanvases && this.layerCanvases.length
+      ? this.layerCanvases
+      : Array.from(this.canvasContainer.querySelectorAll('canvas'));
+
     canvases.forEach(canvas => {
-      canvas.width = rect.width * dpr;
-      canvas.height = rect.height * dpr;
-      canvas.style.width = rect.width + 'px';
-      canvas.style.height = rect.height + 'px';
+      const width = Math.max(1, Math.round(rect.width * resolutionScale * dpr));
+      const height = Math.max(1, Math.round(rect.height * resolutionScale * dpr));
+      if (canvas.width !== width) canvas.width = width;
+      if (canvas.height !== height) canvas.height = height;
+      canvas.style.width = '100%';
+      canvas.style.height = '100%';
     });
+  }
+
+  attachBrandLayer() {
+    const assetPreference = this.card.dataset.visualizerAsset || this.systemType;
+    if (typeof acquireVibBrandAsset !== 'function') {
+      return null;
+    }
+
+    const pageProfile = window.__CLEAR_SEAS_PAGE_PROFILE || {};
+    const overlaySettings = this.brandOverrideApi.mergeOverlaySettings(pageProfile.overlay || {}, this.brandOverrides ? this.brandOverrides.overlay : null);
+    const palette = this.brandOverrideApi.applyPalette(this.brandOverrides, pageProfile.palette || 'foundation');
+
+    let asset = null;
+    const cycleIndex = this.assetCycle || 0;
+    if (this.brandOverrides && this.brandOverrideApi.hasAssetList(this.brandOverrides, 'videos')) {
+      const overrideVideo = this.brandOverrideApi.pickAsset(this.brandOverrides, 'videos', cycleIndex, () => null);
+      if (overrideVideo) {
+        asset = { type: 'video', src: overrideVideo };
+      }
+    }
+    if (!asset && this.brandOverrides && this.brandOverrideApi.hasAssetList(this.brandOverrides, 'images')) {
+      const overrideImage = this.brandOverrideApi.pickAsset(this.brandOverrides, 'images', cycleIndex, () => null);
+      if (overrideImage) {
+        asset = { type: 'image', src: overrideImage };
+      }
+    }
+    if (!asset) {
+      const fallback = acquireVibBrandAsset(assetPreference);
+      if (!fallback || !fallback.src) {
+        return null;
+      }
+      asset = fallback;
+    }
+
+    const host = document.createElement('div');
+    host.className = 'visualizer-shell__brand';
+    host.dataset.brandType = asset.type;
+    host.dataset.brandPalette = palette;
+    host.style.setProperty('--brand-overlay-opacity', overlaySettings.opacity != null ? String(overlaySettings.opacity) : '1');
+    host.style.setProperty('--brand-overlay-filter', overlaySettings.filter || 'brightness(1)');
+    host.style.setProperty('--brand-overlay-blend', overlaySettings.blend || 'screen');
+    host.style.setProperty('--brand-overlay-rotate', overlaySettings.rotate || '0deg');
+    host.style.setProperty('--brand-overlay-depth', overlaySettings.depth || '0px');
+
+    if (!this.card.style.getPropertyValue('--brand-rotation')) {
+      this.card.style.setProperty('--brand-rotation', `${(Math.random() * 32 - 16).toFixed(2)}deg`);
+    }
+
+    if (asset.type === 'video') {
+      host.classList.add('visualizer-shell__brand--video');
+      const video = document.createElement('video');
+      video.className = 'visualizer-shell__brand-media';
+      video.src = this.resolveMediaSource(asset.src);
+      video.muted = true;
+      video.loop = true;
+      video.autoplay = true;
+      video.playsInline = true;
+      video.setAttribute('muted', '');
+      video.setAttribute('playsinline', '');
+      video.addEventListener('loadeddata', () => {
+        video.play().catch(() => {});
+      }, { once: true });
+      host.appendChild(video);
+      this.brandMedia = video;
+    } else {
+      host.classList.add('visualizer-shell__brand--image');
+      host.style.setProperty('--brand-image', `url(${this.resolveMediaSource(asset.src)})`);
+      this.brandMedia = null;
+    }
+
+    this.brandHost = host;
+    return host;
+  }
+
+  resolveMediaSource(src) {
+    if (!src) {
+      return '';
+    }
+    const trimmed = String(src).trim();
+    if (/^(?:https?:|data:)/i.test(trimmed)) {
+      return trimmed;
+    }
+    if (trimmed.startsWith('assets/') || trimmed.startsWith('./') || trimmed.startsWith('../')) {
+      return trimmed;
+    }
+    return `./${trimmed.replace(/^\.\/?/, '')}`;
+  }
+
+  refreshBrandLayer(options = {}) {
+    const { recalcOverrides = false, resetCycle = false } = options || {};
+    if (recalcOverrides && this.brandOverrideApi && typeof this.brandOverrideApi.collect === 'function') {
+      this.brandOverrides = this.brandOverrideApi.collect(this.card);
+    }
+    if (resetCycle) {
+      this.assetCycle = 0;
+    }
+    if (this.brandHost && this.brandHost.parentNode) {
+      this.brandHost.parentNode.removeChild(this.brandHost);
+    }
+    if (this.brandMedia) {
+      try {
+        this.brandMedia.pause();
+      } catch (error) {
+        // ignore pause errors
+      }
+      this.brandMedia = null;
+    }
+    this.brandHost = this.attachBrandLayer();
+    if (this.brandHost && this.canvasContainer) {
+      this.canvasContainer.appendChild(this.brandHost);
+    }
+  }
+
+  tryCycleBrand(trigger) {
+    if (!this.brandOverrideApi.shouldCycle(this.brandOverrides, trigger)) {
+      return;
+    }
+    this.assetCycle = this.brandOverrideApi.nextCycleIndex(this.brandOverrides, this.assetCycle);
+    this.refreshBrandLayer();
   }
 
   setupUserInteractions() {
     // Smart mouse tracking for elegant parameter changes
-    this.card.addEventListener('mouseenter', () => {
+    const handleEnter = () => {
       this.mouseState.intensity = 1.0;
+      this.focusState.target = Math.max(this.focusState.target, 1.05);
       this.updateVIB34DParameters({ intensity: 1.0 });
-    });
+      this.tryCycleBrand('focus');
+      if (this.brandMedia) {
+        this.brandMedia.play().catch(() => {});
+      }
+    };
 
-    this.card.addEventListener('mouseleave', () => {
+    const handleLeave = () => {
       this.mouseState.intensity = 0.7;
       this.mouseState.targetX = 0.5;
       this.mouseState.targetY = 0.5;
+      this.focusState.target = Math.max(0.32, this.focusState.target * 0.75);
       this.updateVIB34DParameters({ intensity: 0.7 });
-    });
+    };
 
-    this.card.addEventListener('mousemove', (e) => {
+    const handleMove = (e) => {
       const rect = this.card.getBoundingClientRect();
       this.mouseState.targetX = (e.clientX - rect.left) / rect.width;
       this.mouseState.targetY = (e.clientY - rect.top) / rect.height;
 
       // Convert mouse position to VIB34D rotation parameters
       this.updateMouseBasedParameters();
-    });
+    };
+
+    this.card.addEventListener('mouseenter', handleEnter);
+    this.card.addEventListener('mouseleave', handleLeave);
+    this.card.addEventListener('mousemove', handleMove);
+    const handlePointerDown = () => {
+      this.focusState.pulse = 1;
+      this.tryCycleBrand('click');
+      if (this.brandMedia) {
+        this.brandMedia.play().catch(() => {});
+      }
+    };
+    this.card.addEventListener('pointerdown', handlePointerDown);
+    this.card.addEventListener('focusin', handleEnter);
+    this.card.addEventListener('focusout', handleLeave);
 
     // Responsive resize observer
-    const resizeObserver = new ResizeObserver(() => {
+    this.resizeObserver = new ResizeObserver(() => {
       this.resizeCanvases();
       if (this.engine && this.engine.resize) {
         this.engine.resize();
       }
     });
-    resizeObserver.observe(this.card);
+    this.resizeObserver.observe(this.card);
   }
 
   getVIB34DParametersForSystem(systemType) {
@@ -310,17 +717,24 @@ class VIB34DContainedVisualizer {
     this.mouseState.y += (this.mouseState.targetY - this.mouseState.y) * 0.1;
 
     // Convert mouse position to VIB34D 4D rotation parameters
-    this.dynamicParams.rot4dXW = (this.mouseState.x - 0.5) * Math.PI;
-    this.dynamicParams.rot4dYW = (this.mouseState.y - 0.5) * Math.PI;
-    this.dynamicParams.rot4dZW = Math.sin(Date.now() * 0.001) * 0.2;
+    const motion = this.globalMotionState || {};
+    const globalTiltX = motion.tiltX || 0;
+    const globalTiltY = motion.tiltY || 0;
+    const globalWarp = motion.warp || 0;
+    const globalSynergy = Math.max(0, motion.synergy || 0);
+    const globalFocus = Math.max(0, motion.focusAmount || 0);
+
+    this.dynamicParams.rot4dXW = (this.mouseState.x - 0.5) * Math.PI + globalTiltY * Math.PI * 0.45;
+    this.dynamicParams.rot4dYW = (this.mouseState.y - 0.5) * Math.PI - globalTiltX * Math.PI * 0.45;
+    this.dynamicParams.rot4dZW = Math.sin(Date.now() * 0.001) * 0.2 + globalWarp * 0.4;
 
     // Dynamic parameter modulation based on mouse interaction
-    const morphModulation = this.parameters.morphFactor + (this.mouseState.y - 0.5) * 0.8;
-    const chaosModulation = this.parameters.chaos + (this.mouseState.x - 0.5) * 0.3;
-    const intensityModulation = this.parameters.intensity + (this.mouseState.intensity - 0.7) * 0.5;
+    const morphModulation = this.parameters.morphFactor + (this.mouseState.y - 0.5) * 0.8 + globalSynergy * 0.35;
+    const chaosModulation = this.parameters.chaos + (this.mouseState.x - 0.5) * 0.3 + globalWarp * 0.2;
+    const intensityModulation = this.parameters.intensity + (this.mouseState.intensity - 0.7) * 0.5 + globalFocus * 0.45;
 
     // Geometry morphing based on mouse movement (cycles through available geometries)
-    const geometryFloat = this.parameters.geometry + (this.mouseState.x * 2.0); // Allows geometry blending
+    const geometryFloat = this.parameters.geometry + (this.mouseState.x * 2.0) + globalSynergy * 1.2; // Allows geometry blending
 
     // Update VIB34D system with rich parameter set
     this.updateVIB34DParameters({
@@ -339,6 +753,50 @@ class VIB34DContainedVisualizer {
       intensity: Math.max(0.3, Math.min(2.0, intensityModulation)),
       saturation: this.parameters.saturation
     });
+
+    const tiltXDeg = (0.5 - this.mouseState.y) * 18 - globalTiltX * 22;
+    const tiltYDeg = (this.mouseState.x - 0.5) * 18 + globalTiltY * 22;
+    this.card.style.setProperty('--tilt-x', `${tiltXDeg.toFixed(2)}deg`);
+    this.card.style.setProperty('--tilt-y', `${tiltYDeg.toFixed(2)}deg`);
+    this.card.style.setProperty('--tilt-x-value', tiltXDeg.toFixed(4));
+    this.card.style.setProperty('--tilt-y-value', tiltYDeg.toFixed(4));
+    this.card.style.setProperty('--focus-pointer-x', this.mouseState.x.toFixed(3));
+    this.card.style.setProperty('--focus-pointer-y', this.mouseState.y.toFixed(3));
+  }
+
+  startFocusLoop() {
+    if (this.focusState.raf) {
+      cancelAnimationFrame(this.focusState.raf);
+    }
+
+    const step = () => {
+      const isEngaged = this.card.matches(':hover') || this.card.matches(':focus-within');
+      const sharedMotion = this.globalMotionState || {};
+      const synergyLift = Math.max(0, sharedMotion.synergy || 0);
+      const sharedFocus = Math.max(0, sharedMotion.focusAmount || 0);
+      const baseTarget = isEngaged ? 1.05 + synergyLift * 0.18 : 0.32 + sharedFocus * 0.25;
+      this.focusState.target += (baseTarget - this.focusState.target) * 0.08;
+      this.focusState.current += (this.focusState.target - this.focusState.current) * 0.12;
+      this.focusState.pulse *= 0.88;
+
+      const focusValue = Math.max(0, this.focusState.current);
+      this.card.style.setProperty('--focus-intensity', focusValue.toFixed(3));
+      this.card.style.setProperty('--focus-pulse', this.focusState.pulse.toFixed(3));
+
+      if (this.brandMedia instanceof HTMLVideoElement) {
+        const scrollVelocity = Number(this.card.style.getPropertyValue('--scroll-velocity') || 0);
+        const sharedScroll = sharedMotion.scrollMomentum || 0;
+        const playbackRate = 0.85
+          + focusValue * 0.42
+          + Math.abs(scrollVelocity + sharedScroll) * 0.18
+          + synergyLift * 0.12;
+        this.brandMedia.playbackRate = Math.min(1.8, Math.max(0.7, playbackRate));
+      }
+
+      this.focusState.raf = requestAnimationFrame(step);
+    };
+
+    this.focusState.raf = requestAnimationFrame(step);
   }
 
   updateVIB34DParameters(newParams) {
@@ -467,10 +925,31 @@ class VIB34DContainedVisualizer {
       if (this.engine.destroy) this.engine.destroy();
     }
 
+    if (this.focusState.raf) {
+      cancelAnimationFrame(this.focusState.raf);
+      this.focusState.raf = null;
+    }
+
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+
+    if (this.brandHost && this.brandHost.parentNode) {
+      this.brandHost.parentNode.removeChild(this.brandHost);
+    }
+
     // Remove canvas container
     if (this.canvasContainer && this.canvasContainer.parentNode) {
       this.canvasContainer.parentNode.removeChild(this.canvasContainer);
     }
+
+    this.card.classList.remove('visualizer-host');
+    this.card.classList.remove('card-brand-enhanced');
+    this.brandHost = null;
+    this.brandMedia = null;
+    this.layerCanvases = [];
+    this.canvasContainer = null;
 
     console.log('🗑️ VIB34D contained visualizer destroyed');
   }

--- a/src/core/CanvasManager.js
+++ b/src/core/CanvasManager.js
@@ -115,31 +115,38 @@ export class CanvasManager {
     const canvasIds = this.getCanvasIdsForSystem(systemName);
     
     // Create 5 fresh canvases
+    const bleedScale = 1.3;
     canvasIds.forEach((canvasId, index) => {
       const canvas = document.createElement('canvas');
       canvas.id = canvasId;
       canvas.className = 'visualization-canvas';
       canvas.style.position = 'absolute';
-      canvas.style.top = '0';
-      canvas.style.left = '0';
-      canvas.style.width = '100%';
-      canvas.style.height = '100%';
+      canvas.style.top = '50%';
+      canvas.style.left = '50%';
+      canvas.style.width = `${bleedScale * 100}%`;
+      canvas.style.height = `${bleedScale * 100}%`;
+      canvas.style.transform = 'translate(-50%, -50%) scale(1)';
+      canvas.style.transformOrigin = 'center';
+      canvas.style.pointerEvents = 'none';
+      canvas.style.willChange = 'transform, filter';
       canvas.style.zIndex = index + 1;
-      
-      // Set canvas dimensions
+
+      // Set canvas dimensions with bleed so resolution matches the visual expansion
       const viewWidth = window.innerWidth;
       const viewHeight = window.innerHeight;
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      canvas.width = viewWidth * dpr;
-      canvas.height = viewHeight * dpr;
-      
+      canvas.width = viewWidth * dpr * bleedScale;
+      canvas.height = viewHeight * dpr * bleedScale;
+
       targetContainer.appendChild(canvas);
     });
-    
+
     // Show the target container
     targetContainer.style.display = 'block';
     targetContainer.style.visibility = 'visible';
     targetContainer.style.opacity = '1';
+    targetContainer.style.overflow = 'visible';
+    targetContainer.style.transformStyle = 'preserve-3d';
     
     console.log(`✅ Created 5 fresh canvases for ${systemName}: ${canvasIds.join(', ')}`);
   }

--- a/src/export/TradingCardGenerator.js
+++ b/src/export/TradingCardGenerator.js
@@ -365,6 +365,8 @@ export class TradingCardGenerator {
             --mouse-x: 50%;
             --mouse-y: 50%;
             --bend-intensity: 0;
+            --scroll-tilt: 0;
+            --visualizer-scroll-tilt: 0;
         }
         
         .trading-card:hover {
@@ -482,13 +484,13 @@ export class TradingCardGenerator {
         /* GALLERY-STYLE: Card preview expands and tilts based on mouse position */
         .trading-card:hover .card-preview {
             /* Match gallery card preview behavior exactly */
-            transform: 
+            transform:
                 perspective(1000px)
                 translateZ(30px)
                 scale(1.1)
-                rotateY(calc((var(--mouse-x) - 50) * 0.2deg))
-                rotateX(calc((var(--mouse-y) - 50) * 0.15deg));
-            box-shadow: 
+                rotateY(calc((var(--mouse-x) - 50) * 0.2deg + var(--scroll-tilt, var(--visualizer-scroll-tilt, 0)) * 4deg))
+                rotateX(calc((var(--mouse-y) - 50) * 0.15deg - var(--scroll-tilt, var(--visualizer-scroll-tilt, 0)) * 6deg));
+            box-shadow:
                 0 0 50px rgba(0, 255, 255, 0.6),
                 0 0 100px rgba(255, 0, 255, 0.4),
                 inset 0 0 20px rgba(255, 255, 255, 0.1);
@@ -506,15 +508,28 @@ export class TradingCardGenerator {
             height: 100%;
             position: relative;
             border-radius: 12px;
-            overflow: hidden;
+            overflow: visible;
             background: #000;
+            transform-style: preserve-3d;
+            --visualizer-scroll-tilt: var(--scroll-tilt);
         }
-        
+
         .visualizer-canvas {
-            width: 100%;
-            height: 100%;
-            display: block;
-            border-radius: 10px;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 130%;
+            height: 130%;
+            transform: translate(-50%, -50%) scale(1.12)
+                rotateX(calc(var(--visualizer-scroll-tilt, var(--scroll-tilt, 0)) * -5deg))
+                rotateY(calc(var(--visualizer-scroll-tilt, var(--scroll-tilt, 0)) * 2.5deg));
+            transform-origin: center;
+            border-radius: 16px;
+            filter: saturate(1.1) brightness(1.05);
+            pointer-events: none;
+            box-shadow:
+                0 0 45px rgba(0, 255, 255, 0.25),
+                0 0 85px rgba(255, 0, 255, 0.18);
         }
         
         .stats-panel {
@@ -805,6 +820,8 @@ export class TradingCardGenerator {
             display: flex;
             box-shadow: 0 0 40px hsla(${state.hue}, 80%, 50%, 0.3);
             animation: cardPulse 4s ease-in-out infinite alternate;
+            --scroll-tilt: 0;
+            --visualizer-scroll-tilt: 0;
         }
         
         @keyframes cardPulse {
@@ -816,20 +833,38 @@ export class TradingCardGenerator {
             flex: 1;
             position: relative;
             background: radial-gradient(ellipse at center, hsla(${state.hue}, 80%, 50%, 0.1), rgba(0, 0, 0, 0.8));
+            overflow: visible;
+            transform-style: preserve-3d;
+            --visualizer-scroll-tilt: var(--scroll-tilt);
         }
-        
+
         .visualizer-canvas {
-            width: 100%;
-            height: 100%;
-            display: block;
-            border-radius: 10px;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 135%;
+            height: 135%;
+            transform: translate(-50%, -50%) scale(1.08)
+                rotateX(calc(var(--visualizer-scroll-tilt, var(--scroll-tilt, 0)) * -4deg))
+                rotateY(calc(var(--visualizer-scroll-tilt, var(--scroll-tilt, 0)) * 2deg));
+            transform-origin: center;
+            border-radius: 18px;
+            pointer-events: none;
+            box-shadow:
+                0 0 45px rgba(0, 255, 255, 0.25),
+                0 0 90px rgba(255, 0, 255, 0.18);
         }
         
         .visualizer-container img {
-            width: 100%;
-            height: 100%;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 135%;
+            height: 135%;
+            transform: translate(-50%, -50%) scale(1.08);
             object-fit: cover;
-            border-radius: 10px;
+            border-radius: 18px;
+            pointer-events: none;
         }
         
         .card-info {

--- a/src/holograms/HolographicVisualizer.js
+++ b/src/holograms/HolographicVisualizer.js
@@ -64,11 +64,16 @@ export class HolographicVisualizer {
         this.parallaxDepth = 0.0;
         this.gridDensityShift = 0.0;
         this.colorScrollShift = 0.0;
-        
+        this.scrollTilt = 0.0;
+        this.scrollTiltTarget = 0.0;
+        this.scrollRotationXW = 0.0;
+        this.scrollRotationYW = 0.0;
+        this.scrollRotationZW = 0.0;
+
         // Density system
         this.densityVariation = 0.0;
         this.densityTarget = 0.0;
-        
+
         // Audio reactivity
         this.audioData = { bass: 0, mid: 0, high: 0 };
         this.audioDensityBoost = 0.0;
@@ -76,7 +81,13 @@ export class HolographicVisualizer {
         this.audioSpeedBoost = 0.0;
         this.audioChaosBoost = 0.0;
         this.audioColorShift = 0.0;
-        
+
+        this.externalRotations = {
+            xw: this.variantParams.rot4dXW || 0.0,
+            yw: this.variantParams.rot4dYW || 0.0,
+            zw: this.variantParams.rot4dZW || 0.0
+        };
+
         this.startTime = Date.now();
         this.initShaders();
         this.initBuffers();
@@ -651,6 +662,9 @@ export class HolographicVisualizer {
     updateScroll(deltaY) {
         this.scrollVelocity += deltaY * 0.001;
         this.scrollVelocity = Math.max(-2.0, Math.min(2.0, this.scrollVelocity));
+        const normalized = Math.max(-1.2, Math.min(1.2, deltaY * 0.0025));
+        this.scrollTiltTarget += normalized;
+        this.scrollTiltTarget = Math.max(-2.0, Math.min(2.0, this.scrollTiltTarget));
     }
     
     // Audio reactivity now handled directly in render() loop
@@ -708,6 +722,14 @@ export class HolographicVisualizer {
         this.parallaxDepth = Math.sin(this.scrollPosition * 0.1) * 0.5;
         this.gridDensityShift = Math.sin(this.scrollPosition * 0.05) * 0.3;
         this.colorScrollShift = (this.scrollPosition * 0.02) % (Math.PI * 2);
+        this.scrollTilt += (this.scrollTiltTarget - this.scrollTilt) * 0.12;
+        this.scrollTiltTarget *= 0.88;
+        if (Math.abs(this.scrollTilt) < 0.0005) {
+            this.scrollTilt = 0;
+        }
+        this.scrollRotationXW = this.scrollTilt * 0.48;
+        this.scrollRotationYW = this.scrollTilt * -0.32;
+        this.scrollRotationZW = this.scrollTilt * 0.22;
     }
     
     render() {
@@ -806,9 +828,16 @@ export class HolographicVisualizer {
         this.gl.uniform1f(this.uniforms.audioColorShift, audioColor);
         
         // 4D rotation uniforms
-        this.gl.uniform1f(this.uniforms.rot4dXW, this.variantParams.rot4dXW || 0.0);
-        this.gl.uniform1f(this.uniforms.rot4dYW, this.variantParams.rot4dYW || 0.0);
-        this.gl.uniform1f(this.uniforms.rot4dZW, this.variantParams.rot4dZW || 0.0);
+        const baseRotXW = this.externalRotations.xw ?? (this.variantParams.rot4dXW || 0.0);
+        const baseRotYW = this.externalRotations.yw ?? (this.variantParams.rot4dYW || 0.0);
+        const baseRotZW = this.externalRotations.zw ?? (this.variantParams.rot4dZW || 0.0);
+        const dynamicRotXW = baseRotXW + this.scrollRotationXW;
+        const dynamicRotYW = baseRotYW + this.scrollRotationYW;
+        const dynamicRotZW = baseRotZW + this.scrollRotationZW;
+
+        this.gl.uniform1f(this.uniforms.rot4dXW, dynamicRotXW);
+        this.gl.uniform1f(this.uniforms.rot4dYW, dynamicRotYW);
+        this.gl.uniform1f(this.uniforms.rot4dZW, dynamicRotZW);
         
         this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
     }
@@ -874,9 +903,17 @@ export class HolographicVisualizer {
                         scaledValue = 0.3 + (parseFloat(params[param]) - 5) / 95 * 2.2;
                         console.log(`🔧 Density scaling: gridDensity=${params[param]} → density=${scaledValue.toFixed(3)} (normal range)`);
                     }
-                    
+
                     this.variantParams[mappedParam] = scaledValue;
-                    
+
+                    if (mappedParam === 'rot4dXW') {
+                        this.externalRotations.xw = scaledValue;
+                    } else if (mappedParam === 'rot4dYW') {
+                        this.externalRotations.yw = scaledValue;
+                    } else if (mappedParam === 'rot4dZW') {
+                        this.externalRotations.zw = scaledValue;
+                    }
+
                     // Handle special parameter types
                     if (mappedParam === 'geometryType') {
                         // Regenerate role params with new geometry

--- a/styles/clear-seas-ai.css
+++ b/styles/clear-seas-ai.css
@@ -240,6 +240,161 @@ body::after {
     z-index: -1;
 }
 
+:root,
+.visualizer-host,
+.canvas-card,
+.stacked-card,
+.hero__module,
+.flow-step,
+.flow-thread,
+.system-card,
+.variant-card,
+.signal-card,
+.signal-node,
+.resource-card,
+.micro-card,
+.metric {
+    --tilt-x: 0deg;
+    --tilt-y: 0deg;
+    --tilt-x-value: 0;
+    --tilt-y-value: 0;
+    --tilt-scroll: 0deg;
+    --visualizer-parallax: 0px;
+    --visualizer-rot-xw: 0deg;
+    --visualizer-rot-yw: 0deg;
+    --visualizer-rot-zw: 0deg;
+    --scroll-velocity: 0;
+    --focus-intensity: 0;
+    --focus-pulse: 0;
+    --focus-pointer-x: 0.5;
+    --focus-pointer-y: 0.5;
+    --visualizer-bleed: 1.28;
+    --visualizer-scale: 1.22;
+    --bend-intensity: 0;
+    --bend-tilt-x-deg: 0deg;
+    --bend-tilt-y-deg: 0deg;
+    --bend-skew-x-deg: 0deg;
+    --bend-skew-y-deg: 0deg;
+    --bend-twist-deg: 0deg;
+    --bend-depth: 0px;
+    --visualizer-bend-depth: 0px;
+    --lift-scale: 1;
+    --lift-translate-y: 0px;
+}
+
+.visualizer-host,
+.canvas-card,
+.stacked-card,
+.hero__module,
+.flow-step,
+.flow-thread,
+.system-card,
+.variant-card,
+.signal-card,
+.signal-node,
+.resource-card,
+.micro-card,
+.metric {
+    position: relative;
+    overflow: visible;
+    transform-style: preserve-3d;
+}
+
+.visualizer-host > :not(.visualizer-shell),
+.canvas-card > :not(.visualizer-shell),
+.stacked-card > :not(.visualizer-shell),
+.hero__module > :not(.visualizer-shell) {
+    position: relative;
+    z-index: 2;
+}
+
+.visualizer-shell {
+    position: absolute;
+    inset: calc(-16% * var(--visualizer-bleed, 1.32));
+    pointer-events: none;
+    z-index: 0;
+    overflow: visible;
+    transform-style: preserve-3d;
+    filter: drop-shadow(0 26px 48px rgba(20, 42, 96, 0.45));
+    will-change: transform, filter, opacity;
+}
+
+.visualizer-shell__canvas {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: calc(120% * var(--visualizer-scale, 1.2));
+    height: calc(120% * var(--visualizer-scale, 1.2));
+    transform:
+        translate(-50%, -50%)
+        rotateX(calc(var(--tilt-x, 0deg) + var(--tilt-scroll, 0deg) + var(--bend-tilt-x-deg, 0deg) * 0.55))
+        rotateY(calc(var(--tilt-y, 0deg) + var(--bend-tilt-y-deg, 0deg) * 0.55))
+        rotateZ(calc(var(--visualizer-rot-zw, 0deg) + var(--bend-twist-deg, 0deg) * 0.42))
+        skewX(calc(var(--bend-skew-x-deg, 0deg) * 0.65))
+        skewY(calc(var(--bend-skew-y-deg, 0deg) * 0.65))
+        translate3d(
+            calc(var(--tilt-y-value, 0) * -18px),
+            calc(var(--tilt-x-value, 0) * 18px + var(--visualizer-parallax, 0px)),
+            calc(var(--focus-intensity, 0) * 36px + var(--visualizer-bend-depth, 0px))
+        );
+    border-radius: 28px;
+    opacity: calc(0.78 + var(--focus-intensity, 0) * 0.22);
+    mix-blend-mode: screen;
+    filter:
+        saturate(calc(1.05 + var(--focus-intensity, 0) * 0.35))
+        brightness(calc(1.05 + var(--focus-intensity, 0) * 0.28))
+        contrast(1.05);
+    transition: filter 320ms ease, opacity 280ms ease;
+    backface-visibility: hidden;
+    will-change: transform, opacity, filter;
+}
+
+.visualizer-shell__brand {
+    position: absolute;
+    inset: calc(-28% * var(--visualizer-bleed, 1.2));
+    pointer-events: none;
+    transform-style: preserve-3d;
+    mix-blend-mode: screen;
+    opacity: calc(0.22 + var(--focus-intensity, 0) * 0.42 + var(--focus-pulse, 0) * 0.25);
+    transform:
+        rotate(var(--brand-rotation, 0deg))
+        translate3d(
+            calc(var(--tilt-y-value, 0) * -22px),
+            calc(var(--tilt-x-value, 0) * 22px),
+            calc(var(--focus-intensity, 0) * 42px)
+        );
+    transition:
+        transform 420ms cubic-bezier(0.22, 0.67, 0.3, 1),
+        opacity 320ms ease;
+    filter: saturate(calc(1.1 + var(--focus-intensity, 0) * 0.4)) drop-shadow(0 0 32px rgba(118, 198, 255, 0.35));
+    will-change: transform, opacity, filter;
+}
+
+.visualizer-shell__brand--image::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: var(--brand-image, none);
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.visualizer-shell__brand--video .visualizer-shell__brand-media {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    mix-blend-mode: screen;
+    opacity: 0.78;
+    filter: saturate(1.15) brightness(1.1);
+    border-radius: 28px;
+}
+
+.visualizer-shell__brand-media {
+    display: block;
+    pointer-events: none;
+}
+
 :root[data-background-mode="quantum"] {
     --text-hue-gradient: linear-gradient(130deg, #7af0ff 0%, #ff74f9 44%, #ffd86c 78%, #7effeb 100%);
     --text-hue-glow: rgba(138, 224, 255, 0.4);
@@ -775,7 +930,16 @@ body::after {
     box-shadow: inset 0 0 0 1px rgba(122, 213, 255, 0.05), var(--shadow-soft);
     backdrop-filter: blur(16px);
     transition: transform var(--transition-fast), border-color var(--transition-fast);
-    transform: perspective(900px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(900px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .metric::after {
@@ -857,7 +1021,16 @@ body::after {
     box-shadow: var(--shadow-soft);
     backdrop-filter: blur(18px);
     overflow: hidden;
-    transform: perspective(1300px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1300px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
     transform-style: preserve-3d;
     transition: transform var(--transition-slow), box-shadow var(--transition-fast);
 }
@@ -996,7 +1169,16 @@ body::after {
     backdrop-filter: blur(18px);
     overflow: hidden;
     transition: transform var(--transition-slow), border-color var(--transition-fast), box-shadow var(--transition-fast);
-    transform: perspective(1200px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1200px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .canvas-card::after {
@@ -1088,7 +1270,16 @@ body::after {
     border: 1px solid hsla(var(--card-secondary-hue), 78%, 60%, 0.4);
     box-shadow: 0 50px 110px rgba(10, 12, 36, 0.6);
     backdrop-filter: blur(22px) saturate(145%);
-    transform: perspective(1400px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--stack-translate)) scale(var(--tilt-scale));
+    transform:
+        perspective(1400px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--stack-translate))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--tilt-scale));
     opacity: 0.2;
     filter: blur(var(--stack-blur)) saturate(92%);
     transition: transform 680ms cubic-bezier(0.22, 0.61, 0.36, 1), opacity 520ms ease, filter 520ms ease, border-color 420ms ease, box-shadow 420ms ease, background 560ms ease;
@@ -1215,12 +1406,30 @@ body::after {
     0% {
         opacity: 1;
         filter: blur(0) saturate(118%);
-        transform: perspective(1400px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(0) scale(1);
+        transform:
+            perspective(1400px)
+            rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+            rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+            rotateZ(var(--bend-twist-deg, 0deg))
+            skewX(var(--bend-skew-x-deg, 0deg))
+            skewY(var(--bend-skew-y-deg, 0deg))
+            translateY(0)
+            translateZ(var(--bend-depth, 0px))
+            scale(1);
     }
     100% {
         opacity: 0;
         filter: blur(18px) saturate(80%);
-        transform: perspective(1400px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(-22%) scale(0.86);
+        transform:
+            perspective(1400px)
+            rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+            rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+            rotateZ(var(--bend-twist-deg, 0deg))
+            skewX(var(--bend-skew-x-deg, 0deg))
+            skewY(var(--bend-skew-y-deg, 0deg))
+            translateY(-22%)
+            translateZ(var(--bend-depth, 0px))
+            scale(0.86);
     }
 }
 
@@ -1259,7 +1468,16 @@ body::after {
     box-shadow: var(--shadow-lift);
     backdrop-filter: blur(16px);
     transition: transform var(--transition-slow), box-shadow var(--transition-fast);
-    transform: perspective(1100px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1100px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .flow-step:hover,
@@ -1306,7 +1524,16 @@ body::after {
     overflow: hidden;
     box-shadow: var(--shadow-soft);
     transition: transform var(--transition-slow), border-color var(--transition-fast);
-    transform: perspective(1200px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1200px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .case::before {
@@ -1402,7 +1629,16 @@ body::after {
     border: 1px solid rgba(100, 135, 255, 0.25);
     box-shadow: var(--shadow-lift);
     transition: transform var(--transition-slow), border-color var(--transition-fast);
-    transform: perspective(1100px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1100px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
 }
 
 .insight:hover,
@@ -1464,7 +1700,16 @@ body::after {
     border: 1px solid rgba(108, 150, 255, 0.28);
     box-shadow: var(--shadow-lift);
     backdrop-filter: blur(16px);
-    transform: perspective(1100px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y)) translateY(var(--lift-translate-y)) scale(var(--lift-scale));
+    transform:
+        perspective(1100px)
+        rotateX(calc(var(--tilt-x) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translateY(var(--lift-translate-y))
+        translateZ(var(--bend-depth, 0px))
+        scale(var(--lift-scale));
     transition: transform var(--transition-slow), border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 

--- a/styles/consolidated-styles.css
+++ b/styles/consolidated-styles.css
@@ -153,6 +153,166 @@ body {
 body.loading { overflow: hidden; }
 body.loading * { animation-play-state: paused !important; transition: none !important; }
 
+:root,
+.visualizer-host,
+.tech-card,
+.unified-card,
+.portfolio-item,
+.card,
+.card-shell,
+.polytopal-card,
+.system-card,
+.variant-card,
+.signal-card,
+.resource-card,
+.micro-card,
+.metric,
+.canvas-card,
+.stacked-card {
+    --tilt-x: 0deg;
+    --tilt-y: 0deg;
+    --tilt-x-value: 0;
+    --tilt-y-value: 0;
+    --tilt-scroll: 0deg;
+    --visualizer-parallax: 0px;
+    --visualizer-rot-xw: 0deg;
+    --visualizer-rot-yw: 0deg;
+    --visualizer-rot-zw: 0deg;
+    --scroll-velocity: 0;
+    --focus-intensity: 0;
+    --focus-pulse: 0;
+    --focus-pointer-x: 0.5;
+    --focus-pointer-y: 0.5;
+    --visualizer-bleed: 1.24;
+    --visualizer-scale: 1.18;
+    --bend-intensity: 0;
+    --bend-tilt-x-deg: 0deg;
+    --bend-tilt-y-deg: 0deg;
+    --bend-skew-x-deg: 0deg;
+    --bend-skew-y-deg: 0deg;
+    --bend-twist-deg: 0deg;
+    --bend-depth: 0px;
+    --visualizer-bend-depth: 0px;
+    --lift-scale: 1;
+    --lift-translate-y: 0px;
+}
+
+.visualizer-host,
+.tech-card,
+.unified-card,
+.portfolio-item,
+.card,
+.system-card,
+.variant-card,
+.signal-card,
+.resource-card,
+.micro-card,
+.metric,
+.canvas-card,
+.stacked-card {
+    position: relative;
+    overflow: visible;
+    transform-style: preserve-3d;
+}
+
+.visualizer-host > :not(.visualizer-shell),
+.tech-card > :not(.visualizer-shell),
+.unified-card > :not(.visualizer-shell),
+.portfolio-item > :not(.visualizer-shell),
+.card > :not(.visualizer-shell),
+.canvas-card > :not(.visualizer-shell),
+.stacked-card > :not(.visualizer-shell) {
+    position: relative;
+    z-index: 2;
+}
+
+.visualizer-shell {
+    position: absolute;
+    inset: calc(-14% * var(--visualizer-bleed, 1.26));
+    pointer-events: none;
+    z-index: 0;
+    overflow: visible;
+    transform-style: preserve-3d;
+    filter: drop-shadow(0 28px 52px rgba(10, 24, 64, 0.52));
+    will-change: transform, filter, opacity;
+}
+
+.visualizer-shell__canvas {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: calc(118% * var(--visualizer-scale, 1.16));
+    height: calc(118% * var(--visualizer-scale, 1.16));
+    transform:
+        translate(-50%, -50%)
+        rotateX(calc(var(--tilt-x, 0deg) + var(--tilt-scroll, 0deg) + var(--bend-tilt-x-deg, 0deg) * 0.55))
+        rotateY(calc(var(--tilt-y, 0deg) + var(--bend-tilt-y-deg, 0deg) * 0.55))
+        rotateZ(calc(var(--visualizer-rot-zw, 0deg) + var(--bend-twist-deg, 0deg) * 0.4))
+        skewX(calc(var(--bend-skew-x-deg, 0deg) * 0.65))
+        skewY(calc(var(--bend-skew-y-deg, 0deg) * 0.65))
+        translate3d(
+            calc(var(--tilt-y-value, 0) * -16px),
+            calc(var(--tilt-x-value, 0) * 16px + var(--visualizer-parallax, 0px)),
+            calc(var(--focus-intensity, 0) * 34px + var(--visualizer-bend-depth, 0px))
+        );
+    border-radius: 26px;
+    opacity: calc(0.76 + var(--focus-intensity, 0) * 0.24);
+    mix-blend-mode: screen;
+    filter:
+        saturate(calc(1.04 + var(--focus-intensity, 0) * 0.32))
+        brightness(calc(1.04 + var(--focus-intensity, 0) * 0.26))
+        contrast(1.04);
+    transition: filter 320ms ease, opacity 280ms ease;
+    backface-visibility: hidden;
+    will-change: transform, opacity, filter;
+}
+
+.visualizer-shell__brand {
+    position: absolute;
+    inset: calc(-24% * var(--visualizer-bleed, 1.2));
+    pointer-events: none;
+    transform-style: preserve-3d;
+    mix-blend-mode: screen;
+    opacity: calc(0.2 + var(--focus-intensity, 0) * 0.4 + var(--focus-pulse, 0) * 0.24);
+    transform:
+        rotate(var(--brand-rotation, 0deg))
+        translate3d(
+            calc(var(--tilt-y-value, 0) * -18px),
+            calc(var(--tilt-x-value, 0) * 18px),
+            calc(var(--focus-intensity, 0) * 40px)
+        );
+    transition:
+        transform 400ms cubic-bezier(0.24, 0.66, 0.32, 1),
+        opacity 300ms ease;
+    filter: saturate(calc(1.08 + var(--focus-intensity, 0) * 0.36)) drop-shadow(0 0 28px rgba(90, 192, 255, 0.32));
+    will-change: transform, opacity, filter;
+}
+
+.visualizer-shell__brand--image::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: var(--brand-image, none);
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+.visualizer-shell__brand--video .visualizer-shell__brand-media {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    mix-blend-mode: screen;
+    opacity: 0.76;
+    filter: saturate(1.1) brightness(1.08);
+    border-radius: 26px;
+}
+
+.visualizer-shell__brand-media {
+    display: block;
+    pointer-events: none;
+}
+
 /* ==========================================================================
    3. TYPOGRAPHY SYSTEM
    ========================================================================== */
@@ -356,11 +516,28 @@ a:hover {
     border-radius: 20px;
     background: var(--bg-secondary);
     transform-style: preserve-3d;
-    transition: transform var(--duration-normal) var(--ease-spring), 
+    --card-hover-scale: 1;
+    --card-hover-translate-z: 0px;
+    --card-perspective: var(--perspective, 1400px);
+    transition: transform var(--duration-normal) var(--ease-spring),
                 box-shadow var(--duration-normal) var(--ease-spring);
-    
+    transform:
+        perspective(var(--card-perspective))
+        rotateX(calc(var(--tilt-x, 0deg) + var(--bend-tilt-x-deg, 0deg)))
+        rotateY(calc(var(--tilt-y, 0deg) + var(--bend-tilt-y-deg, 0deg)))
+        rotateZ(var(--bend-twist-deg, 0deg))
+        skewX(var(--bend-skew-x-deg, 0deg))
+        skewY(var(--bend-skew-y-deg, 0deg))
+        translate3d(
+            calc(var(--focus-parallax-x, 0px) * 0.08),
+            calc(var(--lift-translate-y, 0px) + var(--focus-parallax-y, 0px) * 0.08),
+            calc(var(--card-hover-translate-z, 0px) + var(--bend-depth, 0px))
+        )
+        scale(var(--lift-scale, 1))
+        scale(var(--card-hover-scale));
+
     /* Neoskeuomorphic base shadow */
-    box-shadow: 
+    box-shadow:
         -8px -8px 16px var(--neo-shadow-light),
          8px  8px 16px var(--neo-shadow-dark),
          inset 1px 1px 0 var(--neo-highlight);
@@ -368,8 +545,9 @@ a:hover {
 
 /* Total Reactivity System - Pop-out on Hover */
 .unified-card:hover, .tech-card:hover, .portfolio-item:hover {
-    transform: scale(var(--pop-out-scale)) translateZ(var(--pop-out-translate-z));
-    box-shadow: 
+    --card-hover-scale: var(--pop-out-scale);
+    --card-hover-translate-z: var(--pop-out-translate-z);
+    box-shadow:
         0 0 50px var(--theme-primary),
         0 0 80px var(--theme-secondary),
         -12px -12px 24px var(--neo-shadow-light),

--- a/styles/global-card-synergy.css
+++ b/styles/global-card-synergy.css
@@ -1,0 +1,518 @@
+:root {
+  --global-focus-x: 0.5;
+  --global-focus-y: 0.5;
+  --global-focus-amount: 0;
+  --global-scroll-momentum: 0;
+  --global-scroll-tilt: 0deg;
+  --global-synergy-glow: 0;
+  --global-bend-intensity: 0;
+  --global-tilt-x: 0;
+  --global-tilt-y: 0;
+  --global-tilt-strength: 0;
+  --global-warp: 0;
+  --global-tilt-skew: 0;
+  --global-focus-trend: 0;
+  --global-scroll-speed: 0;
+  --global-scroll-direction: 0;
+  --global-brand-accent: #6fe8ff;
+  --global-family-focus-boost: 1;
+  --global-family-bend-boost: 1;
+  --global-family-parallax-scale: 1;
+  --global-family-overlay-bloom: 1;
+}
+
+body {
+  --global-background-shift-x: calc(
+    ((var(--global-focus-x) - 0.5) * 12px +
+      var(--global-scroll-momentum) * 18px +
+      var(--global-tilt-x) * 24px) * var(--global-family-parallax-scale)
+  );
+  --global-background-shift-y: calc(
+    ((0.5 - var(--global-focus-y)) * 10px +
+      var(--global-tilt-y) * 22px) * var(--global-family-parallax-scale)
+  );
+  background-position: calc(50% + var(--global-background-shift-x) + var(--global-focus-trend) * 40px * var(--global-family-parallax-scale)) calc(50% + var(--global-background-shift-y));
+  perspective: calc(1600px - var(--global-bend-intensity) * 420px * var(--global-family-bend-boost));
+  transform-style: preserve-3d;
+  filter: saturate(calc((1 + var(--global-tilt-strength) * 0.12 + var(--global-scroll-speed) * 0.1) * var(--global-family-focus-boost)))
+    hue-rotate(calc(var(--global-warp) * 32deg))
+    brightness(calc((1 + var(--global-bend-intensity) * 0.08 + var(--global-scroll-speed) * 0.05 + var(--global-focus-trend) * 0.06) * var(--global-family-focus-boost)));
+  transform-origin: 50% 50%;
+  transform: rotateZ(calc(var(--global-tilt-skew) * 1.4deg * var(--global-scroll-direction)));
+  transition: background-position 0.8s ease, filter 0.8s ease;
+}
+
+html[data-global-page-family="meta"] {
+  --global-family-parallax-scale: 1.12;
+  --global-family-focus-boost: 1.08;
+  --global-family-bend-boost: 0.82;
+  --global-family-overlay-bloom: 1.12;
+}
+
+html[data-global-page-family="foundation"] {
+  --global-family-parallax-scale: 1;
+  --global-family-focus-boost: 1.02;
+  --global-family-bend-boost: 1;
+  --global-family-overlay-bloom: 1.05;
+}
+
+html[data-global-page-family="immersive"] {
+  --global-family-parallax-scale: 1.24;
+  --global-family-focus-boost: 1.18;
+  --global-family-bend-boost: 1.28;
+  --global-family-overlay-bloom: 1.25;
+}
+
+html[data-global-page-family="labs"] {
+  --global-family-parallax-scale: 1.2;
+  --global-family-focus-boost: 1.14;
+  --global-family-bend-boost: 1.05;
+  --global-family-overlay-bloom: 1.32;
+}
+
+[data-global-card-group="true"] {
+  position: relative;
+  z-index: 0;
+  --group-focus-amount: 0;
+  --group-focus-x: 0.5;
+  --group-focus-y: 0.5;
+  --group-synergy: 0;
+  transform-style: preserve-3d;
+  transition: transform 0.6s ease, filter 0.6s ease, box-shadow 0.6s ease;
+  overflow: visible;
+  transform:
+    perspective(calc(1800px - var(--global-bend-intensity) * 520px))
+    rotateX(calc(var(--global-tilt-y) * 10deg + (0.5 - var(--group-focus-y)) * 6deg))
+    rotateY(calc(var(--global-tilt-x) * 12deg + (var(--group-focus-x) - 0.5) * 6deg))
+    translateZ(calc(var(--group-focus-amount) * 28px + var(--global-bend-intensity) * 12px));
+}
+
+[data-global-card-group="true"]::before {
+  content: '';
+  position: absolute;
+  inset: -8% -6%;
+  z-index: -2;
+  border-radius: clamp(18px, 6vw, 48px);
+  background: radial-gradient(
+    circle at calc(var(--group-focus-x) * 100%) calc(var(--group-focus-y) * 100%),
+    rgba(0, 255, 255, calc(0.08 + var(--group-focus-amount) * 0.35 + var(--group-synergy) * 0.25)),
+    rgba(132, 56, 255, calc(0.05 + var(--group-synergy) * 0.25)) 48%,
+    rgba(8, 10, 24, 0) 80%
+  );
+  opacity: calc((0.12 + var(--group-synergy) * 0.4) * var(--global-family-overlay-bloom));
+  filter: blur(calc(28px - var(--group-focus-amount) * 12px - var(--global-tilt-strength) * 6px));
+  transform:
+    translateZ(calc(-60px - var(--global-bend-intensity) * 40px))
+    rotateZ(calc(var(--global-warp) * 10deg))
+    scale(calc(1 + var(--group-synergy) * 0.08 + var(--global-tilt-strength) * 0.05));
+  transition: opacity 0.6s ease, filter 0.6s ease, transform 0.6s ease;
+  pointer-events: none;
+}
+
+[data-global-card-group="true"] > * {
+  position: relative;
+  z-index: 1;
+}
+
+[data-global-group-active="true"] {
+  filter: saturate(calc(1 + var(--section-synergy, 0) * 0.35))
+    brightness(calc(1 + var(--section-synergy, 0) * 0.15));
+  transition: filter 0.6s ease;
+}
+
+[data-global-card-group="true"] :is(h1, h2, h3, h4, h5, h6,
+  .section-title,
+  .version-title,
+  .card-title,
+  .group-title,
+  .section-intro,
+  .version-description,
+  .card-description) {
+  transition: color 0.6s ease, text-shadow 0.6s ease, transform 0.6s ease;
+}
+
+[data-global-card-group="true"][data-global-group-active="true"] :is(h1, h2, h3, h4, h5, h6,
+  .section-title,
+  .version-title,
+  .card-title,
+  .group-title) {
+  color: rgba(255, 255, 255, calc(0.82 + var(--group-focus-amount) * 0.25));
+  text-shadow:
+    0 0 calc(12px + var(--group-focus-amount) * 20px) rgba(0, 255, 255, 0.28),
+    0 0 calc(22px + var(--group-synergy) * 40px) rgba(132, 56, 255, 0.24);
+  transform: translateZ(calc(var(--group-focus-amount) * 12px));
+}
+
+[data-global-card-group="true"][data-global-group-active="true"] :is(.section-intro,
+  .version-description,
+  .card-description) {
+  color: rgba(255, 255, 255, calc(0.68 + var(--group-synergy) * 0.2));
+  text-shadow: 0 0 calc(10px + var(--group-synergy) * 16px) rgba(0, 255, 255, 0.18);
+}
+
+.global-visualizer-card,
+[data-visualizer-card] {
+  position: relative;
+  transform-style: preserve-3d;
+  --card-focus-x: 0.5;
+  --card-focus-y: 0.5;
+  --card-focus-strength: 0;
+  --card-support-intensity: 0;
+  --card-scroll-momentum: 0;
+  --card-twist: 0deg;
+  --card-pulse: 0;
+  --card-overlay-shift: 0px;
+  --card-visibility-factor: var(--card-visibility, 1);
+  --support-distance-z: 0px;
+  --support-distance-glow: 0;
+  --shared-focus-signal: var(--shared-focus-amount, var(--global-focus-amount, 0));
+  --shared-synergy-signal: var(--shared-synergy, var(--global-synergy-glow, 0));
+  --shared-tilt-x-signal: var(--shared-tilt-x, var(--global-tilt-x, 0));
+  --shared-tilt-y-signal: var(--shared-tilt-y, var(--global-tilt-y, 0));
+  --shared-tilt-strength-signal: var(--shared-tilt-strength, var(--global-tilt-strength, 0));
+  --shared-bend-signal: var(--shared-bend, var(--global-bend-intensity, 0));
+  --shared-warp-signal: var(--shared-warp, var(--global-warp, 0));
+  --shared-scroll-signal: var(--shared-scroll, var(--global-scroll-momentum, 0));
+  --shared-scroll-direction-signal: var(--shared-scroll-direction, var(--global-scroll-direction, 0));
+  --shared-scroll-speed-signal: var(--shared-scroll-speed, var(--global-scroll-speed, 0));
+  --shared-focus-trend-signal: var(--shared-focus-trend, var(--global-focus-trend, 0));
+  --shared-tilt-skew-signal: var(--shared-tilt-skew, var(--global-tilt-skew, 0));
+  transition:
+    box-shadow 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+    border-color 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+    filter 0.6s ease,
+    opacity 0.6s ease;
+  will-change: transform, box-shadow, filter;
+  contain: layout paint;
+  opacity: calc(0.68 + var(--card-visibility-factor) * 0.32);
+}
+
+.global-visualizer-card[data-support-role="primary"],
+[data-visualizer-card][data-support-role="primary"] {
+  z-index: 5;
+  filter: saturate(calc(1.05 + var(--card-focus-strength) * 0.45 + var(--shared-synergy-signal) * 0.4))
+    brightness(calc(1 + var(--card-focus-strength) * 0.2 + var(--shared-focus-signal) * 0.18 + var(--shared-focus-trend-signal) * 0.1));
+  transform: translateZ(calc(var(--shared-focus-trend-signal) * 16px));
+  box-shadow:
+    0 0 calc(18px + var(--card-focus-strength) * 36px) color-mix(in srgb, var(--global-brand-accent) 60%, transparent),
+    0 0 calc(32px + var(--shared-synergy-signal) * 48px) rgba(12, 20, 40, 0.32);
+  border-color: color-mix(in srgb, var(--global-brand-accent) 35%, rgba(255, 255, 255, 0.25));
+}
+
+.global-visualizer-card[data-support-distance="0"],
+[data-visualizer-card][data-support-distance="0"] {
+  --support-distance-z: 22px;
+  --support-distance-glow: 0.24;
+}
+
+.global-visualizer-card[data-support-distance="1"],
+[data-visualizer-card][data-support-distance="1"] {
+  --support-distance-z: 14px;
+  --support-distance-glow: 0.16;
+}
+
+.global-visualizer-card[data-support-distance="2"],
+[data-visualizer-card][data-support-distance="2"] {
+  --support-distance-z: 8px;
+  --support-distance-glow: 0.08;
+}
+
+.global-visualizer-card[data-support-distance="visible"],
+[data-visualizer-card][data-support-distance="visible"] {
+  --support-distance-z: 10px;
+  --support-distance-glow: 0.12;
+}
+
+.global-visualizer-card[data-support-distance="far"],
+[data-visualizer-card][data-support-distance="far"] {
+  --support-distance-z: -8px;
+  --support-distance-glow: -0.06;
+}
+
+.global-visualizer-card[data-support-role="supporting"],
+[data-visualizer-card][data-support-role="supporting"] {
+  opacity: calc(0.82 + var(--card-support-intensity) * 0.18 + var(--shared-synergy-signal) * 0.12);
+  filter: saturate(calc(0.86 + var(--card-focus-strength) * 0.2 + var(--shared-synergy-signal) * 0.28));
+  transform: perspective(1600px)
+    rotateX(calc(
+      (0.5 - var(--card-focus-y)) * 22deg +
+      var(--card-scroll-momentum) * 4deg +
+      var(--shared-tilt-y-signal) * 16deg
+    ))
+    rotateY(calc(
+      (var(--card-focus-x) - 0.5) * 20deg +
+      var(--shared-tilt-x-signal) * 18deg
+    ))
+    rotateZ(calc(
+      var(--card-twist) * 0.82 +
+      var(--shared-warp-signal) * 6deg +
+      var(--shared-scroll-signal) * 4deg +
+      var(--shared-tilt-skew-signal) * 4deg
+    ))
+    translateZ(calc(
+      var(--card-focus-strength) * 26px +
+      var(--shared-focus-signal) * 18px +
+      var(--shared-bend-signal) * 20px +
+      var(--shared-focus-trend-signal) * 28px +
+      var(--shared-scroll-speed-signal) * 12px
+    ))
+    translateX(calc(
+      (var(--card-focus-x) - 0.5) * 22px +
+      var(--shared-scroll-direction-signal) * var(--shared-scroll-speed-signal) * 16px
+    ))
+    translateY(calc(
+      (var(--card-focus-y) - 0.5) * -18px +
+      var(--shared-focus-trend-signal) * -16px
+    ))
+    scale(calc(
+      1 + var(--card-focus-strength) * 0.04 +
+      var(--card-support-intensity) * 0.02 +
+      var(--shared-synergy-signal) * 0.04
+    ));
+}
+
+.global-visualizer-card[data-support-role="ambient"],
+[data-visualizer-card][data-support-role="ambient"] {
+  opacity: calc(0.72 + var(--card-support-intensity) * 0.2 + var(--shared-synergy-signal) * 0.1);
+  filter: saturate(calc(0.78 + var(--card-focus-strength) * 0.18 + var(--shared-synergy-signal) * 0.18));
+  transform: perspective(1500px)
+    rotateX(calc(
+      (0.5 - var(--card-focus-y)) * 18deg +
+      var(--card-scroll-momentum) * 2deg +
+      var(--shared-tilt-y-signal) * 14deg
+    ))
+    rotateY(calc(
+      (var(--card-focus-x) - 0.5) * 18deg +
+      var(--shared-tilt-x-signal) * 14deg
+    ))
+    rotateZ(calc(
+      var(--card-twist) * 0.65 +
+      var(--shared-warp-signal) * 5deg +
+      var(--shared-scroll-signal) * 3deg
+    ))
+    translateZ(calc(
+      var(--card-focus-strength) * 18px +
+      var(--shared-bend-signal) * 16px +
+      var(--shared-focus-signal) * 12px
+    ))
+    scale(calc(0.98 + var(--card-support-intensity) * 0.02 + var(--shared-synergy-signal) * 0.03));
+}
+
+.global-visualizer-card[data-support-role="neutral"],
+[data-visualizer-card][data-support-role="neutral"] {
+  opacity: calc(0.85 + var(--card-support-intensity) * 0.12 + var(--shared-synergy-signal) * 0.12);
+  filter: saturate(calc(0.9 + var(--card-focus-strength) * 0.18 + var(--shared-synergy-signal) * 0.2));
+  transform: perspective(1550px)
+    rotateX(calc(
+      (0.5 - var(--card-focus-y)) * 20deg +
+      var(--card-scroll-momentum) * 3deg +
+      var(--shared-tilt-y-signal) * 15deg
+    ))
+    rotateY(calc(
+      (var(--card-focus-x) - 0.5) * 19deg +
+      var(--shared-tilt-x-signal) * 16deg
+    ))
+    rotateZ(calc(
+      var(--card-twist) * 0.74 +
+      var(--shared-warp-signal) * 5deg +
+      var(--shared-scroll-signal) * 3.5deg
+    ))
+    translateZ(calc(
+      var(--card-focus-strength) * 22px +
+      var(--shared-bend-signal) * 18px +
+      var(--shared-focus-signal) * 16px
+    ))
+    scale(calc(1 + var(--card-support-intensity) * 0.015 + var(--shared-synergy-signal) * 0.035));
+}
+
+.global-visualizer-card::before,
+[data-visualizer-card]::before {
+  content: '';
+  position: absolute;
+  inset: -14%;
+  background: radial-gradient(
+    circle at calc(var(--card-focus-x) * 100%) calc(var(--card-focus-y) * 100%),
+    rgba(0, 255, 255, calc(0.18 + var(--card-focus-strength) * 0.4 + var(--card-support-intensity) * 0.2)),
+    rgba(132, 56, 255, calc(0.12 + var(--card-support-intensity) * 0.25)) 45%,
+    rgba(12, 12, 32, 0) 78%
+  );
+  opacity: calc(0.35 + var(--card-focus-strength) * 0.5 + var(--card-support-intensity) * 0.25 + var(--group-synergy, 0) * 0.3 + var(--support-distance-glow, 0) + (var(--card-visibility-factor) - 1) * 0.15);
+  filter: blur(calc(22px - var(--card-focus-strength) * 8px - var(--group-synergy, 0) * 6px - var(--global-tilt-strength) * 4px + (1 - var(--card-visibility-factor)) * 6px));
+  transform:
+    translateZ(calc(-24px + var(--support-distance-glow, 0) * 60px - var(--global-bend-intensity) * 24px))
+    rotateZ(calc(var(--global-warp) * 6deg))
+    scale(calc(1.08 + var(--group-synergy, 0) * 0.06 + var(--global-tilt-strength) * 0.04));
+  pointer-events: none;
+  z-index: 0;
+  transition: opacity 0.6s ease, filter 0.6s ease;
+}
+
+.global-visualizer-card::after,
+[data-visualizer-card]::after {
+  content: '';
+  position: absolute;
+  inset: -8%;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, calc(0.1 + var(--card-support-intensity) * 0.3 + var(--support-distance-glow, 0) * 0.4));
+  opacity: calc(0.25 + var(--card-focus-strength) * 0.35 + var(--group-synergy, 0) * 0.2 + var(--support-distance-glow, 0) * 0.6 + (var(--card-visibility-factor) - 1) * 0.12 + var(--global-bend-intensity) * 0.15);
+  filter: blur(calc(6px - var(--card-focus-strength) * 2px - var(--group-synergy, 0) * 1.2px - var(--global-tilt-strength) * 1.5px + (1 - var(--card-visibility-factor)) * 2px));
+  pointer-events: none;
+  z-index: 1;
+  mix-blend-mode: screen;
+  transition: opacity 0.6s ease, filter 0.6s ease;
+}
+
+.global-visualizer-card,
+[data-visualizer-card] {
+  transform:
+    perspective(calc(1600px - var(--global-bend-intensity) * 320px))
+    rotateX(calc(
+      (0.5 - var(--card-focus-y)) * 26deg +
+      var(--card-scroll-momentum) * 6deg +
+      var(--global-tilt-y) * 24deg
+    ))
+    rotateY(calc(
+      (var(--card-focus-x) - 0.5) * 28deg +
+      var(--global-tilt-x) * 26deg
+    ))
+    rotateZ(calc(var(--card-twist) + var(--global-warp) * 8deg))
+    translateZ(calc(var(--card-focus-strength) * 48px + var(--support-distance-z) + var(--global-bend-intensity) * 24px))
+    scale(calc(1 + var(--card-focus-strength) * 0.06 + var(--card-support-intensity) * 0.03 + var(--global-bend-intensity) * 0.02));
+  box-shadow:
+    0 30px 70px rgba(8, 12, 32, calc((0.25 + var(--card-focus-strength) * 0.35) * (0.5 + var(--card-visibility-factor) * 0.5))),
+    0 12px 34px rgba(0, 240, 255, calc((0.12 + var(--card-support-intensity) * 0.3) * (0.5 + var(--card-visibility-factor) * 0.5))),
+    inset 0 1px 0 rgba(255, 255, 255, calc((0.2 + var(--card-focus-strength) * 0.3) * (0.6 + var(--card-visibility-factor) * 0.4)));
+  border: 1px solid rgba(255, 255, 255, calc(0.18 + var(--card-focus-strength) * 0.35));
+  filter: saturate(calc(1 + var(--card-focus-strength) * 0.4 + var(--card-support-intensity) * 0.3))
+    saturate(calc(1 + var(--global-tilt-strength) * 0.18))
+    brightness(calc(1 + var(--card-support-intensity) * 0.15 + (var(--card-visibility-factor) - 1) * 0.08 + var(--global-bend-intensity) * 0.12));
+}
+
+.global-visualizer-card .global-brand-overlay,
+[data-visualizer-card] .global-brand-overlay {
+  position: absolute;
+  inset: -22%;
+  z-index: 2;
+  border-radius: inherit;
+  pointer-events: none;
+  background-size: cover;
+  background-position: center;
+  opacity: calc((0.2 + var(--card-focus-strength) * 0.55 + var(--card-support-intensity) * 0.35 + var(--group-synergy, 0) * 0.18 + (var(--card-visibility-factor) - 1) * 0.25 + var(--support-distance-glow, 0) * 0.5) * var(--brand-overlay-opacity, 1));
+  mix-blend-mode: var(--brand-overlay-blend, screen);
+  filter:
+    saturate(calc(1.2 + var(--card-focus-strength) * 1.4 + var(--group-synergy, 0) * 0.6))
+    blur(calc((0.4 - var(--card-focus-strength) * 0.3 - var(--group-synergy, 0) * 0.1 - var(--global-tilt-strength) * 0.08 + (1 - var(--card-visibility-factor)) * 0.2) * 18px))
+    var(--brand-overlay-filter, brightness(1));
+  transform:
+    translateZ(calc(18px + var(--card-focus-strength) * 36px + var(--group-synergy, 0) * 24px + var(--support-distance-z) * 0.4 + var(--brand-overlay-depth, 0px) + var(--global-bend-intensity) * 32px))
+    rotateX(calc(var(--card-scroll-momentum) * -1.8deg + var(--group-synergy, 0) * -1.2deg + var(--global-tilt-y) * -18deg))
+    rotateY(calc(var(--card-scroll-momentum) * 1.6deg + var(--group-synergy, 0) * 1.1deg + var(--global-tilt-x) * 18deg))
+    rotateZ(calc(var(--brand-overlay-rotate, 0deg) + var(--global-warp) * 10deg));
+  transition: opacity 0.5s ease, filter 0.6s ease, transform 0.6s ease;
+}
+
+.global-brand-overlay video,
+.global-brand-overlay img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.9;
+  filter: inherit;
+  mix-blend-mode: inherit;
+}
+
+.global-brand-overlay::after {
+  content: '';
+  position: absolute;
+  inset: -10%;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+  opacity: calc(0.45 + var(--card-focus-strength) * 0.4 + (var(--card-visibility-factor) - 1) * 0.2);
+  transform: translateZ(12px);
+}
+
+.global-visualizer-card canvas[data-visualizer],
+.global-visualizer-card canvas[data-vib34d],
+.global-visualizer-card canvas[class*="visualizer"],
+.global-visualizer-card canvas[class*="hologram"],
+.global-visualizer-card .holographic-canvas canvas,
+[data-visualizer-card] canvas[data-visualizer],
+[data-visualizer-card] canvas[data-vib34d],
+[data-visualizer-card] canvas[class*="visualizer"],
+[data-visualizer-card] canvas[class*="hologram"],
+[data-visualizer-card] .holographic-canvas canvas {
+  position: absolute;
+  inset: calc(-18% - var(--global-bend-intensity) * 4%);
+  width: calc(136% + var(--global-bend-intensity) * 18%);
+  height: calc(136% + var(--global-bend-intensity) * 18%);
+  transform:
+    translateZ(calc(-36px + var(--card-focus-strength) * -18px - var(--group-synergy, 0) * 16px + var(--support-distance-z) * -0.6 + var(--card-canvas-depth, 0px) - var(--global-bend-intensity) * 28px))
+    rotateX(calc((0.5 - var(--card-focus-y)) * 18deg + var(--card-scroll-momentum) * 4deg + var(--group-synergy, 0) * 2deg + var(--global-tilt-y) * 20deg))
+    rotateY(calc((var(--card-focus-x) - 0.5) * 18deg + var(--group-synergy, 0) * -2deg + var(--global-tilt-x) * 20deg))
+    rotateZ(calc(var(--card-rotation-phase, 0) * 18deg + var(--global-warp) * 12deg))
+    scale3d(
+      calc(1 + var(--card-canvas-scale, 0) + var(--global-bend-intensity) * 0.04),
+      calc(1 + var(--card-canvas-scale, 0) + var(--global-bend-intensity) * 0.04),
+      1
+    );
+  filter: saturate(calc(1.1 + var(--card-focus-strength) * 0.4 + var(--group-synergy, 0) * 0.25 + (var(--card-visibility-factor) - 1) * 0.3 + var(--global-tilt-strength) * 0.2))
+    hue-rotate(calc(var(--global-warp) * 14deg));
+  pointer-events: none;
+  transition: transform 0.6s ease, filter 0.6s ease;
+}
+
+body[data-global-brand-palette="meta"] .global-visualizer-card::before,
+body[data-global-brand-palette="meta"] [data-visualizer-card]::before {
+  background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.32), rgba(30, 52, 92, 0));
+}
+
+body[data-global-brand-palette="immersive"] .global-brand-overlay::after,
+body[data-global-brand-palette="immersive"] [data-visualizer-card] .global-brand-overlay::after {
+  background: radial-gradient(circle at 60% 40%, rgba(72, 0, 255, 0.45), rgba(0, 0, 0, 0));
+}
+
+body[data-global-brand-palette="concept"] .global-brand-overlay::after,
+body[data-global-brand-palette="concept"] [data-visualizer-card] .global-brand-overlay::after {
+  background: radial-gradient(circle at 40% 60%, rgba(0, 255, 213, 0.48), rgba(0, 0, 0, 0));
+}
+
+.global-visualizer-card[data-has-focus="true"]::before,
+[data-visualizer-card][data-has-focus="true"]::before {
+  opacity: calc(0.5 + var(--card-focus-strength) * 0.35);
+}
+
+.global-visualizer-card[data-has-focus="true"]::after,
+[data-visualizer-card][data-has-focus="true"]::after {
+  opacity: calc(0.38 + var(--card-focus-strength) * 0.4);
+}
+
+.global-visualizer-card .supporting-layer,
+[data-visualizer-card] .supporting-layer {
+  transform: translateZ(calc(-20px + var(--card-support-intensity) * -10px));
+  opacity: calc(0.6 + var(--card-support-intensity) * 0.4);
+  transition: transform 0.6s ease, opacity 0.6s ease;
+}
+
+.global-visualizer-card[data-interaction-active="true"],
+[data-visualizer-card][data-interaction-active="true"] {
+  filter: brightness(calc(1.05 + var(--card-focus-strength) * 0.2));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .global-visualizer-card,
+  [data-visualizer-card] {
+    transition: none;
+    transform: none !important;
+    box-shadow: none;
+  }
+
+  .global-visualizer-card::before,
+  [data-visualizer-card]::before,
+  .global-visualizer-card::after,
+  [data-visualizer-card]::after,
+  .global-visualizer-card .global-brand-overlay,
+  [data-visualizer-card] .global-brand-overlay {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add an orchestrator mode flag so catalog pages can disable tilt/effect injection while still sharing baseline motion metadata
- refine tilt, bend, and rotation weighting so cards, canvases, and overlays react together more smoothly
- document the static catalog mode and updated tilt blending in the global motion reference

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d5b334633c8329b71690cbd1ca4576