### PR TITLE
Improve global card tilt orchestration

### DIFF
--- a/styles/global-card-synergy.css
+++ b/styles/global-card-synergy.css
@@ -14,6 +14,9 @@
   --global-focus-trend: 0;
   --global-scroll-speed: 0;
   --global-scroll-direction: 0;
+  --global-pointer-presence: 0;
+  --global-viewport-x: 0.5;
+  --global-viewport-y: 0.5;
   --global-brand-accent: #6fe8ff;
   --global-family-focus-boost: 1;
   --global-family-bend-boost: 1;
@@ -177,6 +180,9 @@ html[data-global-page-family="labs"] {
   --shared-scroll-speed-signal: var(--shared-scroll-speed, var(--global-scroll-speed, 0));
   --shared-focus-trend-signal: var(--shared-focus-trend, var(--global-focus-trend, 0));
   --shared-tilt-skew-signal: var(--shared-tilt-skew, var(--global-tilt-skew, 0));
+  --shared-pointer-presence-signal: var(--shared-pointer-presence, var(--global-pointer-presence, 0));
+  --shared-viewport-x-signal: var(--shared-viewport-x, var(--global-viewport-x, 0.5));
+  --shared-viewport-y-signal: var(--shared-viewport-y, var(--global-viewport-y, 0.5));
   transition:
     box-shadow 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
     border-color 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
@@ -236,17 +242,18 @@ html[data-global-page-family="labs"] {
   transform: perspective(1600px)
     rotateX(calc(
       (0.5 - var(--card-focus-y)) * 22deg +
-      var(--card-scroll-momentum) * 4deg +
+      (0.5 - var(--shared-viewport-y-signal)) * 14deg * (1 - var(--shared-pointer-presence-signal)) +
       var(--shared-tilt-y-signal) * 16deg
     ))
     rotateY(calc(
       (var(--card-focus-x) - 0.5) * 20deg +
+      (var(--shared-viewport-x-signal) - 0.5) * 16deg * (1 - var(--shared-pointer-presence-signal)) +
       var(--shared-tilt-x-signal) * 18deg
     ))
     rotateZ(calc(
       var(--card-twist) * 0.82 +
       var(--shared-warp-signal) * 6deg +
-      var(--shared-scroll-signal) * 4deg +
+      (var(--shared-viewport-x-signal) - 0.5) * 5deg * (1 - var(--shared-pointer-presence-signal)) +
       var(--shared-tilt-skew-signal) * 4deg
     ))
     translateZ(calc(
@@ -258,10 +265,12 @@ html[data-global-page-family="labs"] {
     ))
     translateX(calc(
       (var(--card-focus-x) - 0.5) * 22px +
-      var(--shared-scroll-direction-signal) * var(--shared-scroll-speed-signal) * 16px
+      (var(--shared-viewport-x-signal) - 0.5) * 18px * (1 - var(--shared-pointer-presence-signal)) +
+      var(--shared-scroll-direction-signal) * var(--shared-scroll-speed-signal) * 8px
     ))
     translateY(calc(
       (var(--card-focus-y) - 0.5) * -18px +
+      (0.5 - var(--shared-viewport-y-signal)) * 14px * (1 - var(--shared-pointer-presence-signal)) +
       var(--shared-focus-trend-signal) * -16px
     ))
     scale(calc(
@@ -278,22 +287,31 @@ html[data-global-page-family="labs"] {
   transform: perspective(1500px)
     rotateX(calc(
       (0.5 - var(--card-focus-y)) * 18deg +
-      var(--card-scroll-momentum) * 2deg +
+      (0.5 - var(--shared-viewport-y-signal)) * 12deg * (1 - var(--shared-pointer-presence-signal)) +
       var(--shared-tilt-y-signal) * 14deg
     ))
     rotateY(calc(
       (var(--card-focus-x) - 0.5) * 18deg +
+      (var(--shared-viewport-x-signal) - 0.5) * 14deg * (1 - var(--shared-pointer-presence-signal)) +
       var(--shared-tilt-x-signal) * 14deg
     ))
     rotateZ(calc(
       var(--card-twist) * 0.65 +
       var(--shared-warp-signal) * 5deg +
-      var(--shared-scroll-signal) * 3deg
+      (var(--shared-viewport-x-signal) - 0.5) * 4deg * (1 - var(--shared-pointer-presence-signal))
     ))
     translateZ(calc(
       var(--card-focus-strength) * 18px +
       var(--shared-bend-signal) * 16px +
       var(--shared-focus-signal) * 12px
+    ))
+    translateX(calc(
+      (var(--card-focus-x) - 0.5) * 18px +
+      (var(--shared-viewport-x-signal) - 0.5) * 14px * (1 - var(--shared-pointer-presence-signal))
+    ))
+    translateY(calc(
+      (var(--card-focus-y) - 0.5) * -14px +
+      (0.5 - var(--shared-viewport-y-signal)) * 12px * (1 - var(--shared-pointer-presence-signal))
     ))
     scale(calc(0.98 + var(--card-support-intensity) * 0.02 + var(--shared-synergy-signal) * 0.03));
 }
@@ -305,22 +323,31 @@ html[data-global-page-family="labs"] {
   transform: perspective(1550px)
     rotateX(calc(
       (0.5 - var(--card-focus-y)) * 20deg +
-      var(--card-scroll-momentum) * 3deg +
+      (0.5 - var(--shared-viewport-y-signal)) * 13deg * (1 - var(--shared-pointer-presence-signal)) +
       var(--shared-tilt-y-signal) * 15deg
     ))
     rotateY(calc(
       (var(--card-focus-x) - 0.5) * 19deg +
+      (var(--shared-viewport-x-signal) - 0.5) * 15deg * (1 - var(--shared-pointer-presence-signal)) +
       var(--shared-tilt-x-signal) * 16deg
     ))
     rotateZ(calc(
       var(--card-twist) * 0.74 +
       var(--shared-warp-signal) * 5deg +
-      var(--shared-scroll-signal) * 3.5deg
+      (var(--shared-viewport-x-signal) - 0.5) * 4.5deg * (1 - var(--shared-pointer-presence-signal))
     ))
     translateZ(calc(
       var(--card-focus-strength) * 22px +
       var(--shared-bend-signal) * 18px +
       var(--shared-focus-signal) * 16px
+    ))
+    translateX(calc(
+      (var(--card-focus-x) - 0.5) * 20px +
+      (var(--shared-viewport-x-signal) - 0.5) * 16px * (1 - var(--shared-pointer-presence-signal))
+    ))
+    translateY(calc(
+      (var(--card-focus-y) - 0.5) * -16px +
+      (0.5 - var(--shared-viewport-y-signal)) * 13px * (1 - var(--shared-pointer-presence-signal))
     ))
     scale(calc(1 + var(--card-support-intensity) * 0.015 + var(--shared-synergy-signal) * 0.035));
 }
@@ -368,11 +395,12 @@ html[data-global-page-family="labs"] {
     perspective(calc(1600px - var(--global-bend-intensity) * 320px))
     rotateX(calc(
       (0.5 - var(--card-focus-y)) * 26deg +
-      var(--card-scroll-momentum) * 6deg +
+      (0.5 - var(--shared-viewport-y-signal)) * 16deg * (1 - var(--shared-pointer-presence-signal)) +
       var(--global-tilt-y) * 24deg
     ))
     rotateY(calc(
       (var(--card-focus-x) - 0.5) * 28deg +
+      (var(--shared-viewport-x-signal) - 0.5) * 18deg * (1 - var(--shared-pointer-presence-signal)) +
       var(--global-tilt-x) * 26deg
     ))
     rotateZ(calc(var(--card-twist) + var(--global-warp) * 8deg))
@@ -405,8 +433,16 @@ html[data-global-page-family="labs"] {
     var(--brand-overlay-filter, brightness(1));
   transform:
     translateZ(calc(18px + var(--card-focus-strength) * 36px + var(--group-synergy, 0) * 24px + var(--support-distance-z) * 0.4 + var(--brand-overlay-depth, 0px) + var(--global-bend-intensity) * 32px))
-    rotateX(calc(var(--card-scroll-momentum) * -1.8deg + var(--group-synergy, 0) * -1.2deg + var(--global-tilt-y) * -18deg))
-    rotateY(calc(var(--card-scroll-momentum) * 1.6deg + var(--group-synergy, 0) * 1.1deg + var(--global-tilt-x) * 18deg))
+    rotateX(calc(
+      (0.5 - var(--shared-viewport-y-signal)) * -12deg * (1 - var(--shared-pointer-presence-signal)) +
+      var(--group-synergy, 0) * -1.2deg +
+      var(--global-tilt-y) * -18deg
+    ))
+    rotateY(calc(
+      (var(--shared-viewport-x-signal) - 0.5) * 10deg * (1 - var(--shared-pointer-presence-signal)) +
+      var(--group-synergy, 0) * 1.1deg +
+      var(--global-tilt-x) * 18deg
+    ))
     rotateZ(calc(var(--brand-overlay-rotate, 0deg) + var(--global-warp) * 10deg));
   transition: opacity 0.5s ease, filter 0.6s ease, transform 0.6s ease;
 }
@@ -448,8 +484,18 @@ html[data-global-page-family="labs"] {
   height: calc(136% + var(--global-bend-intensity) * 18%);
   transform:
     translateZ(calc(-36px + var(--card-focus-strength) * -18px - var(--group-synergy, 0) * 16px + var(--support-distance-z) * -0.6 + var(--card-canvas-depth, 0px) - var(--global-bend-intensity) * 28px))
-    rotateX(calc((0.5 - var(--card-focus-y)) * 18deg + var(--card-scroll-momentum) * 4deg + var(--group-synergy, 0) * 2deg + var(--global-tilt-y) * 20deg))
-    rotateY(calc((var(--card-focus-x) - 0.5) * 18deg + var(--group-synergy, 0) * -2deg + var(--global-tilt-x) * 20deg))
+    rotateX(calc(
+      (0.5 - var(--card-focus-y)) * 18deg +
+      (0.5 - var(--shared-viewport-y-signal)) * 12deg * (1 - var(--shared-pointer-presence-signal)) +
+      var(--group-synergy, 0) * 2deg +
+      var(--global-tilt-y) * 20deg
+    ))
+    rotateY(calc(
+      (var(--card-focus-x) - 0.5) * 18deg +
+      (var(--shared-viewport-x-signal) - 0.5) * 12deg * (1 - var(--shared-pointer-presence-signal)) +
+      var(--group-synergy, 0) * -2deg +
+      var(--global-tilt-x) * 20deg
+    ))
     rotateZ(calc(var(--card-rotation-phase, 0) * 18deg + var(--global-warp) * 12deg))
     scale3d(
       calc(1 + var(--card-canvas-scale, 0) + var(--global-bend-intensity) * 0.04),


### PR DESCRIPTION
## Summary
- blend pointer focus with viewport centroids in the global orchestrator and expose the new motion metrics
- smooth layout sampling per card, reduce scroll-driven momentum, and broaden the reset defaults
- retune the synergy stylesheet to drive card, overlay, and canvas tilts from viewport alignment instead of scroll momentum

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d70445076483299e0cd63f9d404e68