### PR TITLE
Layer trait handoff choreography into orthogonal depth progression

### DIFF
--- a/25-orthogonal-depth-progression.html
+++ b/25-orthogonal-depth-progression.html
@@ -31,6 +31,13 @@
             --holographic-pink: #ff1493;
             --void-black: #0a0a0a;
             --depth-perspective: 1200px;
+
+            /* Ambient reactivity channels */
+            --bg-parallax-x: 0px;
+            --bg-parallax-y: 0px;
+            --bg-scale: 1;
+            --bg-sheen: 0.32;
+            --bg-twist: 0deg;
         }
 
         body {
@@ -41,6 +48,24 @@
             height: 100vh;
             perspective: var(--depth-perspective);
             perspective-origin: center center;
+            position: relative;
+        }
+
+        body::before {
+            content: "";
+            position: fixed;
+            inset: -20%;
+            background: radial-gradient(circle at 50% 40%, rgba(0, 255, 255, 0.22), rgba(255, 0, 255, 0.08) 45%, transparent 75%);
+            mix-blend-mode: screen;
+            opacity: var(--bg-sheen);
+            transform: translate3d(var(--bg-parallax-x), var(--bg-parallax-y), 0) scale(var(--bg-scale)) rotate(var(--bg-twist));
+            filter: saturate(1.1);
+            pointer-events: none;
+            transition:
+                transform 0.6s cubic-bezier(0.22, 1, 0.36, 1),
+                opacity 0.6s ease,
+                filter 0.6s ease;
+            z-index: 0;
         }
 
         /* ORTHOGONAL PROGRESSION CONTAINER */
@@ -70,6 +95,29 @@
             backdrop-filter: blur(10px);
             transition: all 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
             cursor: pointer;
+            overflow: hidden;
+            isolation: isolate;
+            --card-glow-shift-x: 0px;
+            --card-glow-shift-y: 0px;
+            --card-glow-scale: 1;
+            --card-glow-opacity: 0.18;
+        }
+
+        .progression-card::after {
+            content: "";
+            position: absolute;
+            inset: -18%;
+            background: radial-gradient(circle at 50% 50%, rgba(0, 255, 255, 0.25), rgba(255, 0, 255, 0.12) 45%, transparent 70%);
+            border-radius: inherit;
+            pointer-events: none;
+            opacity: var(--card-glow-opacity);
+            transform: translate3d(var(--card-glow-shift-x), var(--card-glow-shift-y), 0) scale(var(--card-glow-scale));
+            filter: blur(calc(18px * var(--card-glow-scale)));
+            transition:
+                opacity 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+                transform 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+                filter 0.45s ease;
+            z-index: 0;
         }
 
         /* DEPTH PROGRESSION STATES */
@@ -308,7 +356,7 @@
     <div class="depth-progression-container" id="progressionContainer">
 
         <!-- CARD 1: QUANTUM SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum">
+        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum" data-reactive-profile="quantum-hyperglass" data-portal-variant="spiral">
             <canvas class="vib34d-tilt-canvas" id="quantum-tilt-canvas"></canvas>
             <div class="portal-text-visualizer" id="quantum-portal"></div>
             <div class="card-header">
@@ -321,7 +369,7 @@
         </div>
 
         <!-- CARD 2: HOLOGRAPHIC SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="holographic" data-destruction="holographic">
+        <div class="progression-card far-depth" data-vib34d="holographic" data-destruction="holographic" data-reactive-profile="holo-ribbon-surge" data-portal-variant="filament">
             <canvas class="vib34d-tilt-canvas" id="holographic-tilt-canvas"></canvas>
             <div class="portal-text-visualizer" id="holographic-portal"></div>
             <div class="card-header">
@@ -334,7 +382,7 @@
         </div>
 
         <!-- CARD 3: FACETED SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="faceted" data-destruction="faceted">
+        <div class="progression-card far-depth" data-vib34d="faceted" data-destruction="faceted" data-reactive-profile="faceted-orbital-forge" data-portal-variant="prism">
             <canvas class="vib34d-tilt-canvas" id="faceted-tilt-canvas"></canvas>
             <div class="portal-text-visualizer" id="faceted-portal"></div>
             <div class="card-header">
@@ -347,7 +395,7 @@
         </div>
 
         <!-- CARD 4: NEURAL SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum">
+        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum" data-reactive-profile="neural-lumen-exchange" data-portal-variant="axon">
             <canvas class="vib34d-tilt-canvas" id="neural-tilt-canvas"></canvas>
             <div class="portal-text-visualizer" id="neural-portal"></div>
             <div class="card-header">
@@ -382,6 +430,12 @@
             // Initialize orthogonal depth progression
             if (window.OrthogonalDepthProgression) {
                 window.progressionSystem = new OrthogonalDepthProgression();
+            }
+
+            if (window.progressionSystem && window.OrthogonalDepthReactivityOrchestrator) {
+                window.progressionReactivity = new OrthogonalDepthReactivityOrchestrator(window.progressionSystem, {
+                    tiltSystem: window.geometricTiltSystem
+                });
             }
 
             console.log('✅ VIB34D Systems initialized - Professional Avant-garde Mode Active');

--- a/docs/orthogonal-depth-reactivity-plan.md
+++ b/docs/orthogonal-depth-reactivity-plan.md
@@ -1,0 +1,35 @@
+# Orthogonal Depth Reactivity Rebuild Roadmap
+
+This roadmap captures the staged rebuild required to deliver the "refined and proper" Clear Seas reactive card progression.  Each phase tightens the choreography between the progression cards, VIB3-4D visualizers, portal canvases, and the ambient field so **every action drives at least two coordinated responses**.
+
+---
+
+## Phase 1 — Systems Architecture & Dual-Reaction Foundation *(current pull request)*
+- Introduce a formal reactivity orchestrator that observes progression state changes and pointer / scroll input.
+- Pipe every interaction into **paired responses** (active card + background field, active card + incoming card, card visualizer + portal visualizer) using lightweight CSS custom properties and the existing VIB34D APIs.
+- Enrich the VIB34D tilt visualizer and portal renderer with `applyInteractionResponse` / `applyReactiveImpulse` hooks, giving the orchestrator a deterministic way to modulate speed, glitch, density, depth, hue, and flourish energy.
+- Establish ambient background parallax and intra-card glow layers that animate via CSS transitions so motions remain smooth even when JavaScript pulses are brief.
+
+## Phase 2 — Trait Hand-off Micro-choreography
+- Extend the orchestrator to listen for destruction events and orchestrate choreographed trait transfers: dying card performs a multi-stage collapse while the successor card mirrors the effect with inverse density and inherited geometry seeds.
+- Layer in audio-reactive channels (FFT bands from the Ultimate Viewer engine) that modulate both the background field and the focused card’s moiré / glitch envelopes.
+- Add scroll velocity sampling so rapid scrolls trigger higher-order responses (e.g., card orbiting, portal vortex shearing) while gentle scrolls surface subtle parallax and color grading changes.
+
+### Phase 2 Progress Update *(current work)*
+- Trait inheritance now travels through a formal handshake signal. Destruction sequences generate gift-bearing trait packets that pre-charge the incoming card’s tilt visualizer and portal before it reaches focus.
+- Portal visualizers respond to inherited gifts with bespoke geometry variants (spiral, filament, prism, axon) and intensity boosts so the successor canvas always reacts in tandem with the outgoing collapse.
+- The reactivity orchestrator listens for `trait-handshake` broadcasts and coordinates glow, portal, and background surges to satisfy the dual-entity motion requirement during transfers.
+
+## Phase 3 — Magazine-grade Presentation Polish
+- Integrate page-level typography and navigation polish inspired by versions #30 and #1, ensuring the novel depth progression still reads like a “master class” scrolling site.
+- Add choreographed entrance / exit cinematics for menus, copy blocks, and metrics panels so they tether visually to the card and portal responses.
+- Implement persistent session memory of trait evolution so revisiting cards shows evolved geometry palettes instead of resetting to defaults.
+
+## Phase 4 — Hyper Reactive Refinements
+- Blend Ultimate Viewer presets for touch, swipe, audio, and idle states into the orchestrator so each input channel has curated presets (e.g., idle breathing, swipe ribbon casting, hold-induced dimensional lifts).
+- Introduce per-card shader swaps (WebGL or WASM pipelines) for the background field that react to inherited traits, ensuring every card transition feels bespoke in both geometry and chroma.
+- Add detailed destruction cinematics with timed particle systems and inter-card crossfades, finalizing the “spectacular choreographed event” requirement.
+
+---
+
+> **Implementation Note:** The current code submission completes Phase 1 by wiring the orchestrator, reactivity hooks, and shared polish layers.  Subsequent phases build directly on this foundation.

--- a/scripts/orthogonal-depth-progression.js
+++ b/scripts/orthogonal-depth-progression.js
@@ -26,6 +26,9 @@ class OrthogonalDepthProgression {
         this.scrollThreshold = 100;
         this.isScrollProgression = true;
 
+        this.pendingInheritedTrait = null;
+        this.eventTarget = new EventTarget();
+
         this.init();
     }
 
@@ -91,8 +94,17 @@ class OrthogonalDepthProgression {
     }
 
     handleScrollProgression() {
+        const magnitude = Math.min(1, Math.abs(this.scrollAccumulator) / this.scrollThreshold);
+        this.emit('scroll-accumulating', {
+            accumulator: this.scrollAccumulator,
+            magnitude
+        });
+
         if (Math.abs(this.scrollAccumulator) > this.scrollThreshold) {
-            if (this.scrollAccumulator > 0) {
+            const direction = this.scrollAccumulator > 0 ? 1 : -1;
+            this.emit('scroll-threshold', { direction, magnitude });
+
+            if (direction > 0) {
                 this.nextCard();
             } else {
                 this.previousCard();
@@ -101,6 +113,10 @@ class OrthogonalDepthProgression {
         } else {
             // Decay scroll accumulator
             this.scrollAccumulator *= 0.9;
+            this.emit('scroll-decay', {
+                accumulator: this.scrollAccumulator,
+                magnitude: Math.min(1, Math.abs(this.scrollAccumulator) / this.scrollThreshold)
+            });
         }
     }
 
@@ -132,12 +148,12 @@ class OrthogonalDepthProgression {
         this.cards.forEach((card, index) => {
             const portalElement = card.querySelector('.portal-text-visualizer');
             if (portalElement) {
-                this.createPortalVisualizer(portalElement, card.dataset.vib34d, index);
+                this.createPortalVisualizer(portalElement, card.dataset.vib34d, index, card);
             }
         });
     }
 
-    createPortalVisualizer(portalElement, systemType, cardIndex) {
+    createPortalVisualizer(portalElement, systemType, cardIndex, card) {
         // Create canvas for portal visualization
         const canvas = document.createElement('canvas');
         canvas.className = 'portal-canvas';
@@ -154,10 +170,34 @@ class OrthogonalDepthProgression {
         portalElement.appendChild(canvas);
 
         // Create portal visualizer instance
-        const portalVisualizer = new PortalTextVisualizer(canvas, systemType, cardIndex);
+        const profileKey = card ? card.dataset.reactiveProfile || null : null;
+        const portalVariant = card ? card.dataset.portalVariant || null : null;
+        const portalVisualizer = new PortalTextVisualizer(canvas, systemType, cardIndex, {
+            profileKey,
+            portalVariant
+        });
 
         // Store reference on card
         portalElement.portalVisualizer = portalVisualizer;
+    }
+
+    getVisualizerForCard(card) {
+        const canvas = card.querySelector('.vib34d-tilt-canvas');
+        if (canvas && canvas.vib34dVisualizer) {
+            return canvas.vib34dVisualizer;
+        }
+        return null;
+    }
+
+    updateVisualizerState(card, state, options = {}) {
+        const visualizer = this.getVisualizerForCard(card);
+        if (!visualizer) return;
+
+        if (state === 'destroyed') {
+            visualizer.setCardState(state);
+        } else {
+            visualizer.setCardState(state, { inheritedTrait: options.inheritedTrait });
+        }
     }
 
     setInitialPositions() {
@@ -178,8 +218,9 @@ class OrthogonalDepthProgression {
         if (this.currentIndex >= this.cards.length - 1) {
             // Loop to beginning with destruction animation
             this.destroyCurrentCard(() => {
+                const inheritedTrait = this.pendingInheritedTrait;
                 this.currentIndex = 0;
-                this.progressToCurrentCard();
+                this.progressToCurrentCard(inheritedTrait);
             });
             return;
         }
@@ -203,9 +244,24 @@ class OrthogonalDepthProgression {
         }
     }
 
+    peekCard(offset = 1) {
+        if (!this.cards.length) return null;
+        const length = this.cards.length;
+        const index = (this.currentIndex + offset + length) % length;
+        return this.cards[index] || null;
+    }
+
+    primeCardTrait(card, trait) {
+        if (!card || !trait) return;
+        const pending = card._pendingTrait || {};
+        card._pendingTrait = { ...pending, ...trait };
+    }
+
     progressToCard(newIndex) {
         const currentCard = this.cards[this.currentIndex];
         const newCard = this.cards[newIndex];
+        const inheritedTrait = this.pendingInheritedTrait;
+        this.pendingInheritedTrait = null;
 
         // Deactivate current card portal
         this.deactivatePortalForCard(currentCard);
@@ -215,12 +271,12 @@ class OrthogonalDepthProgression {
 
         // Bring new card forward through progression states
         setTimeout(() => {
-            this.setCardState(newCard, 'approaching');
+            this.setCardState(newCard, 'approaching', { inheritedTrait });
 
             setTimeout(() => {
-                this.setCardState(newCard, 'focused');
+                this.setCardState(newCard, 'focused', { inheritedTrait });
                 this.currentIndex = newIndex;
-                this.activatePortalForCard(newCard);
+                this.activatePortalForCard(newCard, inheritedTrait);
 
                 // Move old card to far depth
                 setTimeout(() => {
@@ -232,11 +288,11 @@ class OrthogonalDepthProgression {
         }, this.timings.cardTransition / 4);
     }
 
-    progressToCurrentCard() {
+    progressToCurrentCard(inheritedTrait = null) {
         this.cards.forEach((card, index) => {
             if (index === this.currentIndex) {
-                this.setCardState(card, 'focused');
-                this.activatePortalForCard(card);
+                this.setCardState(card, 'focused', { inheritedTrait });
+                this.activatePortalForCard(card, inheritedTrait);
             } else if (index < this.currentIndex) {
                 this.setCardState(card, 'far-depth');
                 this.deactivatePortalForCard(card);
@@ -245,19 +301,30 @@ class OrthogonalDepthProgression {
                 this.deactivatePortalForCard(card);
             }
         });
+
+        this.pendingInheritedTrait = null;
     }
 
-    setCardState(card, state) {
-        // Remove all progression state classes
-        this.progressionStates.forEach(s => card.classList.remove(s));
+    setCardState(card, state, options = {}) {
+        const inheritedTrait = options.inheritedTrait;
 
-        // Add new state
+        if (inheritedTrait) {
+            card._pendingTrait = inheritedTrait;
+        }
+
+        const traitForVisualizer = inheritedTrait || card._pendingTrait || card._activeTrait || null;
+        this.updateVisualizerState(card, state, { inheritedTrait: traitForVisualizer });
+
+        this.progressionStates.forEach(s => card.classList.remove(s));
         card.classList.add(state);
 
-        // Update card z-index based on state
         switch (state) {
             case 'focused':
                 card.style.zIndex = 1000;
+                if (card._pendingTrait) {
+                    card._activeTrait = card._pendingTrait;
+                    card._pendingTrait = null;
+                }
                 break;
             case 'approaching':
                 card.style.zIndex = 900;
@@ -272,12 +339,23 @@ class OrthogonalDepthProgression {
                 card.style.zIndex = 50;
                 break;
         }
+
+        this.emit('card-state-changed', {
+            card,
+            state,
+            inheritedTrait: traitForVisualizer
+        });
     }
 
-    activatePortalForCard(card) {
+    activatePortalForCard(card, inheritedTrait = null) {
         const portal = card.querySelector('.portal-text-visualizer');
         if (portal && portal.portalVisualizer) {
+            const trait = inheritedTrait || card._pendingTrait || card._activeTrait || null;
+            if (trait && portal.portalVisualizer.applyInheritedTrait) {
+                portal.portalVisualizer.applyInheritedTrait(trait);
+            }
             portal.portalVisualizer.activate();
+            this.emit('portal-activated', { card, trait });
         }
 
         // Add glow effect to card title
@@ -292,6 +370,7 @@ class OrthogonalDepthProgression {
         const portal = card.querySelector('.portal-text-visualizer');
         if (portal && portal.portalVisualizer) {
             portal.portalVisualizer.deactivate();
+            this.emit('portal-deactivated', { card });
         }
 
         // Remove glow effect from card title
@@ -306,19 +385,50 @@ class OrthogonalDepthProgression {
         const currentCard = this.cards[this.currentIndex];
         const destructionType = currentCard.dataset.destruction || 'quantum';
 
-        // Apply unique destruction animation
-        this.setCardState(currentCard, 'destroyed');
-        currentCard.classList.add(`destruction-${destructionType}`);
-
-        // Deactivate portal
         this.deactivatePortalForCard(currentCard);
 
-        // Reset card after destruction animation
+        this.setCardState(currentCard, 'destroyed');
+
+        const visualizer = this.getVisualizerForCard(currentCard);
+        const inheritedTrait = visualizer ? visualizer.triggerDestructionSequence() : null;
+        this.pendingInheritedTrait = inheritedTrait;
+
+        if (inheritedTrait) {
+            const nextCard = this.peekCard(1);
+            if (nextCard) {
+                this.primeCardTrait(nextCard, inheritedTrait);
+                this.emit('trait-handshake', { from: currentCard, to: nextCard, trait: inheritedTrait });
+            }
+        }
+
+        this.emit('card-destroyed', { card: currentCard, trait: inheritedTrait });
+
+        currentCard.classList.add(`destruction-${destructionType}`);
+
         setTimeout(() => {
             currentCard.classList.remove(`destruction-${destructionType}`);
             this.setCardState(currentCard, 'far-depth');
             if (callback) callback();
         }, this.timings.destructionDelay);
+    }
+
+    on(eventName, handler) {
+        if (!this.eventTarget || typeof handler !== 'function') {
+            return () => {};
+        }
+        const listener = (event) => handler(event.detail, event);
+        this.eventTarget.addEventListener(eventName, listener);
+        return () => this.eventTarget.removeEventListener(eventName, listener);
+    }
+
+    off(eventName, handler) {
+        if (!this.eventTarget || typeof handler !== 'function') return;
+        this.eventTarget.removeEventListener(eventName, handler);
+    }
+
+    emit(eventName, detail = {}) {
+        if (!this.eventTarget) return;
+        this.eventTarget.dispatchEvent(new CustomEvent(eventName, { detail }));
     }
 
     toggleAutoProgress() {
@@ -367,7 +477,7 @@ class OrthogonalDepthProgression {
  * Creates portal-style visualizations within focused card text
  */
 class PortalTextVisualizer {
-    constructor(canvas, systemType, cardIndex) {
+    constructor(canvas, systemType, cardIndex, options = {}) {
         this.canvas = canvas;
         this.context = canvas.getContext('2d');
         this.systemType = systemType;
@@ -381,7 +491,36 @@ class PortalTextVisualizer {
         this.portalRotation = 0;
         this.portalPulse = 0;
 
+        this.inheritedTrait = null;
+        this.traitFlourish = null;
+        this.resizeObserver = null;
+        this.reactiveBurst = { active: false, start: 0, duration: 0, magnitude: 0, polarity: 1 };
+        this.activeGift = null;
+
+        this.profileKey = options.profileKey || null;
+        this.profile = this.resolveProfile(this.profileKey, systemType);
+        this.portalVariant = options.portalVariant || (this.profile && this.profile.portalVariant) || null;
+        this.portalSettings = (this.profile && this.profile.portal) || {};
+
+        this.basePalettes = {
+            quantum: { hue: 280, accent: 220 },
+            holographic: { hue: 330, accent: 190 },
+            faceted: { hue: 200, accent: 150 }
+        };
+
         this.init();
+    }
+
+    resolveProfile(profileKey, systemType) {
+        const library = window.ORTHOGONAL_REACTIVE_PROFILES || {};
+        if (profileKey && library[profileKey]) {
+            return { key: profileKey, ...library[profileKey] };
+        }
+        const matchKey = Object.keys(library).find((key) => library[key].system === systemType);
+        if (matchKey) {
+            return { key: matchKey, ...library[matchKey] };
+        }
+        return null;
     }
 
     init() {
@@ -395,13 +534,14 @@ class PortalTextVisualizer {
 
             this.canvas.width = rect.width * dpr;
             this.canvas.height = rect.height * dpr;
+            this.context.setTransform(1, 0, 0, 1, 0, 0);
             this.context.scale(dpr, dpr);
         };
 
         resizeCanvas();
 
-        const resizeObserver = new ResizeObserver(resizeCanvas);
-        resizeObserver.observe(this.canvas);
+        this.resizeObserver = new ResizeObserver(resizeCanvas);
+        this.resizeObserver.observe(this.canvas);
     }
 
     activate() {
@@ -443,13 +583,89 @@ class PortalTextVisualizer {
         }
     }
 
-    update() {
-        // Smooth portal depth transition
-        this.portalDepth += (this.targetDepth - this.portalDepth) * 0.08;
+    applyInheritedTrait(trait) {
+        if (!trait) return;
+        this.inheritedTrait = { ...trait };
+        this.activeGift = trait.gift || null;
+        this.traitFlourish = {
+            active: true,
+            start: performance.now(),
+            duration: 1200
+        };
+        this.targetDepth = Math.max(this.targetDepth, 0.9);
+    }
 
-        // Portal animation
+    applyReactiveImpulse(options = {}) {
+        const {
+            depthDelta = 0.18,
+            rotationDelta = 0.24,
+            pulse = 0.45,
+            polarity = 1,
+            duration = 900
+        } = options;
+
+        const signedDelta = depthDelta * (polarity >= 0 ? 1 : -0.6);
+        this.targetDepth = Math.min(1.35, Math.max(0.1, this.targetDepth + signedDelta));
+        this.portalRotation += rotationDelta * polarity;
+
+        this.reactiveBurst = {
+            active: true,
+            start: performance.now(),
+            duration,
+            magnitude: Math.abs(pulse),
+            polarity: polarity >= 0 ? 1 : -1
+        };
+    }
+
+    update() {
+        this.portalDepth += (this.targetDepth - this.portalDepth) * 0.08;
         this.portalRotation += 0.02;
         this.portalPulse = Math.sin(Date.now() * 0.003) * 0.5 + 0.5;
+
+        if (this.reactiveBurst && this.reactiveBurst.active) {
+            const progress = (performance.now() - this.reactiveBurst.start) / this.reactiveBurst.duration;
+            if (progress >= 1) {
+                this.reactiveBurst.active = false;
+            }
+        }
+
+        if (this.traitFlourish && this.traitFlourish.active) {
+            const progress = (performance.now() - this.traitFlourish.start) / this.traitFlourish.duration;
+            if (progress >= 1) {
+                this.traitFlourish.active = false;
+            }
+        }
+    }
+
+    getPalette() {
+        const palette = this.basePalettes[this.systemType] || this.basePalettes.faceted;
+        const hueOffset = (this.profile && this.profile.hueOffset) || 0;
+        const accentOffset = (this.profile && this.profile.accentOffset) || 0;
+        const trait = this.inheritedTrait || {};
+        return {
+            hue: this.normalizeHue(palette.hue + hueOffset + (trait.hueShift || 0)),
+            accent: this.normalizeHue((palette.accent + accentOffset) + (trait.accentShift || 0))
+        };
+    }
+
+    getTraitFlourishIntensity() {
+        if (!this.traitFlourish || !this.traitFlourish.active) return 0;
+        const progress = (performance.now() - this.traitFlourish.start) / this.traitFlourish.duration;
+        if (progress >= 1) {
+            this.traitFlourish.active = false;
+            return 0;
+        }
+        return Math.sin(progress * Math.PI);
+    }
+
+    getReactiveBurstIntensity() {
+        if (!this.reactiveBurst || !this.reactiveBurst.active) return 0;
+        const progress = (performance.now() - this.reactiveBurst.start) / this.reactiveBurst.duration;
+        if (progress >= 1) {
+            this.reactiveBurst.active = false;
+            return 0;
+        }
+        return Math.sin(progress * Math.PI) * this.reactiveBurst.magnitude * (this.reactiveBurst.polarity >= 0 ? 1 : 0.7);
     }
 
     renderPortal() {
@@ -457,80 +673,173 @@ class PortalTextVisualizer {
         const width = this.canvas.width / (window.devicePixelRatio || 1);
         const height = this.canvas.height / (window.devicePixelRatio || 1);
 
-        // Clear canvas
         ctx.clearRect(0, 0, width, height);
 
         if (this.portalDepth < 0.01) return;
 
         const centerX = width / 2;
         const centerY = height / 2;
-        const intensity = this.portalDepth;
+        const burst = this.getReactiveBurstIntensity();
+        const gift = this.activeGift || {};
+        let giftMoire = 0;
+        let giftGlitch = 0;
+        let giftPulse = 0;
+        switch (gift.resonance) {
+            case 'moire':
+                giftMoire = (gift.value || 0) * 0.4;
+                break;
+            case 'glow':
+            case 'facet':
+                giftPulse = (gift.value || 0) * 0.35;
+                giftMoire = (gift.value || 0) * 0.2;
+                break;
+            case 'density':
+                giftPulse = (gift.value || 0) * 0.25;
+                break;
+            case 'glitch':
+            case 'signal':
+                giftGlitch = (gift.value || 0) * 0.45;
+                break;
+        }
+        const intensity = this.portalDepth * (1 + burst * 0.35 + giftPulse * 0.3);
+        const palette = this.getPalette();
+        const trait = this.inheritedTrait || {};
+        const flourish = this.getTraitFlourishIntensity();
+        const moireBoost = (trait.moireBoost || 0) + burst * 0.25 + giftMoire;
+        const glitchBoost = (trait.glitchBoost || 0) + burst * 0.3 + giftGlitch;
 
-        // Render portal based on system type
         switch (this.systemType) {
             case 'quantum':
-                this.renderQuantumPortal(ctx, centerX, centerY, intensity);
+                this.renderQuantumPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish);
                 break;
             case 'holographic':
-                this.renderHolographicPortal(ctx, centerX, centerY, intensity);
+                this.renderHolographicPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish);
                 break;
             case 'faceted':
-                this.renderFacetedPortal(ctx, centerX, centerY, intensity);
+            default:
+                this.renderFacetedPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish);
                 break;
+        }
+
+        if (flourish > 0.01) {
+            this.renderTraitFlourish(ctx, centerX, centerY, intensity, palette, flourish);
         }
     }
 
-    renderQuantumPortal(ctx, centerX, centerY, intensity) {
-        const rings = 8;
-        const maxRadius = Math.min(centerX, centerY) * 0.8;
+    renderQuantumPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish) {
+        const ringMultiplier = (this.portalSettings.ringMultiplier || 1);
+        const burstMultiplier = (this.portalSettings.burst || 1);
+        const twist = (this.portalSettings.twist || 0);
+        const variant = this.portalVariant;
+
+        const rings = Math.max(6, Math.round((8 + Math.round((moireBoost + flourish) * 4)) * ringMultiplier));
+        const maxRadius = Math.min(centerX, centerY) * (0.75 + flourish * 0.2) * (variant === 'spiral' ? 1.1 : 1);
 
         for (let i = 0; i < rings; i++) {
             const progress = i / rings;
             const radius = maxRadius * (1 - progress) * intensity;
-            const alpha = intensity * (1 - progress) * this.portalPulse;
+            const alpha = intensity * (1 - progress) * (0.6 + flourish * 0.2) * burstMultiplier;
+            const hue = this.normalizeHue(palette.hue + progress * 16);
+            const offset = Math.sin(this.portalRotation * 2 + i + twist) * glitchBoost * 6 * burstMultiplier;
 
             if (alpha > 0.05) {
-                ctx.strokeStyle = `hsla(280, 70%, ${60 + progress * 20}%, ${alpha})`;
-                ctx.lineWidth = 2 + progress * 3;
-
+                ctx.save();
+                ctx.lineWidth = 2 + progress * 3 * burstMultiplier;
+                ctx.strokeStyle = `hsla(${hue}, 72%, ${60 + progress * 18}%, ${alpha})`;
                 ctx.beginPath();
-                ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+                ctx.arc(centerX, centerY, radius + offset, 0, Math.PI * 2);
                 ctx.stroke();
+                ctx.restore();
             }
         }
 
-        // Central quantum glow
-        const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, 50 * intensity);
-        gradient.addColorStop(0, `rgba(138, 43, 226, ${intensity * 0.5})`);
+        if (variant === 'spiral') {
+            ctx.save();
+            ctx.translate(centerX, centerY);
+            ctx.rotate(this.portalRotation * 1.4);
+            ctx.beginPath();
+            const spiralTurns = 5 + Math.round(glitchBoost * 6);
+            for (let angle = 0; angle < Math.PI * 2 * spiralTurns; angle += 0.2) {
+                const radius = (angle / (Math.PI * 2 * spiralTurns)) * maxRadius;
+                const x = Math.cos(angle) * radius;
+                const y = Math.sin(angle) * radius;
+                if (angle === 0) ctx.moveTo(x, y);
+                else ctx.lineTo(x, y);
+            }
+            ctx.strokeStyle = `hsla(${palette.accent}, 96%, 74%, ${0.28 + flourish * 0.25})`;
+            ctx.lineWidth = 1.5 + glitchBoost * 0.4;
+            ctx.stroke();
+            ctx.restore();
+        } else if (variant === 'axon') {
+            ctx.save();
+            ctx.translate(centerX, centerY);
+            const spokes = 10;
+            ctx.lineWidth = 1.2 + glitchBoost * 0.5;
+            ctx.strokeStyle = `hsla(${palette.accent}, 92%, 76%, ${0.22 + flourish * 0.3})`;
+            for (let i = 0; i < spokes; i++) {
+                const angle = (i / spokes) * Math.PI * 2 + this.portalRotation * 0.8;
+                ctx.beginPath();
+                ctx.moveTo(0, 0);
+                ctx.quadraticCurveTo(
+                    Math.cos(angle) * maxRadius * 0.4,
+                    Math.sin(angle) * maxRadius * 0.4,
+                    Math.cos(angle) * maxRadius,
+                    Math.sin(angle) * maxRadius
+                );
+                ctx.stroke();
+            }
+            ctx.restore();
+        }
+
+        const glowRadius = 60 * intensity * (1 + flourish * 0.4) * burstMultiplier;
+        const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, glowRadius);
+        gradient.addColorStop(0, `hsla(${palette.accent}, 95%, 72%, ${0.35 + flourish * 0.3})`);
         gradient.addColorStop(1, 'transparent');
 
         ctx.fillStyle = gradient;
         ctx.fillRect(0, 0, centerX * 2, centerY * 2);
     }
 
-    renderHolographicPortal(ctx, centerX, centerY, intensity) {
-        const layers = 6;
-        const maxRadius = Math.min(centerX, centerY) * 0.9;
+    renderHolographicPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish) {
+        const ringMultiplier = this.portalSettings.ringMultiplier || 1;
+        const burstMultiplier = this.portalSettings.burst || 1;
+        const twist = this.portalSettings.twist || 0;
+        const variant = this.portalVariant;
+
+        const layers = Math.max(5, Math.round((6 + (moireBoost + flourish) * 3) * ringMultiplier));
+        const maxRadius = Math.min(centerX, centerY) * (0.85 + flourish * 0.15) * (variant === 'filament' ? 1.12 : 1);
 
         ctx.save();
         ctx.translate(centerX, centerY);
-        ctx.rotate(this.portalRotation);
+        ctx.rotate(this.portalRotation * (1 + flourish * 0.5 + twist));
 
         for (let i = 0; i < layers; i++) {
             const progress = i / layers;
-            const radius = maxRadius * (1 - progress * 0.8) * intensity;
-            const alpha = intensity * (1 - progress) * 0.6;
+            const radius = maxRadius * (1 - progress * 0.65) * intensity;
+            const alpha = intensity * (1 - progress) * (0.5 + flourish * 0.2) * burstMultiplier;
+            const hue = this.normalizeHue(palette.hue + progress * 20);
+            const offsetX = Math.sin(this.portalRotation * 1.2 + progress * 6) * 18 * glitchBoost;
+            const offsetY = Math.cos(this.portalRotation * 1.1 + progress * 5) * 18 * glitchBoost;
 
-            ctx.strokeStyle = `hsla(${330 + i * 15}, 80%, 70%, ${alpha})`;
-            ctx.lineWidth = 1 + progress * 2;
+            ctx.strokeStyle = `hsla(${hue}, 90%, ${72 - progress * 18}%, ${alpha})`;
+            ctx.lineWidth = 1.2 + progress * 2 * burstMultiplier;
 
-            // Create holographic interference pattern
             const sides = 8 + i * 2;
             ctx.beginPath();
             for (let j = 0; j <= sides; j++) {
                 const angle = (j / sides) * Math.PI * 2;
-                const x = Math.cos(angle) * radius * (1 + Math.sin(angle * 3) * 0.1);
-                const y = Math.sin(angle) * radius * (1 + Math.cos(angle * 3) * 0.1);
+                const distortion = 1 + Math.sin(angle * 3 + this.portalRotation * 4 + twist) * (0.08 + glitchBoost * 0.05);
+                let x = Math.cos(angle) * radius * distortion;
+                let y = Math.sin(angle) * radius * distortion;
+
+                if (variant === 'filament') {
+                    const filament = Math.sin(angle * 6 + this.portalRotation * 5) * (0.12 + glitchBoost * 0.05);
+                    x += Math.cos(angle + Math.PI / 4) * radius * filament;
+                    y += Math.sin(angle + Math.PI / 4) * radius * filament;
+                } else if (variant === 'ribbon') {
+                    x += Math.sin(angle * 2 + this.portalRotation) * radius * 0.08;
+                    y += Math.cos(angle * 2 + this.portalRotation) * radius * 0.08;
+                }
 
                 if (j === 0) {
                     ctx.moveTo(x, y);
@@ -539,51 +848,584 @@ class PortalTextVisualizer {
                 }
             }
             ctx.stroke();
+
+            const shimmer = (0.2 * (1 - progress) + intensity * 0.05) * burstMultiplier;
+            ctx.setLineDash([6, 10]);
+            ctx.strokeStyle = `hsla(${this.normalizeHue(palette.accent + progress * 30)}, 95%, 75%, ${shimmer})`;
+            ctx.beginPath();
+            ctx.ellipse(
+                offsetX * 0.4,
+                offsetY * 0.4,
+                radius * 0.85,
+                radius * 0.85 * (variant === 'ribbon' ? 0.7 : 1),
+                -this.portalRotation * 0.6,
+                0,
+                Math.PI * 2
+            );
+            ctx.stroke();
+            ctx.setLineDash([]);
+        }
+
+        if (variant === 'filament') {
+            ctx.lineWidth = 1 + glitchBoost * 0.6;
+            ctx.strokeStyle = `hsla(${palette.accent}, 96%, 76%, ${0.28 + flourish * 0.2})`;
+            for (let i = 0; i < 6; i++) {
+                const angle = (i / 6) * Math.PI * 2 + this.portalRotation * 0.6;
+                ctx.beginPath();
+                ctx.moveTo(0, 0);
+                ctx.lineTo(
+                    Math.cos(angle) * maxRadius * 0.9,
+                    Math.sin(angle) * maxRadius * 0.9
+                );
+                ctx.stroke();
+            }
         }
 
         ctx.restore();
     }
 
-    renderFacetedPortal(ctx, centerX, centerY, intensity) {
-        const facets = 12;
-        const maxRadius = Math.min(centerX, centerY) * 0.7;
+    renderFacetedPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish) {
+        const facetMultiplier = this.portalSettings.ringMultiplier || 1;
+        const burstMultiplier = this.portalSettings.burst || 1;
+        const twist = this.portalSettings.twist || 0;
+        const variant = this.portalVariant;
+
+        const facets = Math.max(10, Math.round((10 + (moireBoost + flourish) * 4) * facetMultiplier));
+        const maxRadius = Math.min(centerX, centerY) * (0.7 + flourish * 0.2) * (variant === 'prism' ? 1.18 : 1);
 
         ctx.save();
         ctx.translate(centerX, centerY);
+        ctx.rotate(this.portalRotation * (0.8 + flourish * 0.4 + twist));
 
         for (let i = 0; i < facets; i++) {
-            const angle = (i / facets) * Math.PI * 2 + this.portalRotation;
-            const radius = maxRadius * intensity * (0.5 + this.portalPulse * 0.3);
+            const angle = (i / facets) * Math.PI * 2;
+            const radius = maxRadius * intensity * (0.5 + this.portalPulse * 0.3 + flourish * 0.2);
+            const hue = this.normalizeHue(palette.hue + i * 6);
 
-            ctx.strokeStyle = `hsla(200, 70%, 60%, ${intensity * 0.8})`;
-            ctx.fillStyle = `hsla(200, 70%, 60%, ${intensity * 0.2})`;
-            ctx.lineWidth = 2;
+            ctx.strokeStyle = `hsla(${hue}, 80%, 66%, ${0.6 + flourish * 0.2})`;
+            ctx.fillStyle = `hsla(${palette.accent}, 85%, 68%, ${0.18 + flourish * 0.1})`;
+            ctx.lineWidth = 1.8 + glitchBoost * 0.6 * burstMultiplier;
+
+            const outerRadius = radius * (1 + glitchBoost * 0.12);
+            const innerRadius = radius * (variant === 'prism' ? 1.08 : 1);
 
             ctx.beginPath();
             ctx.moveTo(0, 0);
             ctx.lineTo(
-                Math.cos(angle) * radius,
-                Math.sin(angle) * radius
+                Math.cos(angle) * outerRadius,
+                Math.sin(angle) * outerRadius
             );
             ctx.lineTo(
-                Math.cos(angle + Math.PI / facets) * radius,
-                Math.sin(angle + Math.PI / facets) * radius
+                Math.cos(angle + Math.PI / facets) * innerRadius,
+                Math.sin(angle + Math.PI / facets) * innerRadius
             );
             ctx.closePath();
 
             ctx.fill();
             ctx.stroke();
+
+            if (variant === 'prism') {
+                ctx.beginPath();
+                ctx.moveTo(
+                    Math.cos(angle) * innerRadius * 0.6,
+                    Math.sin(angle) * innerRadius * 0.6
+                );
+                ctx.lineTo(
+                    Math.cos(angle + Math.PI / facets) * innerRadius * 0.6,
+                    Math.sin(angle + Math.PI / facets) * innerRadius * 0.6
+                );
+                ctx.strokeStyle = `hsla(${palette.accent}, 92%, 74%, ${0.25 + flourish * 0.25})`;
+                ctx.stroke();
+            }
         }
 
         ctx.restore();
     }
+    renderTraitFlourish(ctx, centerX, centerY, intensity, palette, flourish) {
+        ctx.save();
+        ctx.translate(centerX, centerY);
+        ctx.rotate(this.portalRotation * 1.5);
+
+        const radius = Math.min(centerX, centerY) * (0.9 + flourish * 0.3) * intensity;
+        ctx.lineWidth = 2 + flourish * 3;
+        ctx.strokeStyle = `hsla(${palette.accent}, 100%, 75%, ${0.4 + flourish * 0.4})`;
+        ctx.beginPath();
+        ctx.arc(0, 0, radius, 0, Math.PI * 2);
+        ctx.stroke();
+
+        ctx.setLineDash([6, 12]);
+        ctx.strokeStyle = `hsla(${this.normalizeHue(palette.accent + 40)}, 100%, 70%, ${0.3 + flourish * 0.3})`;
+        ctx.beginPath();
+        ctx.arc(0, 0, radius * 0.7, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
+
+        ctx.restore();
+    }
+
+    normalizeHue(value) {
+        return ((value % 360) + 360) % 360;
+    }
 
     destroy() {
         this.stopRenderLoop();
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
         this.context = null;
+        this.inheritedTrait = null;
     }
 }
 
+class AmbientBackgroundField {
+    constructor(root) {
+        this.root = root || document.body;
+        this.resetTimer = null;
+    }
+
+    applyImpulse({ offsetX = 0, offsetY = 0, energy = 0.3, twist = 0 } = {}) {
+        if (!this.root) return;
+        const x = (offsetX || 0) * 60;
+        const y = (offsetY || 0) * 60;
+        const energyClamp = Math.max(0, Math.min(1.2, energy));
+
+        this.root.style.setProperty('--bg-parallax-x', `${x.toFixed(2)}px`);
+        this.root.style.setProperty('--bg-parallax-y', `${y.toFixed(2)}px`);
+        this.root.style.setProperty('--bg-scale', (1 + energyClamp * 0.18).toFixed(3));
+        this.root.style.setProperty('--bg-sheen', (0.28 + energyClamp * 0.45).toFixed(3));
+        this.root.style.setProperty('--bg-twist', `${(twist || 0) * 32}deg`);
+
+        clearTimeout(this.resetTimer);
+        this.resetTimer = setTimeout(() => this.reset(0.25), 760);
+    }
+
+    reset(energy = 0.18) {
+        if (!this.root) return;
+        this.root.style.setProperty('--bg-parallax-x', '0px');
+        this.root.style.setProperty('--bg-parallax-y', '0px');
+        this.root.style.setProperty('--bg-scale', (1 + energy * 0.1).toFixed(3));
+        this.root.style.setProperty('--bg-sheen', (0.26 + energy * 0.2).toFixed(3));
+        this.root.style.setProperty('--bg-twist', '0deg');
+    }
+
+    destroy() {
+        clearTimeout(this.resetTimer);
+        this.resetTimer = null;
+    }
+}
+
+class OrthogonalDepthReactivityOrchestrator {
+    constructor(progression, options = {}) {
+        this.progression = progression;
+        this.tiltSystem = options.tiltSystem || null;
+        this.entities = new Map();
+        this.cleanupHandlers = [];
+        this.activeCard = null;
+        this.pointerState = {
+            x: 0.5,
+            y: 0.5,
+            time: performance.now(),
+            velocityX: 0,
+            velocityY: 0
+        };
+
+        this.backgroundField = new AmbientBackgroundField(document.body);
+
+        this.handlePointerMove = this.handlePointerMove.bind(this);
+        this.handlePointerDown = this.handlePointerDown.bind(this);
+        this.handlePointerUp = this.handlePointerUp.bind(this);
+        this.handlePointerLeave = this.handlePointerLeave.bind(this);
+
+        this.init();
+    }
+
+    init() {
+        if (!this.progression) return;
+        this.syncEntities();
+        this.bindProgressionEvents();
+        this.bindPointerEvents();
+    }
+
+    syncEntities() {
+        if (!this.progression || !Array.isArray(this.progression.cards)) return;
+        this.progression.cards.forEach((card) => this.registerCard(card));
+        this.activeCard = this.progression.cards[this.progression.currentIndex] || null;
+    }
+
+    registerCard(card) {
+        if (!card) return;
+        const visualizer = this.progression.getVisualizerForCard(card);
+        const portalEl = card.querySelector('.portal-text-visualizer');
+        const portalVisualizer = portalEl ? portalEl.portalVisualizer : null;
+
+        this.entities.set(card, {
+            card,
+            visualizer: visualizer || null,
+            portal: portalVisualizer || null
+        });
+    }
+
+    getEntity(card) {
+        if (!card) return null;
+        if (!this.entities.has(card)) {
+            this.registerCard(card);
+        } else {
+            const entity = this.entities.get(card);
+            if (entity && !entity.visualizer) {
+                entity.visualizer = this.progression.getVisualizerForCard(card);
+            }
+            if (entity && !entity.portal) {
+                const portalEl = card.querySelector('.portal-text-visualizer');
+                entity.portal = portalEl ? portalEl.portalVisualizer : null;
+            }
+        }
+        return this.entities.get(card) || null;
+    }
+
+    bindProgressionEvents() {
+        this.cleanupHandlers.push(this.progression.on('card-state-changed', (detail) => this.handleCardState(detail)));
+        this.cleanupHandlers.push(this.progression.on('portal-activated', (detail) => this.handlePortalActivated(detail)));
+        this.cleanupHandlers.push(this.progression.on('portal-deactivated', (detail) => this.handlePortalDeactivated(detail)));
+        this.cleanupHandlers.push(this.progression.on('card-destroyed', (detail) => this.handleCardDestroyed(detail)));
+        this.cleanupHandlers.push(this.progression.on('trait-handshake', (detail) => this.handleTraitHandshake(detail)));
+        this.cleanupHandlers.push(this.progression.on('scroll-threshold', (detail) => this.handleScrollImpulse(detail)));
+        this.cleanupHandlers.push(this.progression.on('scroll-accumulating', (detail) => this.handleScrollAccumulation(detail)));
+    }
+
+    bindPointerEvents() {
+        window.addEventListener('pointermove', this.handlePointerMove, { passive: true });
+        window.addEventListener('pointerdown', this.handlePointerDown, { passive: true });
+        window.addEventListener('pointerup', this.handlePointerUp, { passive: true });
+        window.addEventListener('pointerleave', this.handlePointerLeave, { passive: true });
+    }
+
+    handleCardState(detail = {}) {
+        const { card, state } = detail;
+        if (!card) return;
+
+        const entity = this.getEntity(card);
+        if (state === 'focused') {
+            this.activeCard = card;
+            this.applyCardGlow(card, { intensity: 0.32, scale: 1.08, shiftY: -10 });
+            this.backgroundField.applyImpulse({ offsetX: 0, offsetY: -0.12, energy: 0.35, twist: 0 });
+        } else if (state === 'far-depth' || state === 'destroyed') {
+            this.resetCardGlow(card);
+        } else if (state === 'approaching' && entity) {
+            this.applyCardGlow(card, { intensity: 0.2, scale: 1.02, shiftY: -6 });
+        }
+    }
+
+    handlePortalActivated(detail = {}) {
+        const { card } = detail;
+        if (!card) return;
+        this.applyCardGlow(card, { intensity: 0.35, scale: 1.1, shiftY: -14 });
+    }
+
+    handlePortalDeactivated(detail = {}) {
+        const { card } = detail;
+        if (!card) return;
+        this.resetCardGlow(card);
+    }
+
+    handleCardDestroyed(detail = {}) {
+        const { card, trait } = detail;
+        if (!card) return;
+
+        const entity = this.getEntity(card);
+        if (entity) {
+            this.resetCardGlow(entity.card);
+        }
+
+        this.backgroundField.applyImpulse({ energy: 0.68, offsetX: 0.14, offsetY: 0.2, twist: 0.32 });
+
+        const partner = this.getPartnerCard(1);
+        if (partner && partner.portal && typeof partner.portal.applyReactiveImpulse === 'function') {
+            partner.portal.applyReactiveImpulse({ depthDelta: 0.36, rotationDelta: 0.48, pulse: 0.7, polarity: 1, duration: 1500 });
+        }
+
+        if (trait) {
+            this.handleTraitHandshake({ trait, to: partner ? partner.card : null, from: card });
+        }
+    }
+
+    handleTraitHandshake(detail = {}) {
+        const { trait, to: incomingCard, from: outgoingCard } = detail || {};
+        if (!trait) return;
+
+        const incoming = this.getEntity(incomingCard);
+        const outgoing = this.getEntity(outgoingCard);
+
+        if (incoming) {
+            if (incoming.visualizer && typeof incoming.visualizer.applyInheritedTrait === 'function') {
+                incoming.visualizer.applyInheritedTrait(trait, { immediate: false });
+            }
+            if (incoming.portal && typeof incoming.portal.applyInheritedTrait === 'function') {
+                incoming.portal.applyInheritedTrait(trait);
+            }
+            this.applyCardGlow(incoming.card, {
+                shiftX: 0,
+                shiftY: -18,
+                intensity: 0.34,
+                scale: 1.08
+            });
+        }
+
+        if (outgoing && outgoing.visualizer && typeof outgoing.visualizer.applyInteractionResponse === 'function') {
+            outgoing.visualizer.applyInteractionResponse({
+                intensity: 0.6,
+                polarity: -1,
+                hueSpin: -0.8,
+                densityBias: -0.4,
+                duration: 900
+            });
+        }
+
+        this.backgroundField.applyImpulse({
+            offsetX: 0,
+            offsetY: -0.22,
+            energy: 0.42,
+            twist: 0.35
+        });
+    }
+
+    handleScrollAccumulation(detail = {}) {
+        const accumulator = detail.accumulator || 0;
+        const magnitude = detail.magnitude || 0;
+        this.backgroundField.applyImpulse({
+            offsetX: Math.sign(accumulator) * 0.08 * magnitude,
+            offsetY: -0.04 * magnitude,
+            energy: 0.24 + magnitude * 0.25,
+            twist: accumulator * 0.0006
+        });
+    }
+
+    handleScrollImpulse(detail = {}) {
+        const direction = detail.direction || 1;
+        const magnitude = detail.magnitude || 0;
+        const polarity = direction >= 0 ? 1 : -1;
+
+        const active = this.getEntity(this.activeCard);
+        if (active && active.visualizer && typeof active.visualizer.applyInteractionResponse === 'function') {
+            active.visualizer.applyInteractionResponse({
+                intensity: 0.45 + magnitude * 0.65,
+                polarity,
+                hueSpin: polarity * 0.65,
+                densityBias: polarity > 0 ? -0.9 : 0.6,
+                geometryAdvance: polarity,
+                duration: 780
+            });
+        }
+
+        if (active && active.portal && typeof active.portal.applyReactiveImpulse === 'function') {
+            active.portal.applyReactiveImpulse({
+                depthDelta: 0.24 * magnitude,
+                rotationDelta: polarity * (0.25 + magnitude * 0.18),
+                pulse: 0.42 + magnitude * 0.4,
+                polarity,
+                duration: 1100
+            });
+        }
+
+        const partner = this.getPartnerCard(polarity);
+        if (partner && partner.visualizer && typeof partner.visualizer.applyInteractionResponse === 'function') {
+            partner.visualizer.applyInteractionResponse({
+                intensity: 0.28 + magnitude * 0.4,
+                polarity: -polarity,
+                hueSpin: polarity * -0.4,
+                densityBias: polarity > 0 ? 0.45 : -0.45,
+                duration: 680
+            });
+        }
+
+        if (active) {
+            this.applyCardGlow(active.card, {
+                shiftX: polarity * 18,
+                shiftY: -polarity * 24,
+                intensity: 0.36 + magnitude * 0.4,
+                scale: 1.08 + magnitude * 0.18
+            });
+        }
+
+        if (partner) {
+            this.applyCardGlow(partner.card, {
+                shiftX: -polarity * 12,
+                shiftY: polarity * 16,
+                intensity: 0.2 + magnitude * 0.25,
+                scale: 1.02 + magnitude * 0.12
+            });
+        }
+
+        this.backgroundField.applyImpulse({
+            offsetX: polarity * (0.18 + magnitude * 0.12),
+            offsetY: -polarity * (0.16 + magnitude * 0.1),
+            energy: 0.36 + magnitude * 0.55,
+            twist: polarity * (0.28 + magnitude * 0.2)
+        });
+    }
+
+    handlePointerMove(event) {
+        if (!this.activeCard) return;
+        const width = window.innerWidth || 1;
+        const height = window.innerHeight || 1;
+        const normalizedX = event.clientX / width;
+        const normalizedY = event.clientY / height;
+
+        const now = performance.now();
+        const dt = Math.max(0.016, (now - this.pointerState.time) / 1000);
+        const velocityX = (normalizedX - this.pointerState.x) / dt;
+        const velocityY = (normalizedY - this.pointerState.y) / dt;
+
+        this.pointerState = {
+            x: normalizedX,
+            y: normalizedY,
+            time: now,
+            velocityX,
+            velocityY
+        };
+
+        const entity = this.getEntity(this.activeCard);
+        if (!entity) return;
+
+        const offsetX = normalizedX - 0.5;
+        const offsetY = normalizedY - 0.5;
+        const displacement = Math.hypot(offsetX, offsetY);
+        const velocityMagnitude = Math.hypot(velocityX, velocityY);
+        const intensity = Math.min(1, displacement * 3 + velocityMagnitude * 0.12);
+        const polarity = velocityY >= 0 ? 1 : -1;
+
+        if (entity.visualizer && typeof entity.visualizer.applyInteractionResponse === 'function') {
+            entity.visualizer.applyInteractionResponse({
+                intensity: 0.35 + intensity * 0.6,
+                polarity,
+                hueSpin: offsetX * 0.9,
+                densityBias: -offsetY * 0.7,
+                duration: 720
+            });
+        }
+
+        if (entity.portal && typeof entity.portal.applyReactiveImpulse === 'function') {
+            entity.portal.applyReactiveImpulse({
+                depthDelta: intensity * 0.22,
+                rotationDelta: velocityX * 0.02,
+                pulse: 0.35 + intensity * 0.4,
+                polarity,
+                duration: 1050
+            });
+        }
+
+        const partner = this.getPartnerCard(polarity);
+        if (partner) {
+            this.applyCardGlow(partner.card, {
+                shiftX: -offsetX * 16,
+                shiftY: -offsetY * 14,
+                intensity: 0.18 + intensity * 0.3,
+                scale: 1.02 + intensity * 0.1
+            });
+            if (partner.visualizer && typeof partner.visualizer.applyInteractionResponse === 'function') {
+                partner.visualizer.applyInteractionResponse({
+                    intensity: 0.22 + intensity * 0.3,
+                    polarity: -polarity,
+                    hueSpin: offsetX * -0.5,
+                    densityBias: offsetY * 0.4,
+                    duration: 680
+                });
+            }
+        }
+
+        this.applyCardGlow(entity.card, {
+            shiftX: offsetX * 28,
+            shiftY: offsetY * 22,
+            intensity: 0.28 + intensity * 0.45,
+            scale: 1.05 + intensity * 0.18
+        });
+
+        this.backgroundField.applyImpulse({
+            offsetX: offsetX * 0.7,
+            offsetY: offsetY * 0.55,
+            energy: 0.3 + intensity * 0.5,
+            twist: velocityX * 0.03
+        });
+    }
+
+    handlePointerDown() {
+        const entity = this.getEntity(this.activeCard);
+        if (!entity) return;
+        if (entity.visualizer && typeof entity.visualizer.applyInteractionResponse === 'function') {
+            entity.visualizer.applyInteractionResponse({
+                intensity: 0.8,
+                polarity: 1,
+                hueSpin: 0.8,
+                geometryAdvance: 1,
+                duration: 960
+            });
+        }
+        if (entity.portal && typeof entity.portal.applyReactiveImpulse === 'function') {
+            entity.portal.applyReactiveImpulse({ depthDelta: 0.32, rotationDelta: 0.32, pulse: 0.6, polarity: 1, duration: 1300 });
+        }
+        this.backgroundField.applyImpulse({ offsetX: 0, offsetY: -0.2, energy: 0.65, twist: 0.25 });
+    }
+
+    handlePointerUp() {
+        const entity = this.getEntity(this.activeCard);
+        if (entity && entity.visualizer && typeof entity.visualizer.releaseInteraction === 'function') {
+            entity.visualizer.releaseInteraction();
+        }
+        this.backgroundField.reset(0.22);
+    }
+
+    handlePointerLeave() {
+        const entity = this.getEntity(this.activeCard);
+        if (entity) {
+            this.resetCardGlow(entity.card);
+            if (entity.visualizer && typeof entity.visualizer.releaseInteraction === 'function') {
+                entity.visualizer.releaseInteraction();
+            }
+        }
+        this.backgroundField.reset(0.2);
+    }
+
+    getPartnerCard(direction = 1) {
+        if (!this.progression) return null;
+        const targetIndex = this.progression.currentIndex + (direction >= 0 ? 1 : -1);
+        const card = this.progression.cards[targetIndex];
+        if (!card) return null;
+        return this.getEntity(card);
+    }
+
+    applyCardGlow(card, { shiftX = 0, shiftY = 0, intensity = 0.18, scale = 1.0 } = {}) {
+        if (!card) return;
+        card.style.setProperty('--card-glow-shift-x', `${shiftX.toFixed(2)}px`);
+        card.style.setProperty('--card-glow-shift-y', `${shiftY.toFixed(2)}px`);
+        card.style.setProperty('--card-glow-opacity', Math.min(0.85, intensity).toFixed(3));
+        card.style.setProperty('--card-glow-scale', Math.max(0.9, scale).toFixed(3));
+    }
+
+    resetCardGlow(card) {
+        if (!card) return;
+        card.style.setProperty('--card-glow-shift-x', '0px');
+        card.style.setProperty('--card-glow-shift-y', '0px');
+        card.style.setProperty('--card-glow-opacity', '0.18');
+        card.style.setProperty('--card-glow-scale', '1');
+    }
+
+    destroy() {
+        this.cleanupHandlers.forEach((dispose) => {
+            if (typeof dispose === 'function') dispose();
+        });
+        this.cleanupHandlers = [];
+
+        window.removeEventListener('pointermove', this.handlePointerMove);
+        window.removeEventListener('pointerdown', this.handlePointerDown);
+        window.removeEventListener('pointerup', this.handlePointerUp);
+        window.removeEventListener('pointerleave', this.handlePointerLeave);
+
+        this.backgroundField.destroy();
+        this.entities.clear();
+    }
+}
 // Export for global use
 window.OrthogonalDepthProgression = OrthogonalDepthProgression;
 window.PortalTextVisualizer = PortalTextVisualizer;
+window.OrthogonalDepthReactivityOrchestrator = OrthogonalDepthReactivityOrchestrator;
+window.AmbientBackgroundField = AmbientBackgroundField;

--- a/scripts/vib34d-geometric-tilt-system.js
+++ b/scripts/vib34d-geometric-tilt-system.js
@@ -5,6 +5,86 @@
  * A Paul Phillips Manifestation - Paul@clearseassolutions.com
  */
 
+const ORTHOGONAL_REACTIVE_PROFILES = {
+    'quantum-hyperglass': {
+        system: 'quantum',
+        hueOffset: 26,
+        accentOffset: -18,
+        baseSpeedScale: 1.12,
+        baseDensityShift: -0.12,
+        baseMoireShift: 0.18,
+        geometryCycle: ['hypercube', 'wave', 'lattice', 'klein'],
+        traitAmplify: { hue: 1.1, glitch: 1.2, energy: 1.05 },
+        transferGifts: [
+            { resonance: 'moire', value: 0.32 },
+            { resonance: 'density', value: -0.22 },
+            { resonance: 'glitch', value: 0.38 }
+        ],
+        portal: { ringMultiplier: 1.25, burst: 1.18, twist: 0.22 },
+        portalVariant: 'spiral'
+    },
+    'holo-ribbon-surge': {
+        system: 'holographic',
+        hueOffset: -12,
+        accentOffset: 34,
+        baseSpeedScale: 1.24,
+        baseDensityShift: -0.18,
+        baseMoireShift: 0.26,
+        geometryCycle: ['ribbon', 'torus', 'klein', 'shell'],
+        traitAmplify: { hue: 1.05, glitch: 1.28, energy: 1.18 },
+        transferGifts: [
+            { resonance: 'glow', value: 0.4 },
+            { resonance: 'moire', value: 0.38 },
+            { resonance: 'speed', value: 0.35 }
+        ],
+        portal: { ringMultiplier: 1.18, burst: 1.25, twist: 0.32 },
+        portalVariant: 'filament'
+    },
+    'faceted-orbital-forge': {
+        system: 'faceted',
+        hueOffset: 8,
+        accentOffset: 42,
+        baseSpeedScale: 1.08,
+        baseDensityShift: -0.08,
+        baseMoireShift: 0.2,
+        geometryCycle: ['polytope', 'orbital', 'lattice', 'strata'],
+        traitAmplify: { hue: 1.2, glitch: 1.1, energy: 1.15 },
+        transferGifts: [
+            { resonance: 'facet', value: 0.42 },
+            { resonance: 'density', value: -0.18 },
+            { resonance: 'glitch', value: 0.28 }
+        ],
+        portal: { ringMultiplier: 1.12, burst: 1.14, twist: 0.18 },
+        portalVariant: 'prism'
+    },
+    'neural-lumen-exchange': {
+        system: 'quantum',
+        hueOffset: -34,
+        accentOffset: -12,
+        baseSpeedScale: 1.3,
+        baseDensityShift: -0.16,
+        baseMoireShift: 0.22,
+        geometryCycle: ['crystal', 'wave', 'neuron', 'lattice'],
+        traitAmplify: { hue: 1.08, glitch: 1.22, energy: 1.25 },
+        transferGifts: [
+            { resonance: 'signal', value: 0.36 },
+            { resonance: 'moire', value: 0.34 },
+            { resonance: 'density', value: -0.2 }
+        ],
+        portal: { ringMultiplier: 1.28, burst: 1.3, twist: 0.28 },
+        portalVariant: 'axon'
+    }
+};
+
+if (!window.ORTHOGONAL_REACTIVE_PROFILES) {
+    window.ORTHOGONAL_REACTIVE_PROFILES = ORTHOGONAL_REACTIVE_PROFILES;
+} else {
+    window.ORTHOGONAL_REACTIVE_PROFILES = {
+        ...ORTHOGONAL_REACTIVE_PROFILES,
+        ...window.ORTHOGONAL_REACTIVE_PROFILES
+    };
+}
+
 class VIB34DGeometricTiltSystem {
     constructor() {
         this.isEnabled = false;
@@ -146,16 +226,24 @@ class VIB34DGeometricTiltSystem {
             const card = canvas.closest('[data-vib34d]');
             if (card) {
                 const systemType = card.dataset.vib34d;
-                this.createTiltVisualizer(canvas, systemType);
+                const profileKey = card.dataset.reactiveProfile || null;
+                const portalVariant = card.dataset.portalVariant || null;
+                const dataset = Object.assign({}, card.dataset);
+                this.createTiltVisualizer(canvas, systemType, {
+                    profileKey,
+                    portalVariant,
+                    cardDataset: dataset
+                });
             }
         });
 
         console.log(`🎨 Created ${this.visualizers.size} VIB34D tilt visualizers`);
     }
 
-    createTiltVisualizer(canvas, systemType) {
-        const visualizer = new VIB34DTiltVisualizer(canvas, systemType);
+    createTiltVisualizer(canvas, systemType, options = {}) {
+        const visualizer = new VIB34DTiltVisualizer(canvas, systemType, options);
         this.visualizers.set(canvas.id, visualizer);
+        canvas.vib34dVisualizer = visualizer;
     }
 
     updateVisualizers() {
@@ -235,14 +323,40 @@ class VIB34DGeometricTiltSystem {
  * Individual canvas visualizer that responds to geometric tilt
  */
 class VIB34DTiltVisualizer {
-    constructor(canvas, systemType) {
+    constructor(canvas, systemType, options = {}) {
         this.canvas = canvas;
         this.systemType = systemType;
         this.context = null;
+        this.resizeObserver = null;
         this.rotation4D = { rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 };
 
-        // VIB34D Parameters from Paul Phillips' system
-        this.parameters = this.getVIB34DParametersForSystem(systemType);
+        this.profileKey = options.profileKey || null;
+        this.profile = this.resolveProfile(systemType, this.profileKey);
+        this.presets = this.applyProfileToPreset(this.getSystemPreset(systemType), this.profile);
+        this.state = {
+            speed: this.presets.baseSpeed,
+            glitch: this.presets.baseGlitch,
+            density: this.presets.baseDensity,
+            moire: this.presets.baseMoire,
+            hue: this.presets.baseHue,
+            accentHue: this.presets.accentHue,
+            energy: 0.35,
+            geometryVariant: this.presets.geometryCycle[0]
+        };
+        this.targetState = { ...this.state };
+
+        this.variantIndex = 0;
+        this.traitIndex = 0;
+        this.transferCycleIndex = 0;
+        this.hasBeenFocused = false;
+
+        this.destruction = null;
+        this.traitFlourish = null;
+        this.interactionPulse = { active: false, start: 0, duration: 720, magnitude: 0 };
+        this.pulseStrength = 0;
+
+        this.lastTimestamp = performance.now();
+        this.time = 0;
 
         this.init();
     }
@@ -256,11 +370,10 @@ class VIB34DTiltVisualizer {
         this.context = this.canvas.getContext('2d');
         this.resizeCanvas();
 
-        // Resize observer
-        const resizeObserver = new ResizeObserver(() => {
+        this.resizeObserver = new ResizeObserver(() => {
             this.resizeCanvas();
         });
-        resizeObserver.observe(this.canvas);
+        this.resizeObserver.observe(this.canvas);
     }
 
     resizeCanvas() {
@@ -269,37 +382,138 @@ class VIB34DTiltVisualizer {
 
         this.canvas.width = rect.width * dpr;
         this.canvas.height = rect.height * dpr;
+
+        this.context.setTransform(1, 0, 0, 1, 0, 0);
         this.context.scale(dpr, dpr);
     }
 
-    getVIB34DParametersForSystem(systemType) {
-        const configs = {
+    getSystemPreset(systemType) {
+        const presets = {
             quantum: {
-                gridDensity: 20,
-                morphFactor: 1.5,
-                chaos: 0.3,
-                hue: 280,
-                intensity: 0.8,
-                geometry: 3
+                baseHue: 278,
+                accentHue: 210,
+                baseSpeed: 1.15,
+                baseGlitch: 0.35,
+                baseDensity: 0.95,
+                baseMoire: 0.35,
+                geometryCycle: ['hypercube', 'wave', 'crystal', 'lattice'],
+                trait: {
+                    hueShiftStep: 38,
+                    accentShiftStep: 24,
+                    moireBoost: 0.25,
+                    glitchBoost: 0.35,
+                    energyBoost: 0.3
+                }
             },
             holographic: {
-                gridDensity: 25,
-                morphFactor: 1.8,
-                chaos: 0.4,
-                hue: 330,
-                intensity: 0.9,
-                geometry: 7
+                baseHue: 330,
+                accentHue: 180,
+                baseSpeed: 1.25,
+                baseGlitch: 0.4,
+                baseDensity: 0.85,
+                baseMoire: 0.45,
+                geometryCycle: ['torus', 'klein', 'ribbon', 'shell'],
+                trait: {
+                    hueShiftStep: 28,
+                    accentShiftStep: 18,
+                    moireBoost: 0.22,
+                    glitchBoost: 0.32,
+                    energyBoost: 0.28
+                }
             },
             faceted: {
-                gridDensity: 15,
-                morphFactor: 1.0,
-                chaos: 0.2,
-                hue: 200,
-                intensity: 0.7,
-                geometry: 0
+                baseHue: 202,
+                accentHue: 150,
+                baseSpeed: 0.95,
+                baseGlitch: 0.25,
+                baseDensity: 1.05,
+                baseMoire: 0.28,
+                geometryCycle: ['prism', 'polytope', 'lattice'],
+                trait: {
+                    hueShiftStep: 32,
+                    accentShiftStep: 20,
+                    moireBoost: 0.18,
+                    glitchBoost: 0.28,
+                    energyBoost: 0.26
+                }
             }
         };
-        return configs[systemType] || configs.faceted;
+
+        return presets[systemType] || presets.faceted;
+    }
+
+    resolveProfile(systemType, profileKey) {
+        const library = window.ORTHOGONAL_REACTIVE_PROFILES || {};
+        if (profileKey && library[profileKey]) {
+            return { key: profileKey, ...library[profileKey] };
+        }
+
+        const matchKey = Object.keys(library).find((key) => library[key].system === systemType);
+        if (matchKey) {
+            return { key: matchKey, ...library[matchKey] };
+        }
+
+        return null;
+    }
+
+    applyProfileToPreset(preset, profile) {
+        if (!profile) {
+            return { ...preset };
+        }
+
+        const merged = {
+            ...preset,
+            trait: { ...preset.trait }
+        };
+
+        if (Array.isArray(profile.geometryCycle) && profile.geometryCycle.length) {
+            merged.geometryCycle = profile.geometryCycle.slice();
+        }
+
+        if (profile.hueOffset) {
+            merged.baseHue = this.normalizeHue(preset.baseHue + profile.hueOffset);
+        }
+
+        if (profile.accentOffset) {
+            merged.accentHue = this.normalizeHue((preset.accentHue || preset.baseHue) + profile.accentOffset);
+        }
+
+        if (profile.baseSpeedScale) {
+            merged.baseSpeed = preset.baseSpeed * profile.baseSpeedScale;
+        }
+
+        if (profile.baseDensityShift) {
+            merged.baseDensity = preset.baseDensity + profile.baseDensityShift;
+        }
+
+        if (profile.baseMoireShift) {
+            merged.baseMoire = preset.baseMoire + profile.baseMoireShift;
+        }
+
+        if (profile.traitAmplify) {
+            Object.keys(profile.traitAmplify).forEach((key) => {
+                switch (key) {
+                    case 'hue':
+                        merged.trait.hueShiftStep *= profile.traitAmplify[key];
+                        merged.trait.accentShiftStep *= profile.traitAmplify[key];
+                        break;
+                    case 'glitch':
+                        merged.trait.glitchBoost *= profile.traitAmplify[key];
+                        break;
+                    case 'energy':
+                        merged.trait.energyBoost *= profile.traitAmplify[key];
+                        break;
+                    case 'moire':
+                        merged.trait.moireBoost *= profile.traitAmplify[key];
+                        break;
+                    case 'density':
+                        merged.baseDensity += profile.traitAmplify[key];
+                        break;
+                }
+            });
+        }
+
+        return merged;
     }
 
     updateRotation4D(rotation4D) {
@@ -316,140 +530,735 @@ class VIB34DTiltVisualizer {
 
     renderVIB34DVisualization() {
         const ctx = this.context;
+        if (!ctx) return;
+
         const width = this.canvas.width / (window.devicePixelRatio || 1);
         const height = this.canvas.height / (window.devicePixelRatio || 1);
 
-        // Clear canvas
-        ctx.clearRect(0, 0, width, height);
+        const now = performance.now();
+        const delta = (now - this.lastTimestamp) / 1000;
+        this.lastTimestamp = now;
 
-        // Render tilt-responsive VIB34D visualization
-        this.renderTiltResponsiveGeometry(ctx, width, height);
+        this.updateDynamicState(delta);
+
+        ctx.clearRect(0, 0, width, height);
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+
+        this.renderTiltResponsiveGeometry(ctx, width, height, this.time);
+
+        if (this.traitFlourish && this.traitFlourish.active) {
+            this.renderTraitFlourish(ctx, width, height);
+        }
+
+        if (this.destruction && this.destruction.active) {
+            this.renderDestructionChoreography(ctx, width, height);
+        }
+
+        ctx.restore();
     }
 
-    renderTiltResponsiveGeometry(ctx, width, height) {
+    updateDynamicState(delta) {
+        const lerp = (current, target, factor) => current + (target - current) * factor;
+        const factor = Math.min(1, delta * 3.5);
+
+        this.state.speed = this.clamp(lerp(this.state.speed, this.targetState.speed, factor), 0.15, 4.0);
+        this.state.glitch = this.clamp(lerp(this.state.glitch, this.targetState.glitch, factor), 0, 2.5);
+        this.state.density = this.clamp(lerp(this.state.density, this.targetState.density, factor), 0.2, 1.8);
+        this.state.moire = this.clamp(lerp(this.state.moire, this.targetState.moire, factor), 0, 2.0);
+        this.state.hue = lerp(this.state.hue, this.targetState.hue, factor);
+        this.state.accentHue = lerp(this.state.accentHue, this.targetState.accentHue, factor);
+        this.state.energy = this.clamp(lerp(this.state.energy, this.targetState.energy, factor), 0, 2.0);
+        this.state.geometryVariant = this.targetState.geometryVariant;
+
+        this.time += delta * this.state.speed;
+
+        if (this.interactionPulse && this.interactionPulse.active) {
+            const elapsed = performance.now() - this.interactionPulse.start;
+            const progress = elapsed / this.interactionPulse.duration;
+            if (progress >= 1) {
+                this.interactionPulse.active = false;
+                this.pulseStrength = 0;
+            } else {
+                this.pulseStrength = Math.sin(progress * Math.PI) * this.interactionPulse.magnitude;
+            }
+        } else {
+            this.pulseStrength *= Math.max(0, 1 - delta * 1.5);
+        }
+
+        if (this.destruction && this.destruction.active) {
+            const progress = (performance.now() - this.destruction.start) / this.destruction.duration;
+            if (progress >= 1) {
+                this.destruction.active = false;
+            }
+        }
+
+        if (this.traitFlourish && this.traitFlourish.active) {
+            const progress = (performance.now() - this.traitFlourish.start) / this.traitFlourish.duration;
+            if (progress >= 1) {
+                this.traitFlourish.active = false;
+            }
+        }
+    }
+
+    applyInteractionResponse(options = {}) {
+        const {
+            intensity = 0.45,
+            polarity = 1,
+            hueSpin = 0,
+            densityBias = 0,
+            geometryAdvance = 0,
+            duration = 720
+        } = options;
+
+        const clamped = this.clamp(intensity, 0, 2.4);
+        const polaritySign = polarity >= 0 ? 1 : -1;
+
+        this.targetState.speed += clamped * 0.35;
+        this.targetState.glitch += clamped * 0.4;
+        this.targetState.energy += clamped * 0.5;
+        this.targetState.moire += clamped * 0.3 * polaritySign;
+
+        if (densityBias !== 0) {
+            this.targetState.density += clamped * densityBias * 0.25;
+        } else {
+            this.targetState.density += clamped * (polaritySign > 0 ? -0.18 : 0.18);
+        }
+
+        if (hueSpin) {
+            this.targetState.hue += hueSpin * 14;
+            this.targetState.accentHue += hueSpin * 9;
+        }
+
+        if (geometryAdvance !== 0 && this.presets.geometryCycle.length > 1) {
+            const advance = geometryAdvance > 0 ? 1 : -1;
+            const nextIndex = (this.variantIndex + advance + this.presets.geometryCycle.length) % this.presets.geometryCycle.length;
+            this.variantIndex = nextIndex;
+            this.targetState.geometryVariant = this.presets.geometryCycle[nextIndex];
+        }
+
+        this.interactionPulse = {
+            active: true,
+            start: performance.now(),
+            duration,
+            magnitude: Math.min(1.8, clamped * 0.9 + Math.abs(polarity) * 0.2)
+        };
+    }
+
+    releaseInteraction() {
+        this.interactionPulse = {
+            active: true,
+            start: performance.now(),
+            duration: 820,
+            magnitude: Math.max(0.18, this.pulseStrength * 0.6)
+        };
+
+        this.targetState.speed = Math.max(this.presets.baseSpeed, this.targetState.speed * 0.9);
+        this.targetState.glitch = Math.max(this.presets.baseGlitch * 0.6, this.targetState.glitch * 0.88);
+        this.targetState.moire = Math.max(this.presets.baseMoire * 0.5, this.targetState.moire * 0.9);
+        this.targetState.energy = Math.max(0.35, this.targetState.energy * 0.92);
+    }
+
+    setCardState(state, options = {}) {
+        const inheritedTrait = options.inheritedTrait;
+
+        if (inheritedTrait) {
+            this.applyInheritedTrait(inheritedTrait);
+        }
+
+        switch (state) {
+            case 'far-depth':
+                this.targetState.speed = this.presets.baseSpeed * 0.6;
+                this.targetState.glitch = this.presets.baseGlitch * 0.45;
+                this.targetState.density = this.presets.baseDensity * 1.25;
+                this.targetState.moire = this.presets.baseMoire * 0.4;
+                this.targetState.energy = 0.2;
+                break;
+            case 'approaching':
+                this.targetState.speed = this.presets.baseSpeed * 1.1;
+                this.targetState.glitch = this.presets.baseGlitch * 0.8;
+                this.targetState.density = this.presets.baseDensity * 0.85;
+                this.targetState.moire = this.presets.baseMoire * 0.7;
+                this.targetState.energy = 0.65;
+                break;
+            case 'focused':
+                this.targetState.speed = this.presets.baseSpeed * 1.75;
+                this.targetState.glitch = this.presets.baseGlitch * 1.4 + 0.2;
+                this.targetState.density = this.presets.baseDensity * 0.6;
+                this.targetState.moire = this.presets.baseMoire * 1.3 + 0.1;
+                this.targetState.energy = 1.05;
+
+                if (!inheritedTrait || !inheritedTrait.geometryVariant) {
+                    if (!this.hasBeenFocused) {
+                        this.hasBeenFocused = true;
+                        this.targetState.geometryVariant = this.presets.geometryCycle[this.variantIndex];
+                    } else {
+                        this.variantIndex = (this.variantIndex + 1) % this.presets.geometryCycle.length;
+                        this.targetState.geometryVariant = this.presets.geometryCycle[this.variantIndex];
+                    }
+                }
+                break;
+            case 'exiting':
+                this.targetState.speed = this.presets.baseSpeed * 1.35;
+                this.targetState.glitch = this.presets.baseGlitch * 1.1;
+                this.targetState.density = this.presets.baseDensity * 0.75;
+                this.targetState.moire = this.presets.baseMoire * 0.9;
+                this.targetState.energy = 0.5;
+                break;
+            case 'destroyed':
+                this.targetState.speed = this.presets.baseSpeed * 2.1;
+                this.targetState.glitch = this.presets.baseGlitch * 1.9 + 0.4;
+                this.targetState.density = this.presets.baseDensity * 0.35;
+                this.targetState.moire = this.presets.baseMoire * 1.6 + 0.2;
+                this.targetState.energy = 1.2;
+                break;
+        }
+    }
+
+    applyInheritedTrait(trait, options = {}) {
+        if (!trait) return;
+
+        const immediate = options.immediate || false;
+
+        if (typeof trait.hueShift === 'number') {
+            this.targetState.hue = this.presets.baseHue + trait.hueShift;
+        }
+
+        if (typeof trait.accentShift === 'number') {
+            this.targetState.accentHue = this.presets.accentHue + trait.accentShift;
+        }
+
+        if (typeof trait.moireBoost === 'number') {
+            this.targetState.moire += trait.moireBoost;
+        }
+
+        if (typeof trait.glitchBoost === 'number') {
+            this.targetState.glitch += trait.glitchBoost;
+        }
+
+        if (typeof trait.energyBoost === 'number') {
+            this.targetState.energy += trait.energyBoost;
+        }
+
+        if (typeof trait.densityShift === 'number') {
+            this.targetState.density += trait.densityShift;
+        }
+
+        if (typeof trait.speedBoost === 'number') {
+            this.targetState.speed += trait.speedBoost;
+        }
+
+        if (trait.gift && trait.gift.resonance) {
+            switch (trait.gift.resonance) {
+                case 'glow':
+                case 'facet':
+                    this.targetState.moire += (trait.gift.value || 0) * 0.45;
+                    this.targetState.energy += (trait.gift.value || 0) * 0.35;
+                    break;
+                case 'signal':
+                    this.targetState.glitch += (trait.gift.value || 0) * 0.5;
+                    this.targetState.moire += (trait.gift.value || 0) * 0.25;
+                    break;
+                case 'density':
+                    this.targetState.density += trait.gift.value || 0;
+                    break;
+                case 'speed':
+                    this.targetState.speed += (trait.gift.value || 0) * 0.5;
+                    break;
+                default:
+                    this.targetState.moire += (trait.gift.value || 0) * 0.4;
+                    break;
+            }
+        }
+
+        if (trait.geometryVariant) {
+            this.targetState.geometryVariant = trait.geometryVariant;
+            const index = this.presets.geometryCycle.indexOf(trait.geometryVariant);
+            if (index >= 0) {
+                this.variantIndex = index;
+            }
+        }
+
+        this.traitFlourish = {
+            active: true,
+            start: performance.now(),
+            duration: 1200,
+            trait
+        };
+
+        if (immediate) {
+            Object.keys(this.targetState).forEach((key) => {
+                this.state[key] = this.targetState[key];
+            });
+        }
+    }
+
+    generateDestructionTrait() {
+        const cycleLength = this.presets.geometryCycle.length;
+        const geometryVariant = this.presets.geometryCycle[(this.traitIndex + 1) % cycleLength];
+
+        const trait = {
+            geometryVariant,
+            hueShift: this.presets.trait.hueShiftStep * (this.traitIndex + 1),
+            accentShift: this.presets.trait.accentShiftStep * (this.traitIndex + 1),
+            moireBoost: this.presets.trait.moireBoost + 0.08 * this.traitIndex,
+            glitchBoost: this.presets.trait.glitchBoost + 0.07 * this.traitIndex,
+            energyBoost: this.presets.trait.energyBoost + 0.05 * this.traitIndex
+        };
+
+        const giftCycle = this.profile && Array.isArray(this.profile.transferGifts)
+            ? this.profile.transferGifts
+            : [];
+
+        if (giftCycle.length > 0) {
+            const gift = giftCycle[this.transferCycleIndex % giftCycle.length];
+            trait.gift = { ...gift };
+            this.transferCycleIndex = (this.transferCycleIndex + 1) % giftCycle.length;
+
+            switch (gift.resonance) {
+                case 'density':
+                    trait.densityShift = gift.value;
+                    break;
+                case 'glow':
+                case 'facet':
+                case 'signal':
+                    trait.energyBoost += gift.value * 0.6;
+                    break;
+                case 'speed':
+                    trait.speedBoost = gift.value;
+                    break;
+                default:
+                    trait.moireBoost += gift.value * 0.4;
+                    break;
+            }
+        }
+
+        this.traitIndex = (this.traitIndex + 1) % cycleLength;
+
+        return trait;
+    }
+
+    triggerDestructionSequence() {
+        const trait = this.generateDestructionTrait();
+
+        this.destruction = {
+            active: true,
+            start: performance.now(),
+            duration: 1400,
+            trait
+        };
+
+        this.targetState.hue = this.presets.baseHue + trait.hueShift;
+        this.targetState.accentHue = this.presets.accentHue + trait.accentShift;
+        this.targetState.glitch += trait.glitchBoost * 0.5;
+        this.targetState.moire += trait.moireBoost * 0.5;
+        this.targetState.energy += trait.energyBoost * 0.5;
+        if (typeof trait.densityShift === 'number') {
+            this.targetState.density += trait.densityShift * 0.5;
+        }
+        if (typeof trait.speedBoost === 'number') {
+            this.targetState.speed += trait.speedBoost * 0.4;
+        }
+
+        return trait;
+    }
+
+    renderTiltResponsiveGeometry(ctx, width, height, time) {
         const centerX = width / 2;
         const centerY = height / 2;
-        const time = Date.now() * 0.001;
 
-        // Use 4D rotation for geometric transformation
         const rotX = this.rotation4D.rot4dXW;
         const rotY = this.rotation4D.rot4dYW;
         const rotZ = this.rotation4D.rot4dZW;
 
-        // Create geometric patterns based on system type and tilt
+        const hue = this.state.hue;
+        const accentHue = this.state.accentHue;
+        const energy = this.state.energy * (1 + this.pulseStrength * 0.55);
+        const glitch = this.state.glitch * (1 + this.pulseStrength * 0.35);
+        const density = this.state.density * (1 - this.pulseStrength * 0.22);
+        const moire = this.state.moire * (1 + this.pulseStrength * 0.4);
+
+        const state = {
+            hue,
+            accentHue,
+            energy,
+            glitch,
+            density,
+            variant: this.state.geometryVariant,
+            moire
+        };
+
         switch (this.systemType) {
             case 'quantum':
-                this.renderQuantumTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time);
+                this.renderQuantumTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state);
                 break;
             case 'holographic':
-                this.renderHolographicTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time);
+                this.renderHolographicTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state);
                 break;
             case 'faceted':
-                this.renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time);
-                break;
             default:
-                this.renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time);
+                this.renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state);
+                break;
         }
+
+        this.renderMoireOverlay(ctx, centerX, centerY, state.moire, state.hue, state.accentHue, state.energy, time);
     }
 
-    renderQuantumTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time) {
-        const gridSize = 40 - this.parameters.gridDensity;
-        const intensity = this.parameters.intensity;
+    renderQuantumTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state) {
+        const baseSpacing = 38;
+        const clampedDensity = this.clamp(state.density, 0.2, 1.8);
+        const spacing = baseSpacing * (1 + (1 - clampedDensity) * 2.6);
+        const extent = 220 + state.energy * 140;
+        const hue = this.normalizeHue(state.hue);
+        const accentHue = this.normalizeHue(state.accentHue);
+        const glitch = state.glitch;
+        const energy = state.energy;
+        const rawDensity = state.density;
+        const variant = state.variant;
 
-        ctx.strokeStyle = `hsla(${this.parameters.hue}, 70%, 60%, ${intensity * 0.6})`;
-        ctx.lineWidth = 1 + intensity;
+        ctx.lineWidth = 1.2 + energy * 0.5;
 
-        for (let x = -200; x < 200; x += gridSize) {
-            for (let y = -200; y < 200; y += gridSize) {
-                const px = centerX + x * (1 + rotY * 0.5);
-                const py = centerY + y * (1 + rotX * 0.5);
+        for (let x = -extent; x <= extent; x += spacing) {
+            for (let y = -extent; y <= extent; y += spacing) {
+                const baseX = x * (1 + rotY * 0.35);
+                const baseY = y * (1 + rotX * 0.35);
+
+                let jitterX = Math.sin(time * 4 + y * 0.06) * glitch * 8;
+                let jitterY = Math.cos(time * 4 + x * 0.06) * glitch * 8;
+
+                if (variant === 'wave') {
+                    jitterX += Math.sin(time * 3 + y * 0.09) * 12 * energy;
+                } else if (variant === 'crystal') {
+                    jitterY += Math.cos(time * 3 + x * 0.09) * 12 * energy;
+                } else if (variant === 'lattice') {
+                    jitterX += Math.sin((x + time * 30) * 0.02) * 6;
+                    jitterY += Math.cos((y - time * 30) * 0.02) * 6;
+                } else if (variant === 'klein') {
+                    const knot = Math.sin(time * 2 + (x - y) * 0.015);
+                    jitterX += knot * 16 * energy;
+                    jitterY += Math.cos(time * 2.2 + (x + y) * 0.015) * 14 * energy;
+                } else if (variant === 'neuron') {
+                    const pulse = Math.sin(time * 4 + (x + y) * 0.01) * 0.5 + 0.5;
+                    jitterX += Math.sin(time * 6 + y * 0.05) * 18 * pulse;
+                    jitterY += Math.cos(time * 5 + x * 0.05) * 18 * (1 - pulse);
+                } else if (variant === 'orbital') {
+                    const spin = time * 1.5 + (x + y) * 0.002;
+                    jitterX += Math.cos(spin) * 14 * energy;
+                    jitterY += Math.sin(spin) * 14 * energy;
+                } else if (variant === 'strata') {
+                    jitterY += Math.sign(Math.sin(y * 0.04 + time * 3)) * 10 * (1 - rawDensity);
+                }
+
+                const px = centerX + baseX + jitterX;
+                const py = centerY + baseY + jitterY;
 
                 const distance = Math.hypot(px - centerX, py - centerY);
-                const wave = Math.sin(distance * 0.02 + time + rotZ * 2) * 0.5 + 0.5;
-                const alpha = (1 - distance / 300) * wave * intensity;
+                const normalized = Math.max(0, 1 - distance / (extent * 1.2));
+                if (normalized <= 0.01) continue;
 
-                if (alpha > 0.1) {
-                    ctx.globalAlpha = alpha;
+                const wave = (Math.sin(distance * 0.016 + time * 3 + rotZ * 2) + 1) * 0.5;
+                const alpha = Math.pow(normalized, 1.4) * (0.25 + energy * 0.5) * (0.6 + wave * 0.5);
+
+                ctx.strokeStyle = `hsla(${hue}, 72%, ${55 + wave * 18}%, ${alpha})`;
+                ctx.beginPath();
+                ctx.arc(px, py, 2 + wave * 4 + glitch * 1.2, 0, Math.PI * 2);
+                ctx.stroke();
+
+                if (variant === 'crystal' && wave > 0.65) {
+                    ctx.strokeStyle = `hsla(${accentHue}, 88%, 70%, ${alpha * 0.65})`;
                     ctx.beginPath();
-                    ctx.arc(px, py, 2 + wave * 3, 0, Math.PI * 2);
+                    ctx.moveTo(px, py);
+                    ctx.lineTo(
+                        centerX + Math.cos(time + x * 0.015) * distance * 0.25,
+                        centerY + Math.sin(time + y * 0.015) * distance * 0.25
+                    );
                     ctx.stroke();
                 }
             }
         }
 
-        ctx.globalAlpha = 1;
     }
 
-    renderHolographicTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time) {
-        const layers = 5;
-        const intensity = this.parameters.intensity;
+    renderHolographicTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state) {
+        const layers = 6 + Math.floor(state.energy * 3.2);
+        const hue = this.normalizeHue(state.hue);
+        const accentHue = this.normalizeHue(state.accentHue);
+        const glitch = state.glitch;
+        const energy = state.energy;
+        const density = state.density;
+        const variant = state.variant;
 
         for (let i = 0; i < layers; i++) {
-            const radius = 50 + i * 30;
-            const alpha = intensity * (1 - i / layers);
+            const progress = i / layers;
+            let radius = 55 + i * 32 * (1 + (1 - density) * 0.4);
+            let rotation = time * (0.45 + progress * 0.5) + rotZ * 1.2;
+            let offsetX = Math.sin(time * 1.2 + progress * 6) * 18 * glitch;
+            let offsetY = Math.cos(time * 1.1 + progress * 5) * 18 * glitch;
 
-            ctx.strokeStyle = `hsla(${this.parameters.hue + i * 20}, 80%, 70%, ${alpha})`;
-            ctx.lineWidth = 2;
+            if (variant === 'klein') {
+                rotation += Math.sin(time + progress * 2) * 0.8;
+            } else if (variant === 'ribbon') {
+                offsetX += Math.sin(time * 2 + progress * 8) * 36 * energy;
+                offsetY += Math.cos(time * 2 + progress * 8) * 30 * energy;
+            } else if (variant === 'shell') {
+                radius *= 1 + progress * 0.5;
+            } else if (variant === 'torus') {
+                radius *= 1 + Math.sin(time + progress * 3) * 0.12;
+            }
 
-            const offsetX = Math.sin(rotY + time) * 20;
-            const offsetY = Math.cos(rotX + time) * 20;
+            const lineAlpha = 0.55 * (1 - progress) + energy * 0.1;
+            ctx.strokeStyle = `hsla(${(hue + progress * 25) % 360}, 88%, ${70 - progress * 18}%, ${lineAlpha})`;
+            ctx.lineWidth = 1.2 + energy * 0.4;
 
             ctx.beginPath();
             ctx.ellipse(
                 centerX + offsetX,
                 centerY + offsetY,
-                radius * (1 + rotX * 0.2),
-                radius * (1 + rotY * 0.2),
-                rotZ + time,
+                radius * (1 + rotX * 0.25 + energy * 0.1),
+                radius * (1 + rotY * 0.25 + energy * 0.1),
+                rotation,
                 0,
                 Math.PI * 2
             );
             ctx.stroke();
+
+            const shimmer = 0.2 * (1 - progress) + energy * 0.05;
+            ctx.setLineDash([6, 10]);
+            ctx.strokeStyle = `hsla(${accentHue + progress * 30}, 95%, 75%, ${shimmer})`;
+            ctx.beginPath();
+            ctx.ellipse(
+                centerX + offsetX * 0.6,
+                centerY + offsetY * 0.6,
+                radius * 0.85,
+                radius * 0.85 * (variant === 'ribbon' ? 0.7 : 1),
+                -rotation * 0.6,
+                0,
+                Math.PI * 2
+            );
+            ctx.stroke();
+            ctx.setLineDash([]);
         }
+
     }
 
-    renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time) {
-        const sides = 6;
-        const radius = 80;
-        const intensity = this.parameters.intensity;
+    renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state) {
+        const hue = this.normalizeHue(state.hue);
+        const accentHue = this.normalizeHue(state.accentHue);
+        const glitch = state.glitch;
+        const energy = state.energy;
+        const variant = state.variant;
 
-        ctx.strokeStyle = `hsla(${this.parameters.hue}, 70%, 60%, ${intensity})`;
-        ctx.fillStyle = `hsla(${this.parameters.hue}, 70%, 60%, ${intensity * 0.3})`;
-        ctx.lineWidth = 2;
+        let sides = 6;
+        if (variant === 'polytope') {
+            sides = 8;
+        } else if (variant === 'lattice') {
+            sides = 12;
+        } else if (variant === 'orbital') {
+            sides = 10;
+        } else if (variant === 'strata') {
+            sides = 14;
+        }
 
-        const angle = rotZ + time * 0.5;
-        const scaleX = 1 + rotY * 0.3;
-        const scaleY = 1 + rotX * 0.3;
+        const radius = 70 + energy * 40;
 
         ctx.save();
         ctx.translate(centerX, centerY);
-        ctx.scale(scaleX, scaleY);
-        ctx.rotate(angle);
+        const rotationSpeed = variant === 'orbital' ? 1.05 : 0.6;
+        ctx.rotate(time * rotationSpeed + rotZ);
+        const scaleX = 1 + rotY * 0.35 + energy * 0.12;
+        const scaleY = 1 + rotX * 0.35 + energy * 0.12;
+        ctx.scale(
+            variant === 'strata' ? scaleX * 1.2 : scaleX,
+            variant === 'strata' ? scaleY * 0.85 : scaleY
+        );
 
         ctx.beginPath();
         for (let i = 0; i <= sides; i++) {
-            const a = (i / sides) * Math.PI * 2;
-            const x = Math.cos(a) * radius;
-            const y = Math.sin(a) * radius;
+            const angle = (i / sides) * Math.PI * 2;
+            let r = radius;
 
-            if (i === 0) {
-                ctx.moveTo(x, y);
-            } else {
-                ctx.lineTo(x, y);
+            if (variant === 'lattice') {
+                r += Math.sin(time * 3 + angle * 4) * 14 * glitch;
+            } else if (variant === 'polytope') {
+                r += Math.cos(time * 2 + angle * 3) * 18 * energy;
+            } else if (variant === 'orbital') {
+                r += Math.sin(time * 1.5 + angle * 2) * 12 * energy;
+            } else if (variant === 'strata') {
+                r += Math.sign(Math.sin(angle * 4 + time * 3)) * 10 * (1 - density);
             }
+
+            const x = Math.cos(angle) * r;
+            const y = Math.sin(angle) * r;
+
+            if (i === 0) ctx.moveTo(x, y);
+            else ctx.lineTo(x, y);
         }
+        ctx.closePath();
+
+        ctx.fillStyle = `hsla(${hue}, 65%, ${45 + energy * 18}%, ${0.2 + energy * 0.25})`;
+        ctx.strokeStyle = `hsla(${hue}, 72%, 60%, ${0.75 + energy * 0.18})`;
+        ctx.lineWidth = 2 + glitch * 0.8;
         ctx.fill();
         ctx.stroke();
+
+        ctx.strokeStyle = `hsla(${accentHue}, 95%, 72%, ${0.35 + glitch * 0.1})`;
+        for (let i = 0; i < sides; i++) {
+            const angle = (i / sides) * Math.PI * 2;
+            ctx.beginPath();
+            ctx.moveTo(0, 0);
+            ctx.lineTo(
+                Math.cos(angle) * radius * 1.2,
+                Math.sin(angle) * radius * 1.2
+            );
+            ctx.stroke();
+
+            if (variant === 'orbital') {
+                ctx.beginPath();
+                ctx.arc(0, 0, radius * 0.55, angle, angle + Math.PI / sides * 0.6);
+                ctx.strokeStyle = `hsla(${accentHue}, 88%, 74%, ${0.25 + energy * 0.25})`;
+                ctx.stroke();
+            } else if (variant === 'strata') {
+                ctx.beginPath();
+                ctx.moveTo(-radius * 1.1, Math.sin(angle) * radius * 0.3);
+                ctx.lineTo(radius * 1.1, Math.sin(angle) * radius * 0.3);
+                ctx.strokeStyle = `hsla(${hue}, 62%, 58%, ${0.2 + (1 - density) * 0.25})`;
+                ctx.stroke();
+            }
+        }
+
+        ctx.restore();
+
+    }
+
+    renderMoireOverlay(ctx, centerX, centerY, moire, hue, accentHue, energy, time) {
+        const intensity = Math.max(0, moire - 0.05);
+        if (intensity <= 0.01) return;
+
+        const layers = 3 + Math.floor(intensity * 2.5);
+
+        for (let i = 0; i < layers; i++) {
+            const radius = (i + 1) * 30 * (1 + energy * 0.35);
+            const alpha = (0.08 + intensity * 0.12) * (1 - i / layers);
+            const angle = time * (0.5 + intensity * 0.4) + i * 0.6;
+
+            ctx.save();
+            ctx.translate(centerX, centerY);
+            ctx.rotate(angle);
+
+            ctx.strokeStyle = `hsla(${(accentHue + i * 14) % 360}, 92%, 68%, ${alpha})`;
+            ctx.lineWidth = 1 + intensity * 0.4;
+
+            ctx.beginPath();
+            ctx.ellipse(
+                0,
+                0,
+                radius * (1 + Math.sin(time + i) * 0.12 * energy),
+                radius * (1 + Math.cos(time + i * 0.8) * 0.12 * energy),
+                0,
+                0,
+                Math.PI * 2
+            );
+            ctx.stroke();
+
+            ctx.restore();
+        }
+    }
+
+    renderTraitFlourish(ctx, width, height) {
+        if (!this.traitFlourish) return;
+
+        const now = performance.now();
+        const progress = (now - this.traitFlourish.start) / this.traitFlourish.duration;
+        if (progress >= 1) {
+            this.traitFlourish.active = false;
+            return;
+        }
+
+        const intensity = Math.sin(progress * Math.PI);
+        const hue = this.normalizeHue(this.targetState.accentHue + 24);
+
+        ctx.save();
+        ctx.translate(width / 2, height / 2);
+        ctx.rotate(progress * Math.PI * 2);
+
+        const radius = (width + height) * 0.12 * (0.6 + intensity);
+
+        ctx.lineWidth = 2 + intensity * 3;
+        ctx.strokeStyle = `hsla(${hue}, 96%, 75%, ${0.55 * (1 - progress)})`;
+        ctx.beginPath();
+        ctx.arc(0, 0, radius, 0, Math.PI * 2);
+        ctx.stroke();
+
+        ctx.setLineDash([4, 10]);
+        ctx.strokeStyle = `hsla(${(hue + 40) % 360}, 98%, 72%, ${0.35 * (1 - progress)})`;
+        ctx.beginPath();
+        ctx.arc(0, 0, radius * 1.35, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
 
         ctx.restore();
     }
 
+    renderDestructionChoreography(ctx, width, height) {
+        if (!this.destruction) return;
+
+        const now = performance.now();
+        const progress = (now - this.destruction.start) / this.destruction.duration;
+        if (progress >= 1) {
+            this.destruction.active = false;
+            return;
+        }
+
+        const fade = 1 - progress;
+        const hue = this.normalizeHue(this.targetState.hue + 18);
+        const accentHue = this.normalizeHue(this.targetState.accentHue);
+        const radiusBase = Math.max(width, height) * 0.18;
+        const radius = radiusBase + progress * Math.max(width, height) * 0.35;
+
+        ctx.save();
+        ctx.translate(width / 2, height / 2);
+        ctx.globalCompositeOperation = 'screen';
+
+        const gradient = ctx.createRadialGradient(0, 0, radius * 0.1, 0, 0, radius);
+        gradient.addColorStop(0, `hsla(${accentHue}, 100%, 76%, ${0.45 * fade})`);
+        gradient.addColorStop(0.5, `hsla(${hue}, 100%, 66%, ${0.35 * fade})`);
+        gradient.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = gradient;
+        ctx.beginPath();
+        ctx.arc(0, 0, radius, 0, Math.PI * 2);
+        ctx.fill();
+
+        const shards = 18;
+        for (let i = 0; i < shards; i++) {
+            const angle = (i / shards) * Math.PI * 2 + progress * Math.PI * 1.5;
+            const shardLength = radius * (0.55 + 0.3 * Math.sin(progress * 6 + i));
+            ctx.strokeStyle = `hsla(${(hue + i * 12) % 360}, 100%, 70%, ${0.6 * fade})`;
+            ctx.lineWidth = 1.5 + this.state.glitch * 0.4;
+            ctx.beginPath();
+            ctx.moveTo(Math.cos(angle) * radius * 0.35, Math.sin(angle) * radius * 0.35);
+            ctx.lineTo(Math.cos(angle) * shardLength, Math.sin(angle) * shardLength);
+            ctx.stroke();
+        }
+
+        ctx.restore();
+    }
+
+    clamp(value, min, max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    normalizeHue(value) {
+        return ((value % 360) + 360) % 360;
+    }
+
     destroy() {
-        // Clean up resources
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
         this.context = null;
     }
 }
-
 // Export for global use
 window.VIB34DGeometricTiltSystem = VIB34DGeometricTiltSystem;
 window.VIB34DTiltVisualizer = VIB34DTiltVisualizer;


### PR DESCRIPTION
## Summary
- define profile-aware tilt and portal presets so each card exposes unique geometry cycles and transferable gifts
- orchestrate trait handshakes between cards, priming incoming visualizers and coordinating dual-entity responses in the progression orchestrator
- document phase-two progress and tag the progression markup with reactive profile metadata for the new choreography

## Testing
- node --check scripts/orthogonal-depth-progression.js
- node --check scripts/vib34d-geometric-tilt-system.js

------
https://chatgpt.com/codex/tasks/task_e_68d71581991883298eff97480598f0ca