### PR TITLE
Enhance orthogonal progression visuals with multi-layer choreography

### DIFF
--- a/25-orthogonal-depth-progression.html
+++ b/25-orthogonal-depth-progression.html
@@ -31,6 +31,13 @@
             --holographic-pink: #ff1493;
             --void-black: #0a0a0a;
             --depth-perspective: 1200px;
+
+            /* Ambient reactivity channels */
+            --bg-parallax-x: 0px;
+            --bg-parallax-y: 0px;
+            --bg-scale: 1;
+            --bg-sheen: 0.32;
+            --bg-twist: 0deg;
         }
 
         body {
@@ -41,6 +48,24 @@
             height: 100vh;
             perspective: var(--depth-perspective);
             perspective-origin: center center;
+            position: relative;
+        }
+
+        body::before {
+            content: "";
+            position: fixed;
+            inset: -20%;
+            background: radial-gradient(circle at 50% 40%, rgba(0, 255, 255, 0.22), rgba(255, 0, 255, 0.08) 45%, transparent 75%);
+            mix-blend-mode: screen;
+            opacity: var(--bg-sheen);
+            transform: translate3d(var(--bg-parallax-x), var(--bg-parallax-y), 0) scale(var(--bg-scale)) rotate(var(--bg-twist));
+            filter: saturate(1.1);
+            pointer-events: none;
+            transition:
+                transform 0.6s cubic-bezier(0.22, 1, 0.36, 1),
+                opacity 0.6s ease,
+                filter 0.6s ease;
+            z-index: 0;
         }
 
         /* ORTHOGONAL PROGRESSION CONTAINER */
@@ -70,6 +95,29 @@
             backdrop-filter: blur(10px);
             transition: all 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
             cursor: pointer;
+            overflow: hidden;
+            isolation: isolate;
+            --card-glow-shift-x: 0px;
+            --card-glow-shift-y: 0px;
+            --card-glow-scale: 1;
+            --card-glow-opacity: 0.18;
+        }
+
+        .progression-card::after {
+            content: "";
+            position: absolute;
+            inset: -18%;
+            background: radial-gradient(circle at 50% 50%, rgba(0, 255, 255, 0.25), rgba(255, 0, 255, 0.12) 45%, transparent 70%);
+            border-radius: inherit;
+            pointer-events: none;
+            opacity: var(--card-glow-opacity);
+            transform: translate3d(var(--card-glow-shift-x), var(--card-glow-shift-y), 0) scale(var(--card-glow-scale));
+            filter: blur(calc(18px * var(--card-glow-scale)));
+            transition:
+                opacity 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+                transform 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+                filter 0.45s ease;
+            z-index: 0;
         }
 
         /* DEPTH PROGRESSION STATES */
@@ -113,7 +161,7 @@
             position: relative;
             padding: 40px;
             text-align: center;
-            z-index: 2;
+            z-index: 4;
         }
 
         .card-title {
@@ -144,7 +192,7 @@
             border-radius: inherit;
             opacity: 0;
             transition: opacity 0.8s ease;
-            z-index: 1;
+            z-index: 3;
         }
 
         .progression-card.focused .portal-text-visualizer {
@@ -157,15 +205,92 @@
         }
 
         /* VIB34D TILT CANVAS SYSTEM */
+        .visualizer-stack {
+            position: absolute;
+            inset: 0;
+            border-radius: inherit;
+            pointer-events: none;
+            overflow: hidden;
+            mix-blend-mode: screen;
+            filter: saturate(1.08);
+            z-index: 0;
+        }
+
         .vib34d-tilt-canvas {
             position: absolute;
-            top: 0;
-            left: 0;
+            inset: 0;
             width: 100%;
             height: 100%;
             border-radius: inherit;
             pointer-events: none;
-            z-index: 0;
+            transition: opacity 0.6s ease, transform 0.6s ease;
+            mix-blend-mode: screen;
+        }
+
+        .vib34d-tilt-canvas.layer-primary {
+            z-index: 1;
+            opacity: 0.92;
+        }
+
+        .vib34d-tilt-canvas.layer-echo {
+            z-index: 2;
+            opacity: 0.7;
+            filter: blur(4px);
+        }
+
+        .vib34d-tilt-canvas.layer-fracture {
+            z-index: 3;
+            opacity: 0.55;
+            filter: contrast(1.25) saturate(1.35);
+            mix-blend-mode: lighten;
+        }
+
+        .progression-card.focused .vib34d-tilt-canvas.layer-echo {
+            opacity: 0.82;
+            filter: blur(2px);
+        }
+
+        .progression-card.focused .vib34d-tilt-canvas.layer-fracture {
+            opacity: 0.7;
+            filter: contrast(1.45) saturate(1.5);
+        }
+
+        /* RELATIONSHIP CHOREOGRAPHY */
+        .progression-card[data-pair-role="alpha"] {
+            transform-origin: calc(50% - 12%) calc(50% - 8%);
+        }
+
+        .progression-card[data-pair-role="beta"] {
+            transform-origin: calc(50% + 12%) calc(50% + 8%);
+        }
+
+        .progression-card.pair-support {
+            --card-glow-shift-x: 18px;
+            --card-glow-shift-y: -12px;
+            --card-glow-scale: 1.18;
+            --card-glow-opacity: 0.26;
+            border-color: rgba(0, 255, 255, 0.28);
+        }
+
+        .progression-card.triad-anchor {
+            --card-glow-shift-x: -14px;
+            --card-glow-shift-y: 20px;
+            --card-glow-scale: 1.12;
+            --card-glow-opacity: 0.22;
+            border-color: rgba(255, 0, 255, 0.24);
+        }
+
+        .progression-card.fusion-active .card-header {
+            transform: translateY(-4px) scale(1.03);
+        }
+
+        .progression-card.split-state .card-header {
+            transform: translateY(6px) scale(0.97);
+            filter: hue-rotate(-18deg) saturate(0.9);
+        }
+
+        .progression-card .card-header {
+            transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1), filter 0.45s ease;
         }
 
         /* GEOMETRIC TILT INDICATOR */
@@ -308,8 +433,21 @@
     <div class="depth-progression-container" id="progressionContainer">
 
         <!-- CARD 1: QUANTUM SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum">
-            <canvas class="vib34d-tilt-canvas" id="quantum-tilt-canvas"></canvas>
+        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum"
+             data-pair-role="alpha"
+             data-pair-title="Quantum Lattice Resonance"
+             data-pair-description="Paired with holographic lattices to counter-rotate energy fields."
+             data-merge-title="Quantum x Holographic Convergence"
+             data-merge-description="Quantum lattices absorb holographic spectra to birth a hybrid matrix."
+             data-split-title="Quantum Lattice Fission"
+             data-split-description="Quantum nodes split into dual channels to seed the next arrival."
+             data-triad-title="Quantum Harmonics Triad"
+             data-triad-description="Quantum, holographic, and faceted harmonics braid portal depth.">
+            <div class="visualizer-stack" data-visualizer-stack>
+                <canvas class="vib34d-tilt-canvas layer-primary" id="quantum-tilt-canvas" data-layer="primary"></canvas>
+                <canvas class="vib34d-tilt-canvas layer-echo" id="quantum-tilt-echo" data-layer="echo"></canvas>
+                <canvas class="vib34d-tilt-canvas layer-fracture" id="quantum-tilt-fracture" data-layer="fracture"></canvas>
+            </div>
             <div class="portal-text-visualizer" id="quantum-portal"></div>
             <div class="card-header">
                 <h2 class="card-title">Quantum Processing Architecture</h2>
@@ -321,8 +459,21 @@
         </div>
 
         <!-- CARD 2: HOLOGRAPHIC SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="holographic" data-destruction="holographic">
-            <canvas class="vib34d-tilt-canvas" id="holographic-tilt-canvas"></canvas>
+        <div class="progression-card far-depth" data-vib34d="holographic" data-destruction="holographic"
+             data-pair-role="beta"
+             data-pair-title="Holographic Phase Twin"
+             data-pair-description="Moves inverse to the quantum lattice to weave spectral depth."
+             data-merge-title="Holographic Prism Assimilation"
+             data-merge-description="Prismatic arrays capture the departing geometry for layered portals."
+             data-split-title="Holographic Shear Cascade"
+             data-split-description="Holographic sheets shear apart, exposing mirrored corridors."
+             data-triad-title="Holographic Resonance Bloom"
+             data-triad-description="Diffuses resonance throughout the triad to soften transitions.">
+            <div class="visualizer-stack" data-visualizer-stack>
+                <canvas class="vib34d-tilt-canvas layer-primary" id="holographic-tilt-canvas" data-layer="primary"></canvas>
+                <canvas class="vib34d-tilt-canvas layer-echo" id="holographic-tilt-echo" data-layer="echo"></canvas>
+                <canvas class="vib34d-tilt-canvas layer-fracture" id="holographic-tilt-fracture" data-layer="fracture"></canvas>
+            </div>
             <div class="portal-text-visualizer" id="holographic-portal"></div>
             <div class="card-header">
                 <h2 class="card-title">Holographic Visualization Matrix</h2>
@@ -334,8 +485,21 @@
         </div>
 
         <!-- CARD 3: FACETED SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="faceted" data-destruction="faceted">
-            <canvas class="vib34d-tilt-canvas" id="faceted-tilt-canvas"></canvas>
+        <div class="progression-card far-depth" data-vib34d="faceted" data-destruction="faceted"
+             data-pair-role="alpha"
+             data-pair-title="Faceted Polyhedral Counterpart"
+             data-pair-description="Edges mirror the neural engine while counter-balancing motion."
+             data-merge-title="Faceted Resonance Merge"
+             data-merge-description="Crystalline facets refract inherited waves into new vectors."
+             data-split-title="Faceted Prism Fission"
+             data-split-description="Facet shards split apart to stage the neural ingress."
+             data-triad-title="Faceted Triad Choreography"
+             data-triad-description="Angles lock with the triad to stabilize portal depth.">
+            <div class="visualizer-stack" data-visualizer-stack>
+                <canvas class="vib34d-tilt-canvas layer-primary" id="faceted-tilt-canvas" data-layer="primary"></canvas>
+                <canvas class="vib34d-tilt-canvas layer-echo" id="faceted-tilt-echo" data-layer="echo"></canvas>
+                <canvas class="vib34d-tilt-canvas layer-fracture" id="faceted-tilt-fracture" data-layer="fracture"></canvas>
+            </div>
             <div class="portal-text-visualizer" id="faceted-portal"></div>
             <div class="card-header">
                 <h2 class="card-title">Faceted Geometric Engine</h2>
@@ -347,8 +511,21 @@
         </div>
 
         <!-- CARD 4: NEURAL SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum">
-            <canvas class="vib34d-tilt-canvas" id="neural-tilt-canvas"></canvas>
+        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum"
+             data-pair-role="beta"
+             data-pair-title="Neural Harmonic Twin"
+             data-pair-description="Neural fields echo the faceted engine with inverse attenuation."
+             data-merge-title="Neural Assimilation Bloom"
+             data-merge-description="Neural pathways absorb shattered facets into living geometry."
+             data-split-title="Neural Synapse Scatter"
+             data-split-description="Synapse threads separate to invite the reset cycle."
+             data-triad-title="Neural Triad Pulse"
+             data-triad-description="Rhythmic pulses ripple through the triad to signal user feedback.">
+            <div class="visualizer-stack" data-visualizer-stack>
+                <canvas class="vib34d-tilt-canvas layer-primary" id="neural-tilt-canvas" data-layer="primary"></canvas>
+                <canvas class="vib34d-tilt-canvas layer-echo" id="neural-tilt-echo" data-layer="echo"></canvas>
+                <canvas class="vib34d-tilt-canvas layer-fracture" id="neural-tilt-fracture" data-layer="fracture"></canvas>
+            </div>
             <div class="portal-text-visualizer" id="neural-portal"></div>
             <div class="card-header">
                 <h2 class="card-title">Neural Architecture Systems</h2>
@@ -382,6 +559,12 @@
             // Initialize orthogonal depth progression
             if (window.OrthogonalDepthProgression) {
                 window.progressionSystem = new OrthogonalDepthProgression();
+            }
+
+            if (window.progressionSystem && window.OrthogonalDepthReactivityOrchestrator) {
+                window.progressionReactivity = new OrthogonalDepthReactivityOrchestrator(window.progressionSystem, {
+                    tiltSystem: window.geometricTiltSystem
+                });
             }
 
             console.log('✅ VIB34D Systems initialized - Professional Avant-garde Mode Active');

--- a/docs/orthogonal-depth-reactivity-plan.md
+++ b/docs/orthogonal-depth-reactivity-plan.md
@@ -1,0 +1,30 @@
+# Orthogonal Depth Reactivity Rebuild Roadmap
+
+This roadmap captures the staged rebuild required to deliver the "refined and proper" Clear Seas reactive card progression.  Each phase tightens the choreography between the progression cards, VIB3-4D visualizers, portal canvases, and the ambient field so **every action drives at least two coordinated responses**.
+
+---
+
+## Phase 1 — Systems Architecture & Dual-Reaction Foundation *(current pull request)*
+- Introduce a formal reactivity orchestrator that observes progression state changes and pointer / scroll input.
+- Pipe every interaction into **paired responses** (active card + background field, active card + incoming card, card visualizer + portal visualizer) using lightweight CSS custom properties and the existing VIB34D APIs.
+- Enrich the VIB34D tilt visualizer and portal renderer with `applyInteractionResponse` / `applyReactiveImpulse` hooks, giving the orchestrator a deterministic way to modulate speed, glitch, density, depth, hue, and flourish energy.
+- Establish ambient background parallax and intra-card glow layers that animate via CSS transitions so motions remain smooth even when JavaScript pulses are brief.
+
+## Phase 2 — Trait Hand-off Micro-choreography *(in progress)*
+- Extend the orchestrator to listen for destruction events and orchestrate choreographed trait transfers: dying card performs a multi-stage collapse while the successor card mirrors the effect with inverse density and inherited geometry seeds.
+- **Activate the Orthogonal Audio Driver** — a microphone-fed analyser now feeds energy, swing, and peak data into the orchestrator so both the card visualizer and portal canvas gain dual-entity audio modulation (moiré, glitch, density, and glow all respond together).
+- Add scroll velocity sampling so rapid scrolls trigger higher-order responses (e.g., card orbiting, portal vortex shearing) while gentle scrolls surface subtle parallax and color grading changes.
+
+## Phase 3 — Magazine-grade Presentation Polish
+- Integrate page-level typography and navigation polish inspired by versions #30 and #1, ensuring the novel depth progression still reads like a “master class” scrolling site.
+- Add choreographed entrance / exit cinematics for menus, copy blocks, and metrics panels so they tether visually to the card and portal responses.
+- Implement persistent session memory of trait evolution so revisiting cards shows evolved geometry palettes instead of resetting to defaults.
+
+## Phase 4 — Hyper Reactive Refinements
+- Blend Ultimate Viewer presets for touch, swipe, audio, and idle states into the orchestrator so each input channel has curated presets (e.g., idle breathing, swipe ribbon casting, hold-induced dimensional lifts).
+- Introduce per-card shader swaps (WebGL or WASM pipelines) for the background field that react to inherited traits, ensuring every card transition feels bespoke in both geometry and chroma.
+- Add detailed destruction cinematics with timed particle systems and inter-card crossfades, finalizing the “spectacular choreographed event” requirement.
+
+---
+
+> **Implementation Note:** The current code submission completes Phase 1 by wiring the orchestrator, reactivity hooks, and shared polish layers.  Subsequent phases build directly on this foundation.

--- a/scripts/orthogonal-depth-progression.js
+++ b/scripts/orthogonal-depth-progression.js
@@ -26,6 +26,11 @@ class OrthogonalDepthProgression {
         this.scrollThreshold = 100;
         this.isScrollProgression = true;
 
+        this.pendingInheritedTrait = null;
+        this.eventTarget = new EventTarget();
+        this.cardMetadata = new Map();
+        this.pendingMerge = null;
+
         this.init();
     }
 
@@ -33,10 +38,13 @@ class OrthogonalDepthProgression {
         console.log('🎯 Initializing Orthogonal Depth Progression System...');
 
         this.findProgressionCards();
+        this.initializeCardMetadata();
         this.setupScrollProgression();
         this.setupKeyboardControls();
         this.initializePortalVisualizers();
+        this.setupRelationshipHooks();
         this.setInitialPositions();
+        this.applyRelationalChoreography(this.currentIndex);
 
         console.log('✅ Orthogonal Depth Progression initialized - Professional Avant-garde Mode');
     }
@@ -44,6 +52,65 @@ class OrthogonalDepthProgression {
     findProgressionCards() {
         this.cards = Array.from(document.querySelectorAll('.progression-card'));
         console.log(`🎨 Found ${this.cards.length} progression cards`);
+    }
+
+    initializeCardMetadata() {
+        this.cardMetadata.clear();
+
+        this.cards.forEach((card, index) => {
+            const titleElement = card.querySelector('.card-title');
+            const descriptionElement = card.querySelector('.card-description');
+            const baseTitle = titleElement ? titleElement.textContent.trim() : '';
+            const baseDescription = descriptionElement ? descriptionElement.textContent.trim() : '';
+
+            const variants = {
+                base: { title: baseTitle, description: baseDescription },
+                pair: {
+                    title: card.dataset.pairTitle || `${baseTitle} — Dual Resonance`,
+                    description: card.dataset.pairDescription || baseDescription
+                },
+                merge: {
+                    title: card.dataset.mergeTitle || `${baseTitle} Convergence`,
+                    description: card.dataset.mergeDescription || baseDescription
+                },
+                split: {
+                    title: card.dataset.splitTitle || `${baseTitle} Fragment`,
+                    description: card.dataset.splitDescription || baseDescription
+                },
+                trio: {
+                    title: card.dataset.triadTitle || `${baseTitle} Triad`,
+                    description: card.dataset.triadDescription || baseDescription
+                }
+            };
+
+            const metadata = {
+                index,
+                base: { title: baseTitle, description: baseDescription },
+                variants,
+                pairIndex: index % 2 === 0 ? index + 1 : index - 1,
+                trioIndices: this.getTrioIndicesForIndex(index),
+                currentVariant: 'base',
+                lastSourceCard: null
+            };
+
+            if (!card.dataset.pairRole) {
+                card.dataset.pairRole = index % 2 === 0 ? 'alpha' : 'beta';
+            }
+
+            this.cardMetadata.set(card, metadata);
+        });
+    }
+
+    getTrioIndicesForIndex(index) {
+        const trio = [];
+        const start = Math.floor(index / 3) * 3;
+        for (let offset = 0; offset < 3; offset++) {
+            const target = start + offset;
+            if (target < this.cards.length) {
+                trio.push(target);
+            }
+        }
+        return trio;
     }
 
     setupScrollProgression() {
@@ -91,8 +158,17 @@ class OrthogonalDepthProgression {
     }
 
     handleScrollProgression() {
+        const magnitude = Math.min(1, Math.abs(this.scrollAccumulator) / this.scrollThreshold);
+        this.emit('scroll-accumulating', {
+            accumulator: this.scrollAccumulator,
+            magnitude
+        });
+
         if (Math.abs(this.scrollAccumulator) > this.scrollThreshold) {
-            if (this.scrollAccumulator > 0) {
+            const direction = this.scrollAccumulator > 0 ? 1 : -1;
+            this.emit('scroll-threshold', { direction, magnitude });
+
+            if (direction > 0) {
                 this.nextCard();
             } else {
                 this.previousCard();
@@ -101,6 +177,10 @@ class OrthogonalDepthProgression {
         } else {
             // Decay scroll accumulator
             this.scrollAccumulator *= 0.9;
+            this.emit('scroll-decay', {
+                accumulator: this.scrollAccumulator,
+                magnitude: Math.min(1, Math.abs(this.scrollAccumulator) / this.scrollThreshold)
+            });
         }
     }
 
@@ -160,6 +240,190 @@ class OrthogonalDepthProgression {
         portalElement.portalVisualizer = portalVisualizer;
     }
 
+    setupRelationshipHooks() {
+        this.on('card-state-changed', ({ card, state }) => {
+            this.handleCardRelationshipState(card, state);
+        });
+
+        this.on('card-destroyed', ({ card }) => {
+            const destroyedIndex = this.cards.indexOf(card);
+            if (destroyedIndex >= 0) {
+                this.pendingMerge = {
+                    nextIndex: (destroyedIndex + 1) % this.cards.length,
+                    sourceCard: card
+                };
+            }
+        });
+
+        this.on('portal-activated', () => {
+            this.applyRelationalChoreography(this.currentIndex);
+        });
+    }
+
+    applyCardTextVariant(card, variant = 'base', context = {}) {
+        const metadata = this.cardMetadata.get(card);
+        if (!metadata) return;
+
+        const effectiveVariant = metadata.variants[variant] ? variant : 'base';
+        const sourceCard = context.sourceCard || null;
+
+        if (metadata.currentVariant === effectiveVariant && metadata.lastSourceCard === sourceCard) {
+            return;
+        }
+
+        const variantData = metadata.variants[effectiveVariant];
+
+        let titleText = variantData.title;
+        let descriptionText = variantData.description;
+
+        if (effectiveVariant === 'merge' && sourceCard) {
+            const sourceMeta = this.cardMetadata.get(sourceCard);
+            if (sourceMeta && sourceMeta.base.title) {
+                const sourceLabel = sourceMeta.base.title.split(' ')[0];
+                titleText = `${variantData.title} • ${sourceLabel}`;
+                descriptionText = `${variantData.description} Inherits ${sourceMeta.base.title}.`;
+            }
+        } else if (effectiveVariant === 'split' && sourceCard) {
+            const sourceMeta = this.cardMetadata.get(sourceCard);
+            if (sourceMeta && sourceMeta.base.title) {
+                descriptionText = `${variantData.description} Echoing ${sourceMeta.base.title}.`;
+            }
+        } else if (effectiveVariant === 'trio' && sourceCard) {
+            const sourceMeta = this.cardMetadata.get(sourceCard);
+            if (sourceMeta && sourceMeta.base.title) {
+                descriptionText = `${variantData.description} Synchronizing with ${sourceMeta.base.title}.`;
+            }
+        }
+
+        const titleElement = card.querySelector('.card-title');
+        const descriptionElement = card.querySelector('.card-description');
+        if (titleElement && typeof titleText === 'string') {
+            titleElement.textContent = titleText;
+        }
+        if (descriptionElement && typeof descriptionText === 'string') {
+            descriptionElement.textContent = descriptionText;
+        }
+
+        card.classList.toggle('fusion-active', effectiveVariant === 'merge');
+        card.classList.toggle('split-state', effectiveVariant === 'split');
+
+        metadata.currentVariant = effectiveVariant;
+        metadata.lastSourceCard = sourceCard;
+    }
+
+    applyRelationalChoreography(focusedIndex = this.currentIndex) {
+        if (!this.cards.length) return;
+
+        const focusedCard = this.cards[focusedIndex];
+        const focusedMeta = this.cardMetadata.get(focusedCard);
+
+        this.cards.forEach((card, index) => {
+            const meta = this.cardMetadata.get(card);
+            if (!meta) return;
+
+            meta.index = index;
+            meta.trioIndices = this.getTrioIndicesForIndex(index);
+
+            const isPair = meta.pairIndex === focusedIndex && card !== focusedCard;
+            const inTriad = focusedMeta && focusedMeta.trioIndices.includes(index) && focusedMeta.trioIndices.length >= 3;
+
+            if (isPair) {
+                card.classList.add('pair-support');
+                if (meta.currentVariant !== 'merge') {
+                    this.applyCardTextVariant(card, 'pair', { sourceCard: focusedCard });
+                }
+            } else {
+                if (meta.currentVariant === 'pair') {
+                    this.applyCardTextVariant(card, 'base');
+                }
+                card.classList.remove('pair-support');
+            }
+
+            if (!isPair && inTriad) {
+                card.classList.add('triad-anchor');
+                if (card !== focusedCard && meta.currentVariant === 'base') {
+                    this.applyCardTextVariant(card, 'trio', { sourceCard: focusedCard });
+                }
+            } else {
+                card.classList.remove('triad-anchor');
+                if (meta.currentVariant === 'trio') {
+                    this.applyCardTextVariant(card, 'base');
+                }
+            }
+        });
+    }
+
+    handleCardRelationshipState(card, state) {
+        const metadata = this.cardMetadata.get(card);
+        if (!metadata) return;
+
+        const index = this.cards.indexOf(card);
+        metadata.index = index;
+        metadata.trioIndices = this.getTrioIndicesForIndex(index);
+        const focusedCard = this.cards[this.currentIndex];
+
+        switch (state) {
+            case 'approaching': {
+                if (this.pendingMerge && this.pendingMerge.nextIndex === index) {
+                    this.applyCardTextVariant(card, 'merge', { sourceCard: this.pendingMerge.sourceCard });
+                } else if (metadata.pairIndex === this.currentIndex) {
+                    card.classList.add('pair-support');
+                    this.applyCardTextVariant(card, 'pair', { sourceCard: focusedCard });
+                } else if (metadata.trioIndices.includes(this.currentIndex) && metadata.index !== this.currentIndex) {
+                    card.classList.add('triad-anchor');
+                    this.applyCardTextVariant(card, 'trio', { sourceCard: focusedCard });
+                } else {
+                    card.classList.remove('pair-support');
+                    card.classList.remove('triad-anchor');
+                    this.applyCardTextVariant(card, 'base');
+                }
+                break;
+            }
+            case 'focused': {
+                if (this.pendingMerge && this.pendingMerge.nextIndex === index) {
+                    this.applyCardTextVariant(card, 'merge', { sourceCard: this.pendingMerge.sourceCard });
+                    this.pendingMerge = null;
+                } else {
+                    this.applyCardTextVariant(card, 'base');
+                }
+                this.applyRelationalChoreography(index);
+                break;
+            }
+            case 'exiting':
+            case 'destroyed': {
+                card.classList.remove('pair-support');
+                card.classList.remove('triad-anchor');
+                this.applyCardTextVariant(card, 'split', { sourceCard: focusedCard });
+                break;
+            }
+            case 'far-depth':
+                card.classList.remove('pair-support');
+                card.classList.remove('triad-anchor');
+                this.applyCardTextVariant(card, 'base');
+                break;
+        }
+    }
+
+    getVisualizersForCard(card) {
+        const canvases = Array.from(card.querySelectorAll('.vib34d-tilt-canvas'));
+        return canvases
+            .map((canvas) => canvas.vib34dVisualizer)
+            .filter((visualizer) => Boolean(visualizer));
+    }
+
+    updateVisualizerState(card, state, options = {}) {
+        const visualizers = this.getVisualizersForCard(card);
+        if (!visualizers.length) return;
+
+        visualizers.forEach((visualizer) => {
+            if (state === 'destroyed') {
+                visualizer.setCardState(state);
+            } else {
+                visualizer.setCardState(state, { inheritedTrait: options.inheritedTrait });
+            }
+        });
+    }
+
     setInitialPositions() {
         this.cards.forEach((card, index) => {
             card.style.zIndex = this.cards.length - index;
@@ -178,8 +442,9 @@ class OrthogonalDepthProgression {
         if (this.currentIndex >= this.cards.length - 1) {
             // Loop to beginning with destruction animation
             this.destroyCurrentCard(() => {
+                const inheritedTrait = this.pendingInheritedTrait;
                 this.currentIndex = 0;
-                this.progressToCurrentCard();
+                this.progressToCurrentCard(inheritedTrait);
             });
             return;
         }
@@ -206,6 +471,8 @@ class OrthogonalDepthProgression {
     progressToCard(newIndex) {
         const currentCard = this.cards[this.currentIndex];
         const newCard = this.cards[newIndex];
+        const inheritedTrait = this.pendingInheritedTrait;
+        this.pendingInheritedTrait = null;
 
         // Deactivate current card portal
         this.deactivatePortalForCard(currentCard);
@@ -215,12 +482,12 @@ class OrthogonalDepthProgression {
 
         // Bring new card forward through progression states
         setTimeout(() => {
-            this.setCardState(newCard, 'approaching');
+            this.setCardState(newCard, 'approaching', { inheritedTrait });
 
             setTimeout(() => {
-                this.setCardState(newCard, 'focused');
+                this.setCardState(newCard, 'focused', { inheritedTrait });
                 this.currentIndex = newIndex;
-                this.activatePortalForCard(newCard);
+                this.activatePortalForCard(newCard, inheritedTrait);
 
                 // Move old card to far depth
                 setTimeout(() => {
@@ -232,11 +499,11 @@ class OrthogonalDepthProgression {
         }, this.timings.cardTransition / 4);
     }
 
-    progressToCurrentCard() {
+    progressToCurrentCard(inheritedTrait = null) {
         this.cards.forEach((card, index) => {
             if (index === this.currentIndex) {
-                this.setCardState(card, 'focused');
-                this.activatePortalForCard(card);
+                this.setCardState(card, 'focused', { inheritedTrait });
+                this.activatePortalForCard(card, inheritedTrait);
             } else if (index < this.currentIndex) {
                 this.setCardState(card, 'far-depth');
                 this.deactivatePortalForCard(card);
@@ -245,19 +512,30 @@ class OrthogonalDepthProgression {
                 this.deactivatePortalForCard(card);
             }
         });
+
+        this.pendingInheritedTrait = null;
     }
 
-    setCardState(card, state) {
-        // Remove all progression state classes
-        this.progressionStates.forEach(s => card.classList.remove(s));
+    setCardState(card, state, options = {}) {
+        const inheritedTrait = options.inheritedTrait;
 
-        // Add new state
+        if (inheritedTrait) {
+            card._pendingTrait = inheritedTrait;
+        }
+
+        const traitForVisualizer = inheritedTrait || card._pendingTrait || card._activeTrait || null;
+        this.updateVisualizerState(card, state, { inheritedTrait: traitForVisualizer });
+
+        this.progressionStates.forEach(s => card.classList.remove(s));
         card.classList.add(state);
 
-        // Update card z-index based on state
         switch (state) {
             case 'focused':
                 card.style.zIndex = 1000;
+                if (card._pendingTrait) {
+                    card._activeTrait = card._pendingTrait;
+                    card._pendingTrait = null;
+                }
                 break;
             case 'approaching':
                 card.style.zIndex = 900;
@@ -272,12 +550,23 @@ class OrthogonalDepthProgression {
                 card.style.zIndex = 50;
                 break;
         }
+
+        this.emit('card-state-changed', {
+            card,
+            state,
+            inheritedTrait: traitForVisualizer
+        });
     }
 
-    activatePortalForCard(card) {
+    activatePortalForCard(card, inheritedTrait = null) {
         const portal = card.querySelector('.portal-text-visualizer');
         if (portal && portal.portalVisualizer) {
+            const trait = inheritedTrait || card._pendingTrait || card._activeTrait || null;
+            if (trait && portal.portalVisualizer.applyInheritedTrait) {
+                portal.portalVisualizer.applyInheritedTrait(trait);
+            }
             portal.portalVisualizer.activate();
+            this.emit('portal-activated', { card, trait });
         }
 
         // Add glow effect to card title
@@ -292,6 +581,7 @@ class OrthogonalDepthProgression {
         const portal = card.querySelector('.portal-text-visualizer');
         if (portal && portal.portalVisualizer) {
             portal.portalVisualizer.deactivate();
+            this.emit('portal-deactivated', { card });
         }
 
         // Remove glow effect from card title
@@ -306,19 +596,51 @@ class OrthogonalDepthProgression {
         const currentCard = this.cards[this.currentIndex];
         const destructionType = currentCard.dataset.destruction || 'quantum';
 
-        // Apply unique destruction animation
-        this.setCardState(currentCard, 'destroyed');
-        currentCard.classList.add(`destruction-${destructionType}`);
-
-        // Deactivate portal
         this.deactivatePortalForCard(currentCard);
 
-        // Reset card after destruction animation
+        this.setCardState(currentCard, 'destroyed');
+
+        const visualizers = this.getVisualizersForCard(currentCard);
+        const primaryVisualizer = visualizers.length ? visualizers[0] : null;
+        const inheritedTrait = primaryVisualizer ? primaryVisualizer.triggerDestructionSequence() : null;
+        this.pendingInheritedTrait = inheritedTrait;
+
+        if (visualizers.length > 1) {
+            visualizers.slice(1).forEach((visualizer) => {
+                if (visualizer && typeof visualizer.setCardState === 'function') {
+                    visualizer.setCardState('destroyed');
+                }
+            });
+        }
+
+        this.emit('card-destroyed', { card: currentCard, trait: inheritedTrait });
+
+        currentCard.classList.add(`destruction-${destructionType}`);
+
         setTimeout(() => {
             currentCard.classList.remove(`destruction-${destructionType}`);
             this.setCardState(currentCard, 'far-depth');
             if (callback) callback();
         }, this.timings.destructionDelay);
+    }
+
+    on(eventName, handler) {
+        if (!this.eventTarget || typeof handler !== 'function') {
+            return () => {};
+        }
+        const listener = (event) => handler(event.detail, event);
+        this.eventTarget.addEventListener(eventName, listener);
+        return () => this.eventTarget.removeEventListener(eventName, listener);
+    }
+
+    off(eventName, handler) {
+        if (!this.eventTarget || typeof handler !== 'function') return;
+        this.eventTarget.removeEventListener(eventName, handler);
+    }
+
+    emit(eventName, detail = {}) {
+        if (!this.eventTarget) return;
+        this.eventTarget.dispatchEvent(new CustomEvent(eventName, { detail }));
     }
 
     toggleAutoProgress() {
@@ -362,6 +684,166 @@ class OrthogonalDepthProgression {
     }
 }
 
+class OrthogonalAudioDriver {
+    constructor(orchestrator, options = {}) {
+        this.orchestrator = orchestrator;
+        this.options = Object.assign({
+            fftSize: 1024,
+            smoothingTimeConstant: 0.85,
+            minDecibels: -82,
+            maxDecibels: -15,
+            energyFloor: 0.05,
+            peakThreshold: 0.68
+        }, options);
+
+        this.audioContext = null;
+        this.mediaStream = null;
+        this.source = null;
+        this.analyser = null;
+        this.dataArray = null;
+        this.animationFrame = null;
+        this.initialized = false;
+        this.isActive = false;
+        this.pending = null;
+    }
+
+    ensureActive() {
+        if (this.initialized) {
+            if (!this.isActive) {
+                this.startMonitoring();
+            }
+            return Promise.resolve(true);
+        }
+
+        if (this.pending) {
+            return this.pending;
+        }
+
+        this.pending = this.init();
+        return this.pending.finally(() => {
+            this.pending = null;
+        });
+    }
+
+    async init() {
+        if (typeof navigator === 'undefined' || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+            console.warn('🔇 Audio driver unavailable in this environment');
+            return false;
+        }
+
+        try {
+            const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+            this.audioContext = new AudioContextClass();
+            this.mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+            this.source = this.audioContext.createMediaStreamSource(this.mediaStream);
+
+            this.analyser = this.audioContext.createAnalyser();
+            this.analyser.fftSize = this.options.fftSize;
+            this.analyser.smoothingTimeConstant = this.options.smoothingTimeConstant;
+            this.analyser.minDecibels = this.options.minDecibels;
+            this.analyser.maxDecibels = this.options.maxDecibels;
+
+            this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+            this.source.connect(this.analyser);
+
+            this.initialized = true;
+            this.startMonitoring();
+            console.log('🎧 Orthogonal audio driver engaged');
+            return true;
+        } catch (error) {
+            console.warn('🔇 Audio driver initialization failed', error);
+            this.initialized = false;
+            return false;
+        }
+    }
+
+    startMonitoring() {
+        if (!this.initialized || this.isActive) return;
+        this.isActive = true;
+
+        const update = () => {
+            if (!this.isActive || !this.analyser || !this.dataArray) return;
+
+            this.analyser.getByteFrequencyData(this.dataArray);
+
+            const metrics = this.computeMetrics();
+            if (this.orchestrator && typeof this.orchestrator.handleAudioEnergy === 'function') {
+                this.orchestrator.handleAudioEnergy(metrics.energy, {
+                    swing: metrics.swing,
+                    peak: metrics.peak
+                });
+            }
+
+            this.animationFrame = requestAnimationFrame(update);
+        };
+
+        this.animationFrame = requestAnimationFrame(update);
+    }
+
+    computeMetrics() {
+        let sum = 0;
+        for (let i = 0; i < this.dataArray.length; i++) {
+            sum += this.dataArray[i];
+        }
+        const average = sum / (this.dataArray.length * 255);
+
+        const energy = Math.max(0, Math.min(1, (average - this.options.energyFloor) / (1 - this.options.energyFloor)));
+
+        const lowBound = Math.floor(this.dataArray.length * 0.18);
+        const highStart = Math.floor(this.dataArray.length * 0.55);
+
+        const low = this.bandAverage(0, lowBound);
+        const high = this.bandAverage(highStart, this.dataArray.length);
+
+        const swing = Math.max(-1, Math.min(1, high - low));
+        const peak = energy > this.options.peakThreshold;
+
+        return { energy, swing, peak };
+    }
+
+    bandAverage(start, end) {
+        const clampStart = Math.max(0, start);
+        const clampEnd = Math.min(this.dataArray.length, end);
+        if (clampEnd <= clampStart) return 0;
+
+        let sum = 0;
+        for (let i = clampStart; i < clampEnd; i++) {
+            sum += this.dataArray[i];
+        }
+        return (sum / ((clampEnd - clampStart) * 255)) || 0;
+    }
+
+    stopMonitoring() {
+        this.isActive = false;
+        if (this.animationFrame) {
+            cancelAnimationFrame(this.animationFrame);
+            this.animationFrame = null;
+        }
+    }
+
+    destroy() {
+        this.stopMonitoring();
+
+        if (this.source && this.source.disconnect) {
+            try { this.source.disconnect(); } catch (error) { console.warn('Audio source disconnect failed', error); }
+        }
+
+        if (this.mediaStream) {
+            this.mediaStream.getTracks().forEach(track => track.stop());
+            this.mediaStream = null;
+        }
+
+        if (this.audioContext) {
+            try { this.audioContext.close(); } catch (error) { /* ignore */ }
+            this.audioContext = null;
+        }
+
+        this.analyser = null;
+        this.dataArray = null;
+        this.initialized = false;
+    }
+}
+
 /**
  * PORTAL TEXT VISUALIZER
  * Creates portal-style visualizations within focused card text
@@ -381,6 +863,19 @@ class PortalTextVisualizer {
         this.portalRotation = 0;
         this.portalPulse = 0;
 
+        this.inheritedTrait = null;
+        this.traitFlourish = null;
+        this.resizeObserver = null;
+        this.reactiveBurst = { active: false, start: 0, duration: 0, magnitude: 0, polarity: 1 };
+        this.audioEnergy = 0;
+        this.audioPeak = 0;
+
+        this.basePalettes = {
+            quantum: { hue: 280, accent: 220 },
+            holographic: { hue: 330, accent: 190 },
+            faceted: { hue: 200, accent: 150 }
+        };
+
         this.init();
     }
 
@@ -395,13 +890,14 @@ class PortalTextVisualizer {
 
             this.canvas.width = rect.width * dpr;
             this.canvas.height = rect.height * dpr;
+            this.context.setTransform(1, 0, 0, 1, 0, 0);
             this.context.scale(dpr, dpr);
         };
 
         resizeCanvas();
 
-        const resizeObserver = new ResizeObserver(resizeCanvas);
-        resizeObserver.observe(this.canvas);
+        this.resizeObserver = new ResizeObserver(resizeCanvas);
+        this.resizeObserver.observe(this.canvas);
     }
 
     activate() {
@@ -443,13 +939,147 @@ class PortalTextVisualizer {
         }
     }
 
-    update() {
-        // Smooth portal depth transition
-        this.portalDepth += (this.targetDepth - this.portalDepth) * 0.08;
+    applyInheritedTrait(trait) {
+        if (!trait) return;
+        this.inheritedTrait = { ...trait };
+        this.traitFlourish = {
+            active: true,
+            start: performance.now(),
+            duration: 1200
+        };
+        this.targetDepth = Math.max(this.targetDepth, 0.9);
+    }
 
-        // Portal animation
+    applyReactiveImpulse(options = {}) {
+        const {
+            depthDelta = 0.18,
+            rotationDelta = 0.24,
+            pulse = 0.45,
+            polarity = 1,
+            duration = 900
+        } = options;
+
+        const signedDelta = depthDelta * (polarity >= 0 ? 1 : -0.6);
+        this.targetDepth = Math.min(1.35, Math.max(0.1, this.targetDepth + signedDelta));
+        this.portalRotation += rotationDelta * polarity;
+
+        this.reactiveBurst = {
+            active: true,
+            start: performance.now(),
+            duration,
+            magnitude: Math.abs(pulse),
+            polarity: polarity >= 0 ? 1 : -1
+        };
+    }
+
+    applyTiltVector(tilt = {}) {
+        const normalized = tilt.normalized || {};
+        const velocity = tilt.velocity || {};
+        const intensity = typeof tilt.intensity === 'number'
+            ? Math.max(0, Math.min(1.2, tilt.intensity))
+            : Math.min(1.2, Math.sqrt(((normalized.beta || 0) ** 2) + ((normalized.gamma || 0) ** 2)));
+
+        const forward = this.clamp(normalized.beta || 0, -1.2, 1.2);
+        const lateral = this.clamp(normalized.gamma || 0, -1.2, 1.2);
+        const swirl = this.clamp(normalized.alpha || 0, -1.2, 1.2);
+
+        this.targetDepth = this.clamp(this.targetDepth + forward * 0.22, 0.35, 1.35);
+        this.portalRotation += lateral * 0.28 + swirl * 0.22;
+
+        const magnitude = Math.max(Math.abs(forward), Math.abs(lateral));
+
+        this.reactiveBurst = {
+            active: true,
+            start: performance.now(),
+            duration: 680 + intensity * 420,
+            magnitude: Math.max(this.reactiveBurst.magnitude || 0, magnitude * 0.55 + Math.abs(velocity.gamma || 0) * 0.0025),
+            polarity: lateral >= 0 ? 1 : -1
+        };
+
+        this.audioEnergy = Math.max(this.audioEnergy, intensity * 0.4 + Math.abs(velocity.beta || 0) * 0.0018);
+    }
+
+    applyAudioEnergy(level, meta = {}) {
+        if (typeof level !== 'number') return;
+
+        const normalized = Math.max(0, Math.min(1, level));
+        const eased = Math.pow(normalized, 1.3);
+
+        this.audioEnergy = Math.max(this.audioEnergy, eased);
+        if (meta.peak) {
+            this.audioPeak = Math.max(this.audioPeak, 1);
+        }
+
+        const swing = typeof meta.swing === 'number' ? meta.swing : 0;
+        const polarity = swing < 0 ? -1 : 1;
+
+        this.targetDepth = Math.min(1.4, Math.max(0.6, this.targetDepth + eased * 0.3));
+        this.portalRotation += swing * 0.35;
+
+        this.reactiveBurst = {
+            active: true,
+            start: performance.now(),
+            duration: 600 + eased * 600,
+            magnitude: Math.max(this.reactiveBurst.magnitude || 0, eased * 0.7),
+            polarity
+        };
+    }
+
+    update() {
+        this.portalDepth += (this.targetDepth - this.portalDepth) * 0.08;
         this.portalRotation += 0.02;
         this.portalPulse = Math.sin(Date.now() * 0.003) * 0.5 + 0.5;
+
+        if (this.reactiveBurst && this.reactiveBurst.active) {
+            const progress = (performance.now() - this.reactiveBurst.start) / this.reactiveBurst.duration;
+            if (progress >= 1) {
+                this.reactiveBurst.active = false;
+            }
+        }
+
+        if (this.traitFlourish && this.traitFlourish.active) {
+            const progress = (performance.now() - this.traitFlourish.start) / this.traitFlourish.duration;
+            if (progress >= 1) {
+                this.traitFlourish.active = false;
+            }
+        }
+
+        if (this.audioEnergy > 0) {
+            this.audioEnergy = Math.max(0, this.audioEnergy - 0.015);
+        }
+
+        if (this.audioPeak > 0) {
+            this.audioPeak = Math.max(0, this.audioPeak - 0.08);
+        }
+    }
+
+    getPalette() {
+        const palette = this.basePalettes[this.systemType] || this.basePalettes.faceted;
+        const trait = this.inheritedTrait || {};
+        return {
+            hue: this.normalizeHue(palette.hue + (trait.hueShift || 0)),
+            accent: this.normalizeHue(palette.accent + (trait.accentShift || 0))
+        };
+    }
+
+    getTraitFlourishIntensity() {
+        if (!this.traitFlourish || !this.traitFlourish.active) return 0;
+        const progress = (performance.now() - this.traitFlourish.start) / this.traitFlourish.duration;
+        if (progress >= 1) {
+            this.traitFlourish.active = false;
+            return 0;
+        }
+        return Math.sin(progress * Math.PI);
+    }
+
+    getReactiveBurstIntensity() {
+        if (!this.reactiveBurst || !this.reactiveBurst.active) return 0;
+        const progress = (performance.now() - this.reactiveBurst.start) / this.reactiveBurst.duration;
+        if (progress >= 1) {
+            this.reactiveBurst.active = false;
+            return 0;
+        }
+        return Math.sin(progress * Math.PI) * this.reactiveBurst.magnitude * (this.reactiveBurst.polarity >= 0 ? 1 : 0.7);
     }
 
     renderPortal() {
@@ -457,80 +1087,98 @@ class PortalTextVisualizer {
         const width = this.canvas.width / (window.devicePixelRatio || 1);
         const height = this.canvas.height / (window.devicePixelRatio || 1);
 
-        // Clear canvas
         ctx.clearRect(0, 0, width, height);
 
         if (this.portalDepth < 0.01) return;
 
         const centerX = width / 2;
         const centerY = height / 2;
-        const intensity = this.portalDepth;
+        const burst = this.getReactiveBurstIntensity();
+        const audioEnergy = this.audioEnergy || 0;
+        const intensity = this.portalDepth * (1 + burst * 0.35 + audioEnergy * 0.5);
+        const palette = this.getPalette();
+        const trait = this.inheritedTrait || {};
+        const flourish = this.getTraitFlourishIntensity();
+        const moireBoost = (trait.moireBoost || 0) + burst * 0.25 + audioEnergy * 0.35;
+        const glitchBoost = (trait.glitchBoost || 0) + burst * 0.3 + audioEnergy * 0.4;
 
-        // Render portal based on system type
         switch (this.systemType) {
             case 'quantum':
-                this.renderQuantumPortal(ctx, centerX, centerY, intensity);
+                this.renderQuantumPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish);
                 break;
             case 'holographic':
-                this.renderHolographicPortal(ctx, centerX, centerY, intensity);
+                this.renderHolographicPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish);
                 break;
             case 'faceted':
-                this.renderFacetedPortal(ctx, centerX, centerY, intensity);
+            default:
+                this.renderFacetedPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish);
                 break;
+        }
+
+        if (flourish > 0.01) {
+            this.renderTraitFlourish(ctx, centerX, centerY, intensity, palette, flourish);
+        }
+
+        if (audioEnergy > 0.02) {
+            this.renderAudioAura(ctx, centerX, centerY, intensity, palette, audioEnergy, this.audioPeak > 0.05);
         }
     }
 
-    renderQuantumPortal(ctx, centerX, centerY, intensity) {
-        const rings = 8;
-        const maxRadius = Math.min(centerX, centerY) * 0.8;
+    renderQuantumPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish) {
+        const rings = 8 + Math.round((moireBoost + flourish) * 4);
+        const maxRadius = Math.min(centerX, centerY) * (0.75 + flourish * 0.2);
 
         for (let i = 0; i < rings; i++) {
             const progress = i / rings;
             const radius = maxRadius * (1 - progress) * intensity;
-            const alpha = intensity * (1 - progress) * this.portalPulse;
+            const alpha = intensity * (1 - progress) * (0.6 + flourish * 0.2);
+            const hue = this.normalizeHue(palette.hue + progress * 16);
+            const offset = Math.sin(this.portalRotation * 2 + i) * glitchBoost * 6;
 
             if (alpha > 0.05) {
-                ctx.strokeStyle = `hsla(280, 70%, ${60 + progress * 20}%, ${alpha})`;
+                ctx.save();
                 ctx.lineWidth = 2 + progress * 3;
-
+                ctx.strokeStyle = `hsla(${hue}, 72%, ${60 + progress * 18}%, ${alpha})`;
                 ctx.beginPath();
-                ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+                ctx.arc(centerX, centerY, radius + offset, 0, Math.PI * 2);
                 ctx.stroke();
+                ctx.restore();
             }
         }
 
-        // Central quantum glow
-        const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, 50 * intensity);
-        gradient.addColorStop(0, `rgba(138, 43, 226, ${intensity * 0.5})`);
+        const glowRadius = 60 * intensity * (1 + flourish * 0.4);
+        const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, glowRadius);
+        gradient.addColorStop(0, `hsla(${palette.accent}, 95%, 72%, ${0.35 + flourish * 0.3})`);
         gradient.addColorStop(1, 'transparent');
 
         ctx.fillStyle = gradient;
         ctx.fillRect(0, 0, centerX * 2, centerY * 2);
     }
 
-    renderHolographicPortal(ctx, centerX, centerY, intensity) {
-        const layers = 6;
-        const maxRadius = Math.min(centerX, centerY) * 0.9;
+    renderHolographicPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish) {
+        const layers = 6 + Math.floor((moireBoost + flourish) * 3);
+        const maxRadius = Math.min(centerX, centerY) * (0.85 + flourish * 0.15);
 
         ctx.save();
         ctx.translate(centerX, centerY);
-        ctx.rotate(this.portalRotation);
+        ctx.rotate(this.portalRotation * (1 + flourish * 0.5));
 
         for (let i = 0; i < layers; i++) {
             const progress = i / layers;
-            const radius = maxRadius * (1 - progress * 0.8) * intensity;
-            const alpha = intensity * (1 - progress) * 0.6;
+            const radius = maxRadius * (1 - progress * 0.7) * intensity;
+            const alpha = intensity * (1 - progress) * (0.5 + flourish * 0.2);
+            const hue = this.normalizeHue(palette.hue + progress * 20);
 
-            ctx.strokeStyle = `hsla(${330 + i * 15}, 80%, 70%, ${alpha})`;
-            ctx.lineWidth = 1 + progress * 2;
+            ctx.strokeStyle = `hsla(${hue}, 90%, ${72 - progress * 18}%, ${alpha})`;
+            ctx.lineWidth = 1.2 + progress * 2;
 
-            // Create holographic interference pattern
             const sides = 8 + i * 2;
             ctx.beginPath();
             for (let j = 0; j <= sides; j++) {
                 const angle = (j / sides) * Math.PI * 2;
-                const x = Math.cos(angle) * radius * (1 + Math.sin(angle * 3) * 0.1);
-                const y = Math.sin(angle) * radius * (1 + Math.cos(angle * 3) * 0.1);
+                const distortion = 1 + Math.sin(angle * 3 + this.portalRotation * 4) * (0.08 + glitchBoost * 0.05);
+                const x = Math.cos(angle) * radius * distortion;
+                const y = Math.sin(angle) * radius * distortion;
 
                 if (j === 0) {
                     ctx.moveTo(x, y);
@@ -544,26 +1192,28 @@ class PortalTextVisualizer {
         ctx.restore();
     }
 
-    renderFacetedPortal(ctx, centerX, centerY, intensity) {
-        const facets = 12;
-        const maxRadius = Math.min(centerX, centerY) * 0.7;
+    renderFacetedPortal(ctx, centerX, centerY, intensity, palette, moireBoost, glitchBoost, flourish) {
+        const facets = 10 + Math.round((moireBoost + flourish) * 4);
+        const maxRadius = Math.min(centerX, centerY) * (0.7 + flourish * 0.2);
 
         ctx.save();
         ctx.translate(centerX, centerY);
+        ctx.rotate(this.portalRotation * (0.8 + flourish * 0.4));
 
         for (let i = 0; i < facets; i++) {
-            const angle = (i / facets) * Math.PI * 2 + this.portalRotation;
-            const radius = maxRadius * intensity * (0.5 + this.portalPulse * 0.3);
+            const angle = (i / facets) * Math.PI * 2;
+            const radius = maxRadius * intensity * (0.5 + this.portalPulse * 0.3 + flourish * 0.2);
+            const hue = this.normalizeHue(palette.hue + i * 6);
 
-            ctx.strokeStyle = `hsla(200, 70%, 60%, ${intensity * 0.8})`;
-            ctx.fillStyle = `hsla(200, 70%, 60%, ${intensity * 0.2})`;
-            ctx.lineWidth = 2;
+            ctx.strokeStyle = `hsla(${hue}, 80%, 66%, ${0.6 + flourish * 0.2})`;
+            ctx.fillStyle = `hsla(${palette.accent}, 85%, 68%, ${0.18 + flourish * 0.1})`;
+            ctx.lineWidth = 1.8 + glitchBoost * 0.6;
 
             ctx.beginPath();
             ctx.moveTo(0, 0);
             ctx.lineTo(
-                Math.cos(angle) * radius,
-                Math.sin(angle) * radius
+                Math.cos(angle) * radius * (1 + glitchBoost * 0.1),
+                Math.sin(angle) * radius * (1 + glitchBoost * 0.1)
             );
             ctx.lineTo(
                 Math.cos(angle + Math.PI / facets) * radius,
@@ -578,12 +1228,659 @@ class PortalTextVisualizer {
         ctx.restore();
     }
 
+    renderTraitFlourish(ctx, centerX, centerY, intensity, palette, flourish) {
+        ctx.save();
+        ctx.translate(centerX, centerY);
+        ctx.rotate(this.portalRotation * 1.5);
+
+        const radius = Math.min(centerX, centerY) * (0.9 + flourish * 0.3) * intensity;
+        ctx.lineWidth = 2 + flourish * 3;
+        ctx.strokeStyle = `hsla(${palette.accent}, 100%, 75%, ${0.4 + flourish * 0.4})`;
+        ctx.beginPath();
+        ctx.arc(0, 0, radius, 0, Math.PI * 2);
+        ctx.stroke();
+
+        ctx.setLineDash([6, 12]);
+        ctx.strokeStyle = `hsla(${this.normalizeHue(palette.accent + 40)}, 100%, 70%, ${0.3 + flourish * 0.3})`;
+        ctx.beginPath();
+        ctx.arc(0, 0, radius * 0.7, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
+
+        ctx.restore();
+    }
+
+    renderAudioAura(ctx, centerX, centerY, intensity, palette, energy, peak) {
+        const layers = 3 + Math.round(energy * 3);
+        const baseRadius = Math.min(centerX, centerY) * (0.35 + intensity * 0.25 + energy * 0.3);
+        const hue = this.normalizeHue(palette.hue + 32);
+
+        ctx.save();
+        ctx.globalCompositeOperation = 'screen';
+
+        for (let i = 0; i < layers; i++) {
+            const progress = layers <= 1 ? 0 : i / (layers - 1);
+            const radius = baseRadius * (1 + progress * 0.9);
+            const alpha = (0.12 + energy * 0.25) * (1 - progress * 0.35);
+            const lightness = peak ? 78 : 68;
+
+            ctx.lineWidth = 1.5 + energy * 2 - progress * 0.8;
+            ctx.strokeStyle = `hsla(${(hue + progress * 28) % 360}, 92%, ${lightness - progress * 10}%, ${alpha})`;
+            ctx.beginPath();
+            ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+
+        ctx.restore();
+    }
+
+    normalizeHue(value) {
+        return ((value % 360) + 360) % 360;
+    }
+
+    clamp(value, min, max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
     destroy() {
         this.stopRenderLoop();
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
         this.context = null;
+        this.inheritedTrait = null;
     }
 }
 
+class AmbientBackgroundField {
+    constructor(root) {
+        this.root = root || document.body;
+        this.resetTimer = null;
+    }
+
+    applyImpulse({ offsetX = 0, offsetY = 0, energy = 0.3, twist = 0 } = {}) {
+        if (!this.root) return;
+        const x = (offsetX || 0) * 60;
+        const y = (offsetY || 0) * 60;
+        const energyClamp = Math.max(0, Math.min(1.2, energy));
+
+        this.root.style.setProperty('--bg-parallax-x', `${x.toFixed(2)}px`);
+        this.root.style.setProperty('--bg-parallax-y', `${y.toFixed(2)}px`);
+        this.root.style.setProperty('--bg-scale', (1 + energyClamp * 0.18).toFixed(3));
+        this.root.style.setProperty('--bg-sheen', (0.28 + energyClamp * 0.45).toFixed(3));
+        this.root.style.setProperty('--bg-twist', `${(twist || 0) * 32}deg`);
+
+        clearTimeout(this.resetTimer);
+        this.resetTimer = setTimeout(() => this.reset(0.25), 760);
+    }
+
+    reset(energy = 0.18) {
+        if (!this.root) return;
+        this.root.style.setProperty('--bg-parallax-x', '0px');
+        this.root.style.setProperty('--bg-parallax-y', '0px');
+        this.root.style.setProperty('--bg-scale', (1 + energy * 0.1).toFixed(3));
+        this.root.style.setProperty('--bg-sheen', (0.26 + energy * 0.2).toFixed(3));
+        this.root.style.setProperty('--bg-twist', '0deg');
+    }
+
+    destroy() {
+        clearTimeout(this.resetTimer);
+        this.resetTimer = null;
+    }
+}
+
+class OrthogonalDepthReactivityOrchestrator {
+    constructor(progression, options = {}) {
+        this.progression = progression;
+        this.tiltSystem = options.tiltSystem || null;
+        this.entities = new Map();
+        this.cleanupHandlers = [];
+        this.activeCard = null;
+        this.pointerState = {
+            x: 0.5,
+            y: 0.5,
+            time: performance.now(),
+            velocityX: 0,
+            velocityY: 0
+        };
+
+        this.backgroundField = new AmbientBackgroundField(document.body);
+        this.audioDriver = new OrthogonalAudioDriver(this, options.audio || {});
+
+        this.handlePointerMove = this.handlePointerMove.bind(this);
+        this.handlePointerDown = this.handlePointerDown.bind(this);
+        this.handlePointerUp = this.handlePointerUp.bind(this);
+        this.handlePointerLeave = this.handlePointerLeave.bind(this);
+
+        this.init();
+    }
+
+    init() {
+        if (!this.progression) return;
+        this.syncEntities();
+        this.bindProgressionEvents();
+        this.bindPointerEvents();
+        this.bindTiltSystem();
+    }
+
+    syncEntities() {
+        if (!this.progression || !Array.isArray(this.progression.cards)) return;
+        this.progression.cards.forEach((card) => this.registerCard(card));
+        this.activeCard = this.progression.cards[this.progression.currentIndex] || null;
+    }
+
+    registerCard(card) {
+        if (!card) return;
+        const visualizers = this.progression.getVisualizersForCard(card);
+        const visualizer = visualizers.length ? visualizers[0] : null;
+        const portalEl = card.querySelector('.portal-text-visualizer');
+        const portalVisualizer = portalEl ? portalEl.portalVisualizer : null;
+
+        this.entities.set(card, {
+            card,
+            visualizer: visualizer || null,
+            visualizers,
+            portal: portalVisualizer || null
+        });
+    }
+
+    getEntity(card) {
+        if (!card) return null;
+        if (!this.entities.has(card)) {
+            this.registerCard(card);
+        } else {
+            const entity = this.entities.get(card);
+            if (entity && !entity.visualizer) {
+                const visualizers = this.progression.getVisualizersForCard(card);
+                entity.visualizers = visualizers;
+                entity.visualizer = visualizers.length ? visualizers[0] : null;
+            }
+            if (entity && !entity.visualizers) {
+                const visualizers = this.progression.getVisualizersForCard(card);
+                entity.visualizers = visualizers;
+                if (!entity.visualizer && visualizers.length) {
+                    entity.visualizer = visualizers[0];
+                }
+            }
+            if (entity && !entity.portal) {
+                const portalEl = card.querySelector('.portal-text-visualizer');
+                entity.portal = portalEl ? portalEl.portalVisualizer : null;
+            }
+        }
+        return this.entities.get(card) || null;
+    }
+
+    forEachVisualizer(entity, callback) {
+        if (!entity || typeof callback !== 'function') return;
+        const list = Array.isArray(entity.visualizers) && entity.visualizers.length
+            ? entity.visualizers
+            : (entity.visualizer ? [entity.visualizer] : []);
+        list.forEach((visualizer) => {
+            if (visualizer) {
+                callback(visualizer);
+            }
+        });
+    }
+
+    bindProgressionEvents() {
+        this.cleanupHandlers.push(this.progression.on('card-state-changed', (detail) => this.handleCardState(detail)));
+        this.cleanupHandlers.push(this.progression.on('portal-activated', (detail) => this.handlePortalActivated(detail)));
+        this.cleanupHandlers.push(this.progression.on('portal-deactivated', (detail) => this.handlePortalDeactivated(detail)));
+        this.cleanupHandlers.push(this.progression.on('card-destroyed', (detail) => this.handleCardDestroyed(detail)));
+        this.cleanupHandlers.push(this.progression.on('scroll-threshold', (detail) => this.handleScrollImpulse(detail)));
+        this.cleanupHandlers.push(this.progression.on('scroll-accumulating', (detail) => this.handleScrollAccumulation(detail)));
+    }
+
+    bindPointerEvents() {
+        window.addEventListener('pointermove', this.handlePointerMove, { passive: true });
+        window.addEventListener('pointerdown', this.handlePointerDown, { passive: true });
+        window.addEventListener('pointerup', this.handlePointerUp, { passive: true });
+        window.addEventListener('pointerleave', this.handlePointerLeave, { passive: true });
+    }
+
+    bindTiltSystem() {
+        if (!this.tiltSystem || typeof this.tiltSystem.on !== 'function') return;
+        const dispose = this.tiltSystem.on('tilt-vector', (detail) => this.handleTiltVector(detail));
+        this.cleanupHandlers.push(dispose);
+
+        if (typeof this.tiltSystem.enable === 'function') {
+            this.tiltSystem.enable();
+        }
+    }
+
+    handleCardState(detail = {}) {
+        const { card, state } = detail;
+        if (!card) return;
+
+        const entity = this.getEntity(card);
+        if (state === 'focused') {
+            this.activeCard = card;
+            this.applyCardGlow(card, { intensity: 0.32, scale: 1.08, shiftY: -10 });
+            this.backgroundField.applyImpulse({ offsetX: 0, offsetY: -0.12, energy: 0.35, twist: 0 });
+        } else if (state === 'far-depth' || state === 'destroyed') {
+            this.resetCardGlow(card);
+        } else if (state === 'approaching' && entity) {
+            this.applyCardGlow(card, { intensity: 0.2, scale: 1.02, shiftY: -6 });
+        }
+    }
+
+    handlePortalActivated(detail = {}) {
+        const { card } = detail;
+        if (!card) return;
+        this.applyCardGlow(card, { intensity: 0.35, scale: 1.1, shiftY: -14 });
+    }
+
+    handlePortalDeactivated(detail = {}) {
+        const { card } = detail;
+        if (!card) return;
+        this.resetCardGlow(card);
+    }
+
+    handleCardDestroyed(detail = {}) {
+        const { card } = detail;
+        if (!card) return;
+        this.backgroundField.applyImpulse({ energy: 0.78, offsetX: 0.12, offsetY: 0.18, twist: 0.35 });
+        const next = this.getPartnerCard(1);
+        if (next && next.portal && typeof next.portal.applyReactiveImpulse === 'function') {
+            next.portal.applyReactiveImpulse({ depthDelta: 0.3, rotationDelta: 0.42, pulse: 0.65, polarity: 1, duration: 1400 });
+        }
+    }
+
+    handleScrollAccumulation(detail = {}) {
+        const accumulator = detail.accumulator || 0;
+        const magnitude = detail.magnitude || 0;
+        this.backgroundField.applyImpulse({
+            offsetX: Math.sign(accumulator) * 0.08 * magnitude,
+            offsetY: -0.04 * magnitude,
+            energy: 0.24 + magnitude * 0.25,
+            twist: accumulator * 0.0006
+        });
+    }
+
+    handleScrollImpulse(detail = {}) {
+        const direction = detail.direction || 1;
+        const magnitude = detail.magnitude || 0;
+        const polarity = direction >= 0 ? 1 : -1;
+
+        const active = this.getEntity(this.activeCard);
+        if (active && active.visualizer && typeof active.visualizer.applyInteractionResponse === 'function') {
+            active.visualizer.applyInteractionResponse({
+                intensity: 0.45 + magnitude * 0.65,
+                polarity,
+                hueSpin: polarity * 0.65,
+                densityBias: polarity > 0 ? -0.9 : 0.6,
+                geometryAdvance: polarity,
+                duration: 780
+            });
+        }
+
+        if (active && active.portal && typeof active.portal.applyReactiveImpulse === 'function') {
+            active.portal.applyReactiveImpulse({
+                depthDelta: 0.24 * magnitude,
+                rotationDelta: polarity * (0.25 + magnitude * 0.18),
+                pulse: 0.42 + magnitude * 0.4,
+                polarity,
+                duration: 1100
+            });
+        }
+
+        const partner = this.getPartnerCard(polarity);
+        if (partner && partner.visualizer && typeof partner.visualizer.applyInteractionResponse === 'function') {
+            partner.visualizer.applyInteractionResponse({
+                intensity: 0.28 + magnitude * 0.4,
+                polarity: -polarity,
+                hueSpin: polarity * -0.4,
+                densityBias: polarity > 0 ? 0.45 : -0.45,
+                duration: 680
+            });
+        }
+
+        if (active) {
+            this.applyCardGlow(active.card, {
+                shiftX: polarity * 18,
+                shiftY: -polarity * 24,
+                intensity: 0.36 + magnitude * 0.4,
+                scale: 1.08 + magnitude * 0.18
+            });
+        }
+
+        if (partner) {
+            this.applyCardGlow(partner.card, {
+                shiftX: -polarity * 12,
+                shiftY: polarity * 16,
+                intensity: 0.2 + magnitude * 0.25,
+                scale: 1.02 + magnitude * 0.12
+            });
+        }
+
+        this.backgroundField.applyImpulse({
+            offsetX: polarity * (0.18 + magnitude * 0.12),
+            offsetY: -polarity * (0.16 + magnitude * 0.1),
+            energy: 0.36 + magnitude * 0.55,
+            twist: polarity * (0.28 + magnitude * 0.2)
+        });
+    }
+
+    handleAudioEnergy(level = 0, meta = {}) {
+        const energy = Math.max(0, Math.min(1, level));
+        const swing = Math.max(-1, Math.min(1, meta.swing || 0));
+        const polarity = swing >= 0 ? 1 : -1;
+        const peak = Boolean(meta.peak);
+
+        const active = this.getEntity(this.activeCard);
+        if (active && active.visualizer && typeof active.visualizer.applyAudioEnergy === 'function') {
+            active.visualizer.applyAudioEnergy(energy, { swing, peak, polarity });
+        }
+        if (active && active.portal && typeof active.portal.applyAudioEnergy === 'function') {
+            active.portal.applyAudioEnergy(energy, { swing, peak, polarity });
+        }
+
+        const partner = this.getPartnerCard(polarity);
+        if (partner && partner.visualizer && typeof partner.visualizer.applyAudioEnergy === 'function') {
+            partner.visualizer.applyAudioEnergy(Math.max(0, energy - 0.2), {
+                swing: -swing * 0.8,
+                peak: peak && energy > 0.65,
+                polarity: -polarity
+            });
+        }
+        if (partner && partner.portal && typeof partner.portal.applyAudioEnergy === 'function') {
+            partner.portal.applyAudioEnergy(Math.max(0, energy - 0.25), {
+                swing: -swing * 0.6,
+                peak: peak && energy > 0.7,
+                polarity: -polarity
+            });
+        }
+
+        if (active) {
+            this.applyCardGlow(active.card, {
+                shiftX: swing * 26,
+                shiftY: -energy * 28,
+                intensity: 0.24 + energy * 0.45,
+                scale: 1.04 + energy * 0.14
+            });
+        }
+
+        if (energy > 0.02) {
+            this.backgroundField.applyImpulse({
+                offsetX: swing * 0.4,
+                offsetY: -energy * 0.24,
+                energy: 0.28 + energy * 0.6,
+                twist: peak ? 0.45 : swing * 0.18
+            });
+        } else {
+            this.backgroundField.reset(0.2);
+        }
+    }
+
+    handlePointerMove(event) {
+        if (!this.activeCard) return;
+        const width = window.innerWidth || 1;
+        const height = window.innerHeight || 1;
+        const normalizedX = event.clientX / width;
+        const normalizedY = event.clientY / height;
+
+        const now = performance.now();
+        const dt = Math.max(0.016, (now - this.pointerState.time) / 1000);
+        const velocityX = (normalizedX - this.pointerState.x) / dt;
+        const velocityY = (normalizedY - this.pointerState.y) / dt;
+
+        this.pointerState = {
+            x: normalizedX,
+            y: normalizedY,
+            time: now,
+            velocityX,
+            velocityY
+        };
+
+        const entity = this.getEntity(this.activeCard);
+        if (!entity) return;
+
+        const offsetX = normalizedX - 0.5;
+        const offsetY = normalizedY - 0.5;
+        const displacement = Math.hypot(offsetX, offsetY);
+        const velocityMagnitude = Math.hypot(velocityX, velocityY);
+        const intensity = Math.min(1, displacement * 3 + velocityMagnitude * 0.12);
+        const polarity = velocityY >= 0 ? 1 : -1;
+
+        this.forEachVisualizer(entity, (visualizer) => {
+            if (typeof visualizer.applyInteractionResponse === 'function') {
+                visualizer.applyInteractionResponse({
+                    intensity: 0.35 + intensity * 0.6,
+                    polarity,
+                    hueSpin: offsetX * 0.9,
+                    densityBias: -offsetY * 0.7,
+                    duration: 720
+                });
+            }
+        });
+
+        if (entity.portal && typeof entity.portal.applyReactiveImpulse === 'function') {
+            entity.portal.applyReactiveImpulse({
+                depthDelta: intensity * 0.22,
+                rotationDelta: velocityX * 0.02,
+                pulse: 0.35 + intensity * 0.4,
+                polarity,
+                duration: 1050
+            });
+        }
+
+        const partner = this.getPartnerCard(polarity);
+        if (partner) {
+            this.applyCardGlow(partner.card, {
+                shiftX: -offsetX * 16,
+                shiftY: -offsetY * 14,
+                intensity: 0.18 + intensity * 0.3,
+                scale: 1.02 + intensity * 0.1
+            });
+            this.forEachVisualizer(partner, (visualizer) => {
+                if (typeof visualizer.applyInteractionResponse === 'function') {
+                    visualizer.applyInteractionResponse({
+                        intensity: 0.22 + intensity * 0.3,
+                        polarity: -polarity,
+                        hueSpin: offsetX * -0.5,
+                        densityBias: offsetY * 0.4,
+                        duration: 680
+                    });
+                }
+            });
+        }
+
+        this.applyCardGlow(entity.card, {
+            shiftX: offsetX * 28,
+            shiftY: offsetY * 22,
+            intensity: 0.28 + intensity * 0.45,
+            scale: 1.05 + intensity * 0.18
+        });
+
+        this.backgroundField.applyImpulse({
+            offsetX: offsetX * 0.7,
+            offsetY: offsetY * 0.55,
+            energy: 0.3 + intensity * 0.5,
+            twist: velocityX * 0.03
+        });
+    }
+
+    handlePointerDown() {
+        if (this.audioDriver) {
+            this.audioDriver.ensureActive().catch(() => {});
+        }
+        const entity = this.getEntity(this.activeCard);
+        if (!entity) return;
+        this.forEachVisualizer(entity, (visualizer) => {
+            if (typeof visualizer.applyInteractionResponse === 'function') {
+                visualizer.applyInteractionResponse({
+                    intensity: 0.8,
+                    polarity: 1,
+                    hueSpin: 0.8,
+                    geometryAdvance: 1,
+                    duration: 960
+                });
+            }
+        });
+        if (entity.portal && typeof entity.portal.applyReactiveImpulse === 'function') {
+            entity.portal.applyReactiveImpulse({ depthDelta: 0.32, rotationDelta: 0.32, pulse: 0.6, polarity: 1, duration: 1300 });
+        }
+        this.backgroundField.applyImpulse({ offsetX: 0, offsetY: -0.2, energy: 0.65, twist: 0.25 });
+    }
+
+    handlePointerUp() {
+        const entity = this.getEntity(this.activeCard);
+        this.forEachVisualizer(entity, (visualizer) => {
+            if (typeof visualizer.releaseInteraction === 'function') {
+                visualizer.releaseInteraction();
+            }
+        });
+        this.backgroundField.reset(0.22);
+    }
+
+    handlePointerLeave() {
+        const entity = this.getEntity(this.activeCard);
+        if (entity) {
+            this.resetCardGlow(entity.card);
+            this.forEachVisualizer(entity, (visualizer) => {
+                if (typeof visualizer.releaseInteraction === 'function') {
+                    visualizer.releaseInteraction();
+                }
+            });
+        }
+        this.backgroundField.reset(0.2);
+    }
+
+    handleTiltVector(detail = {}) {
+        if (!this.activeCard) return;
+        const entity = this.getEntity(this.activeCard);
+        if (!entity) return;
+
+        const normalized = detail.normalized || {};
+        const velocity = detail.velocity || {};
+        const intensity = typeof detail.intensity === 'number'
+            ? Math.max(0, Math.min(1.2, detail.intensity))
+            : Math.min(1.2, Math.sqrt(((normalized.beta || 0) ** 2) + ((normalized.gamma || 0) ** 2)));
+
+        const forward = normalized.beta || 0;
+        const lateral = normalized.gamma || 0;
+        const swirl = normalized.alpha || 0;
+        const polarity = lateral >= 0 ? 1 : -1;
+
+        this.forEachVisualizer(entity, (visualizer) => {
+            if (typeof visualizer.applyTiltVector === 'function') {
+                visualizer.applyTiltVector(detail);
+            }
+        });
+
+        if (entity.portal && typeof entity.portal.applyTiltVector === 'function') {
+            entity.portal.applyTiltVector(detail);
+        }
+
+        const partner = this.getPartnerCard(polarity);
+        if (partner) {
+            this.forEachVisualizer(partner, (visualizer) => {
+                if (typeof visualizer.applyTiltVector === 'function') {
+                    visualizer.applyTiltVector({
+                        normalized: {
+                            beta: -forward * 0.7,
+                            gamma: -lateral * 0.75,
+                            alpha: -swirl * 0.6
+                        },
+                        velocity: {
+                            beta: (velocity.beta || 0) * -0.7,
+                            gamma: (velocity.gamma || 0) * -0.75,
+                            alpha: (velocity.alpha || 0) * -0.6
+                        },
+                        intensity: Math.min(1, (intensity || 0) * 0.65),
+                        rotation4D: detail.rotation4D
+                    });
+                }
+            });
+        }
+
+        if (partner && partner.portal && typeof partner.portal.applyTiltVector === 'function') {
+            partner.portal.applyTiltVector({
+                normalized: {
+                    beta: -forward * 0.5,
+                    gamma: -lateral * 0.6,
+                    alpha: -swirl * 0.5
+                },
+                velocity: {
+                    beta: (velocity.beta || 0) * -0.5,
+                    gamma: (velocity.gamma || 0) * -0.6,
+                    alpha: (velocity.alpha || 0) * -0.5
+                },
+                intensity: Math.min(1, (intensity || 0) * 0.55),
+                rotation4D: detail.rotation4D
+            });
+        }
+
+        this.applyCardGlow(entity.card, {
+            shiftX: lateral * 34,
+            shiftY: -forward * 30,
+            intensity: 0.24 + intensity * 0.4,
+            scale: 1.05 + intensity * 0.14
+        });
+
+        if (partner) {
+            this.applyCardGlow(partner.card, {
+                shiftX: -lateral * 18,
+                shiftY: forward * 16,
+                intensity: 0.18 + intensity * 0.25,
+                scale: 1.02 + intensity * 0.09
+            });
+        }
+
+        this.backgroundField.applyImpulse({
+            offsetX: lateral * 0.55,
+            offsetY: -forward * 0.4,
+            energy: 0.28 + intensity * 0.45,
+            twist: swirl * 0.35
+        });
+    }
+
+    getPartnerCard(direction = 1) {
+        if (!this.progression) return null;
+        const targetIndex = this.progression.currentIndex + (direction >= 0 ? 1 : -1);
+        const card = this.progression.cards[targetIndex];
+        if (!card) return null;
+        return this.getEntity(card);
+    }
+
+    applyCardGlow(card, { shiftX = 0, shiftY = 0, intensity = 0.18, scale = 1.0 } = {}) {
+        if (!card) return;
+        card.style.setProperty('--card-glow-shift-x', `${shiftX.toFixed(2)}px`);
+        card.style.setProperty('--card-glow-shift-y', `${shiftY.toFixed(2)}px`);
+        card.style.setProperty('--card-glow-opacity', Math.min(0.85, intensity).toFixed(3));
+        card.style.setProperty('--card-glow-scale', Math.max(0.9, scale).toFixed(3));
+    }
+
+    resetCardGlow(card) {
+        if (!card) return;
+        card.style.setProperty('--card-glow-shift-x', '0px');
+        card.style.setProperty('--card-glow-shift-y', '0px');
+        card.style.setProperty('--card-glow-opacity', '0.18');
+        card.style.setProperty('--card-glow-scale', '1');
+    }
+
+    destroy() {
+        this.cleanupHandlers.forEach((dispose) => {
+            if (typeof dispose === 'function') dispose();
+        });
+        this.cleanupHandlers = [];
+
+        window.removeEventListener('pointermove', this.handlePointerMove);
+        window.removeEventListener('pointerdown', this.handlePointerDown);
+        window.removeEventListener('pointerup', this.handlePointerUp);
+        window.removeEventListener('pointerleave', this.handlePointerLeave);
+
+        this.backgroundField.destroy();
+        if (this.audioDriver) {
+            this.audioDriver.destroy();
+        }
+        this.entities.clear();
+    }
+}
 // Export for global use
 window.OrthogonalDepthProgression = OrthogonalDepthProgression;
 window.PortalTextVisualizer = PortalTextVisualizer;
+window.OrthogonalDepthReactivityOrchestrator = OrthogonalDepthReactivityOrchestrator;
+window.AmbientBackgroundField = AmbientBackgroundField;
+window.OrthogonalAudioDriver = OrthogonalAudioDriver;

--- a/scripts/vib34d-geometric-tilt-system.js
+++ b/scripts/vib34d-geometric-tilt-system.js
@@ -32,6 +32,13 @@ class VIB34DGeometricTiltSystem {
         this.smoothing = 0.15;
         this.visualizers = new Map();
         this.isSupported = this.checkDeviceOrientationSupport();
+        this.eventTarget = typeof EventTarget !== 'undefined' ? new EventTarget() : null;
+        this.lastTiltSnapshot = {
+            alpha: 0,
+            beta: 0,
+            gamma: 0,
+            time: performance.now()
+        };
 
         this.init();
     }
@@ -67,6 +74,9 @@ class VIB34DGeometricTiltSystem {
 
         this.setupTiltListeners();
         this.findTiltCanvases();
+        if (this.hasPermission) {
+            this.enable();
+        }
         console.log('✅ VIB34D Geometric Tilt System initialized');
     }
 
@@ -76,9 +86,7 @@ class VIB34DGeometricTiltSystem {
             if (!this.isEnabled) return;
 
             this.updateTiltData(event);
-            this.calculateVIB34DRotation();
-            this.updateVisualizers();
-            this.updateTiltUI();
+            this.processTiltUpdate();
         });
 
         // Fallback: Mouse movement for desktop testing
@@ -121,6 +129,13 @@ class VIB34DGeometricTiltSystem {
         this.rotation4D.rot4dZW = Math.max(-2.0, Math.min(2.0, this.rotation4D.rot4dZW));
     }
 
+    processTiltUpdate() {
+        this.calculateVIB34DRotation();
+        this.updateVisualizers();
+        this.updateTiltUI();
+        this.emitTiltMetrics();
+    }
+
     simulateTiltFromMouse(event) {
         // Desktop fallback: simulate tilt from mouse position
         const centerX = window.innerWidth / 2;
@@ -133,9 +148,7 @@ class VIB34DGeometricTiltSystem {
         this.tiltData.beta = deltaY * 45;  // Up-down
         this.tiltData.alpha += 0.5;       // Slow rotation
 
-        this.calculateVIB34DRotation();
-        this.updateVisualizers();
-        this.updateTiltUI();
+        this.processTiltUpdate();
     }
 
     findTiltCanvases() {
@@ -154,8 +167,11 @@ class VIB34DGeometricTiltSystem {
     }
 
     createTiltVisualizer(canvas, systemType) {
-        const visualizer = new VIB34DTiltVisualizer(canvas, systemType);
-        this.visualizers.set(canvas.id, visualizer);
+        const layerRole = canvas.dataset.layer || 'primary';
+        const visualizer = new VIB34DTiltVisualizer(canvas, systemType, layerRole);
+        const key = canvas.id || `${systemType}-${layerRole}-${this.visualizers.size}`;
+        this.visualizers.set(key, visualizer);
+        canvas.vib34dVisualizer = visualizer;
     }
 
     updateVisualizers() {
@@ -183,9 +199,56 @@ class VIB34DGeometricTiltSystem {
         if (rot4d) rot4d.textContent = this.isEnabled ? 'Active' : 'Inactive';
     }
 
+    emitTiltMetrics() {
+        if (!this.eventTarget || !this.isEnabled) return;
+
+        const now = performance.now();
+        const previous = this.lastTiltSnapshot || { alpha: 0, beta: 0, gamma: 0, time: now - 16 };
+        const dt = Math.max(0.016, (now - previous.time) / 1000);
+
+        const deltaAlpha = this.normalizeAngleDelta(this.tiltData.alpha, previous.alpha);
+        const deltaBeta = this.tiltData.beta - previous.beta;
+        const deltaGamma = this.tiltData.gamma - previous.gamma;
+
+        const velocity = {
+            alpha: deltaAlpha / dt,
+            beta: deltaBeta / dt,
+            gamma: deltaGamma / dt
+        };
+
+        const normalized = {
+            alpha: this.tiltData.alpha / 180,
+            beta: this.tiltData.beta / 90,
+            gamma: this.tiltData.gamma / 90
+        };
+
+        const planarMagnitude = Math.sqrt((normalized.beta ** 2) + (normalized.gamma ** 2));
+        const velocityMagnitude = Math.min(1.4, Math.sqrt(((velocity.beta / 120) ** 2) + ((velocity.gamma / 120) ** 2)));
+        const intensity = Math.max(0, Math.min(1.2, planarMagnitude * 0.85 + velocityMagnitude * 0.45));
+
+        const detail = {
+            timestamp: now,
+            raw: { ...this.tiltData },
+            normalized,
+            velocity,
+            intensity,
+            rotation4D: { ...this.rotation4D }
+        };
+
+        this.emit('tilt-vector', detail);
+        this.lastTiltSnapshot = { ...this.tiltData, time: now };
+    }
+
     clampAngle(angle, min = -180, max = 180) {
         if (angle === null || angle === undefined) return 0;
         return Math.max(min, Math.min(max, angle));
+    }
+
+    normalizeAngleDelta(current, previous) {
+        let delta = current - previous;
+        while (delta > 180) delta -= 360;
+        while (delta < -180) delta += 360;
+        return delta;
     }
 
     createFallbackSystem() {
@@ -194,21 +257,30 @@ class VIB34DGeometricTiltSystem {
         this.hasPermission = true;
         this.setupTiltListeners();
         this.findTiltCanvases();
+        this.enable();
     }
 
     enable() {
+        if (!this.hasPermission) {
+            console.warn('⚠️ Cannot enable tilt system without permission');
+            return false;
+        }
+        if (this.isEnabled) return true;
+
         this.isEnabled = true;
         console.log('✅ VIB34D Geometric Tilt System ENABLED');
+        this.emitTiltMetrics();
+        return true;
     }
 
     disable() {
+        if (!this.isEnabled) return;
         this.isEnabled = false;
         console.log('⏸️ VIB34D Geometric Tilt System DISABLED');
     }
 
     toggle() {
-        this.isEnabled ? this.disable() : this.enable();
-        return this.isEnabled;
+        return this.isEnabled ? (this.disable(), false) : this.enable();
     }
 
     setSensitivity(rot4dXW, rot4dYW, rot4dZW) {
@@ -228,6 +300,25 @@ class VIB34DGeometricTiltSystem {
         this.isEnabled = false;
         console.log('🗑️ VIB34D Geometric Tilt System destroyed');
     }
+
+    on(eventName, handler) {
+        if (!this.eventTarget || typeof handler !== 'function') {
+            return () => {};
+        }
+        const listener = (event) => handler(event.detail, event);
+        this.eventTarget.addEventListener(eventName, listener);
+        return () => this.eventTarget.removeEventListener(eventName, listener);
+    }
+
+    off(eventName, handler) {
+        if (!this.eventTarget || typeof handler !== 'function') return;
+        this.eventTarget.removeEventListener(eventName, handler);
+    }
+
+    emit(eventName, detail = {}) {
+        if (!this.eventTarget) return;
+        this.eventTarget.dispatchEvent(new CustomEvent(eventName, { detail }));
+    }
 }
 
 /**
@@ -235,14 +326,42 @@ class VIB34DGeometricTiltSystem {
  * Individual canvas visualizer that responds to geometric tilt
  */
 class VIB34DTiltVisualizer {
-    constructor(canvas, systemType) {
+    constructor(canvas, systemType, layerRole = 'primary') {
         this.canvas = canvas;
         this.systemType = systemType;
+        this.layerRole = layerRole;
         this.context = null;
+        this.resizeObserver = null;
         this.rotation4D = { rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 };
 
-        // VIB34D Parameters from Paul Phillips' system
-        this.parameters = this.getVIB34DParametersForSystem(systemType);
+        this.presets = this.getSystemPreset(systemType);
+        this.layerProfile = this.getLayerProfile(layerRole);
+        this.state = {
+            speed: this.presets.baseSpeed,
+            glitch: this.presets.baseGlitch,
+            density: this.presets.baseDensity,
+            moire: this.presets.baseMoire,
+            hue: this.presets.baseHue,
+            accentHue: this.presets.accentHue,
+            energy: 0.35,
+            geometryVariant: this.presets.geometryCycle[0]
+        };
+        this.applyLayerMultipliers(this.state);
+        this.targetState = { ...this.state };
+
+        this.variantIndex = 0;
+        this.traitIndex = 0;
+        this.hasBeenFocused = false;
+
+        this.destruction = null;
+        this.traitFlourish = null;
+        this.interactionPulse = { active: false, start: 0, duration: 720, magnitude: 0 };
+        this.pulseStrength = 0;
+        this.audioEnergy = 0;
+        this.audioPeak = 0;
+
+        this.lastTimestamp = performance.now();
+        this.time = 0;
 
         this.init();
     }
@@ -256,11 +375,10 @@ class VIB34DTiltVisualizer {
         this.context = this.canvas.getContext('2d');
         this.resizeCanvas();
 
-        // Resize observer
-        const resizeObserver = new ResizeObserver(() => {
+        this.resizeObserver = new ResizeObserver(() => {
             this.resizeCanvas();
         });
-        resizeObserver.observe(this.canvas);
+        this.resizeObserver.observe(this.canvas);
     }
 
     resizeCanvas() {
@@ -269,37 +387,170 @@ class VIB34DTiltVisualizer {
 
         this.canvas.width = rect.width * dpr;
         this.canvas.height = rect.height * dpr;
+
+        this.context.setTransform(1, 0, 0, 1, 0, 0);
         this.context.scale(dpr, dpr);
     }
 
-    getVIB34DParametersForSystem(systemType) {
-        const configs = {
+    getSystemPreset(systemType) {
+        const presets = {
             quantum: {
-                gridDensity: 20,
-                morphFactor: 1.5,
-                chaos: 0.3,
-                hue: 280,
-                intensity: 0.8,
-                geometry: 3
+                baseHue: 278,
+                accentHue: 210,
+                baseSpeed: 1.15,
+                baseGlitch: 0.35,
+                baseDensity: 0.95,
+                baseMoire: 0.35,
+                geometryCycle: ['hypercube', 'wave', 'crystal', 'lattice'],
+                trait: {
+                    hueShiftStep: 38,
+                    accentShiftStep: 24,
+                    moireBoost: 0.25,
+                    glitchBoost: 0.35,
+                    energyBoost: 0.3
+                }
             },
             holographic: {
-                gridDensity: 25,
-                morphFactor: 1.8,
-                chaos: 0.4,
-                hue: 330,
-                intensity: 0.9,
-                geometry: 7
+                baseHue: 330,
+                accentHue: 180,
+                baseSpeed: 1.25,
+                baseGlitch: 0.4,
+                baseDensity: 0.85,
+                baseMoire: 0.45,
+                geometryCycle: ['torus', 'klein', 'ribbon', 'shell'],
+                trait: {
+                    hueShiftStep: 28,
+                    accentShiftStep: 18,
+                    moireBoost: 0.22,
+                    glitchBoost: 0.32,
+                    energyBoost: 0.28
+                }
             },
             faceted: {
-                gridDensity: 15,
-                morphFactor: 1.0,
-                chaos: 0.2,
-                hue: 200,
-                intensity: 0.7,
-                geometry: 0
+                baseHue: 202,
+                accentHue: 150,
+                baseSpeed: 0.95,
+                baseGlitch: 0.25,
+                baseDensity: 1.05,
+                baseMoire: 0.28,
+                geometryCycle: ['prism', 'polytope', 'lattice'],
+                trait: {
+                    hueShiftStep: 32,
+                    accentShiftStep: 20,
+                    moireBoost: 0.18,
+                    glitchBoost: 0.28,
+                    energyBoost: 0.26
+                }
             }
         };
-        return configs[systemType] || configs.faceted;
+
+        return presets[systemType] || presets.faceted;
+    }
+
+    getLayerProfile(layerRole) {
+        const baseProfile = {
+            role: layerRole,
+            speedMultiplier: 1,
+            glitchMultiplier: 1,
+            densityMultiplier: 1,
+            moireMultiplier: 1,
+            energyMultiplier: 1,
+            responseGain: 1,
+            audioGain: 1,
+            depthBias: 0,
+            depthAttenuation: 0,
+            scaleGain: 0,
+            parallaxGain: 0,
+            tiltAmplification: 1,
+            swirlStrength: 9,
+            rotationalBiasX: 0,
+            rotationalBiasY: 0,
+            rotationalBiasZ: 0,
+            wAmplitude: 1,
+            wFrequency: 1,
+            wPhase: 0.85,
+            wRadialGain: 0.45,
+            alphaMultiplier: 1,
+            moireLayerGain: 1,
+            rippleGain: 1,
+            lineWidthGain: 1,
+            jitterGain: 1
+        };
+
+        const profiles = {
+            primary: {
+                swirlStrength: 9,
+                wPhase: 0.75,
+                wRadialGain: 0.5
+            },
+            echo: {
+                speedMultiplier: 1.08,
+                glitchMultiplier: 1.2,
+                densityMultiplier: 0.92,
+                moireMultiplier: 1.35,
+                energyMultiplier: 0.88,
+                responseGain: 1.25,
+                audioGain: 0.85,
+                depthBias: 90,
+                depthAttenuation: 0.55,
+                scaleGain: 0.28,
+                parallaxGain: 0.65,
+                tiltAmplification: 1.18,
+                swirlStrength: 14,
+                rotationalBiasX: 0.08,
+                rotationalBiasY: -0.06,
+                rotationalBiasZ: 0.04,
+                wAmplitude: 1.5,
+                wFrequency: 1.3,
+                wPhase: 1.1,
+                wRadialGain: 0.7,
+                alphaMultiplier: 0.75,
+                moireLayerGain: 1.25,
+                rippleGain: 1.2,
+                lineWidthGain: 0.95,
+                jitterGain: 1.25
+            },
+            fracture: {
+                speedMultiplier: 1.18,
+                glitchMultiplier: 1.55,
+                densityMultiplier: 0.78,
+                moireMultiplier: 0.92,
+                energyMultiplier: 1.15,
+                responseGain: 1.45,
+                audioGain: 1.18,
+                depthBias: -110,
+                depthAttenuation: 0.32,
+                scaleGain: 0.45,
+                parallaxGain: 1.05,
+                tiltAmplification: 1.32,
+                swirlStrength: 18,
+                rotationalBiasX: -0.12,
+                rotationalBiasY: 0.16,
+                rotationalBiasZ: -0.08,
+                wAmplitude: 2.05,
+                wFrequency: 1.6,
+                wPhase: 1.7,
+                wRadialGain: 0.92,
+                alphaMultiplier: 0.62,
+                moireLayerGain: 0.78,
+                rippleGain: 1.45,
+                lineWidthGain: 1.25,
+                jitterGain: 1.6
+            }
+        };
+
+        const profile = profiles[layerRole] || profiles.primary;
+        return { ...baseProfile, ...profile };
+    }
+
+    applyLayerMultipliers(state) {
+        if (!state || !this.layerProfile) return state;
+        state.speed *= this.layerProfile.speedMultiplier;
+        state.glitch *= this.layerProfile.glitchMultiplier;
+        state.density *= this.layerProfile.densityMultiplier;
+        state.moire *= this.layerProfile.moireMultiplier;
+        state.energy *= this.layerProfile.energyMultiplier;
+        return state;
     }
 
     updateRotation4D(rotation4D) {
@@ -316,140 +567,993 @@ class VIB34DTiltVisualizer {
 
     renderVIB34DVisualization() {
         const ctx = this.context;
+        if (!ctx) return;
+
         const width = this.canvas.width / (window.devicePixelRatio || 1);
         const height = this.canvas.height / (window.devicePixelRatio || 1);
 
-        // Clear canvas
-        ctx.clearRect(0, 0, width, height);
+        const now = performance.now();
+        const delta = (now - this.lastTimestamp) / 1000;
+        this.lastTimestamp = now;
 
-        // Render tilt-responsive VIB34D visualization
-        this.renderTiltResponsiveGeometry(ctx, width, height);
+        this.updateDynamicState(delta);
+
+        ctx.clearRect(0, 0, width, height);
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+
+        this.renderTiltResponsiveGeometry(ctx, width, height, this.time);
+
+        if (this.traitFlourish && this.traitFlourish.active) {
+            this.renderTraitFlourish(ctx, width, height);
+        }
+
+        if (this.destruction && this.destruction.active) {
+            this.renderDestructionChoreography(ctx, width, height);
+        }
+
+        ctx.restore();
     }
 
-    renderTiltResponsiveGeometry(ctx, width, height) {
+    updateDynamicState(delta) {
+        const lerp = (current, target, factor) => current + (target - current) * factor;
+        const factor = Math.min(1, delta * 3.5);
+
+        this.state.speed = this.clamp(lerp(this.state.speed, this.targetState.speed, factor), 0.15, 4.0);
+        this.state.glitch = this.clamp(lerp(this.state.glitch, this.targetState.glitch, factor), 0, 2.5);
+        this.state.density = this.clamp(lerp(this.state.density, this.targetState.density, factor), 0.2, 1.8);
+        this.state.moire = this.clamp(lerp(this.state.moire, this.targetState.moire, factor), 0, 2.0);
+        this.state.hue = lerp(this.state.hue, this.targetState.hue, factor);
+        this.state.accentHue = lerp(this.state.accentHue, this.targetState.accentHue, factor);
+        this.state.energy = this.clamp(lerp(this.state.energy, this.targetState.energy, factor), 0, 2.0);
+        this.state.geometryVariant = this.targetState.geometryVariant;
+
+        this.time += delta * this.state.speed;
+
+        if (this.interactionPulse && this.interactionPulse.active) {
+            const elapsed = performance.now() - this.interactionPulse.start;
+            const progress = elapsed / this.interactionPulse.duration;
+            if (progress >= 1) {
+                this.interactionPulse.active = false;
+                this.pulseStrength = 0;
+            } else {
+                this.pulseStrength = Math.sin(progress * Math.PI) * this.interactionPulse.magnitude;
+            }
+        } else {
+            this.pulseStrength *= Math.max(0, 1 - delta * 1.5);
+        }
+
+        if (this.destruction && this.destruction.active) {
+            const progress = (performance.now() - this.destruction.start) / this.destruction.duration;
+            if (progress >= 1) {
+                this.destruction.active = false;
+            }
+        }
+
+        if (this.traitFlourish && this.traitFlourish.active) {
+            const progress = (performance.now() - this.traitFlourish.start) / this.traitFlourish.duration;
+            if (progress >= 1) {
+                this.traitFlourish.active = false;
+            }
+        }
+
+        if (this.audioEnergy > 0) {
+            this.audioEnergy = Math.max(0, this.audioEnergy - delta * 0.9);
+        }
+
+        if (this.audioPeak > 0) {
+            this.audioPeak = Math.max(0, this.audioPeak - delta * 2.2);
+        }
+    }
+
+    applyTiltVector(tilt = {}) {
+        const normalized = tilt.normalized || {};
+        const velocity = tilt.velocity || {};
+        const rotation4D = tilt.rotation4D || this.rotation4D;
+        const intensity = typeof tilt.intensity === 'number'
+            ? this.clamp(tilt.intensity, 0, 1.2)
+            : Math.min(1.2, Math.sqrt(((normalized.beta || 0) ** 2) + ((normalized.gamma || 0) ** 2)));
+
+        const forward = this.clamp(normalized.beta || 0, -1.3, 1.3);
+        const lateral = this.clamp(normalized.gamma || 0, -1.3, 1.3);
+        const swirl = this.clamp(normalized.alpha || 0, -1.3, 1.3);
+
+        const velocityAlpha = velocity.alpha || 0;
+        const velocityBeta = velocity.beta || 0;
+        const velocityGamma = velocity.gamma || 0;
+
+        this.targetState.speed = this.presets.baseSpeed + Math.abs(lateral) * 0.35 + intensity * 0.55 + Math.abs(velocityGamma) * 0.012;
+        this.targetState.glitch = this.presets.baseGlitch + Math.abs(velocityBeta) * 0.018 + Math.abs(rotation4D.rot4dZW || 0) * 0.45 + intensity * 0.2;
+        this.targetState.moire = this.presets.baseMoire + Math.abs(forward) * 0.42 + Math.abs(swirl) * 0.18;
+        this.targetState.density = this.presets.baseDensity + lateral * 0.22 - forward * 0.3;
+        this.targetState.energy = Math.max(this.targetState.energy, 0.4 + intensity * 0.6 + Math.abs(velocityAlpha) * 0.002);
+        this.pulseStrength = Math.max(this.pulseStrength, intensity * 0.55);
+
+        if (Math.abs(velocityAlpha) > 35) {
+            const polarity = velocityAlpha > 0 ? 1 : -1;
+            this.applyInteractionResponse({
+                intensity: 0.28 + intensity * 0.5,
+                polarity,
+                hueSpin: swirl * 1.1,
+                densityBias: -forward * 0.5,
+                geometryAdvance: polarity,
+                duration: 680
+            });
+        } else {
+            this.targetState.hue += swirl * 6;
+            this.targetState.accentHue += swirl * 4;
+        }
+    }
+
+    applyInteractionResponse(options = {}) {
+        const {
+            intensity = 0.45,
+            polarity = 1,
+            hueSpin = 0,
+            densityBias = 0,
+            geometryAdvance = 0,
+            duration = 720
+        } = options;
+
+        const clamped = this.clamp(intensity, 0, 2.4);
+        const polaritySign = polarity >= 0 ? 1 : -1;
+        const layerGain = this.layerProfile ? this.layerProfile.responseGain || 1 : 1;
+
+        this.targetState.speed += clamped * 0.35 * layerGain;
+        this.targetState.glitch += clamped * 0.4 * layerGain;
+        this.targetState.energy += clamped * 0.5 * layerGain;
+        this.targetState.moire += clamped * 0.3 * polaritySign * layerGain;
+
+        if (densityBias !== 0) {
+            this.targetState.density += clamped * densityBias * 0.25 * layerGain;
+        } else {
+            this.targetState.density += clamped * (polaritySign > 0 ? -0.18 : 0.18) * layerGain;
+        }
+
+        if (hueSpin) {
+            this.targetState.hue += hueSpin * 14;
+            this.targetState.accentHue += hueSpin * 9;
+        }
+
+        if (geometryAdvance !== 0 && this.presets.geometryCycle.length > 1) {
+            const advance = geometryAdvance > 0 ? 1 : -1;
+            const nextIndex = (this.variantIndex + advance + this.presets.geometryCycle.length) % this.presets.geometryCycle.length;
+            this.variantIndex = nextIndex;
+            this.targetState.geometryVariant = this.presets.geometryCycle[nextIndex];
+        }
+
+        this.interactionPulse = {
+            active: true,
+            start: performance.now(),
+            duration,
+            magnitude: Math.min(1.8, (clamped * 0.9 + Math.abs(polarity) * 0.2) * layerGain)
+        };
+    }
+
+    releaseInteraction() {
+        this.interactionPulse = {
+            active: true,
+            start: performance.now(),
+            duration: 820,
+            magnitude: Math.max(0.18, this.pulseStrength * 0.6)
+        };
+
+        this.targetState.speed = Math.max(this.presets.baseSpeed, this.targetState.speed * 0.9);
+        this.targetState.glitch = Math.max(this.presets.baseGlitch * 0.6, this.targetState.glitch * 0.88);
+        this.targetState.moire = Math.max(this.presets.baseMoire * 0.5, this.targetState.moire * 0.9);
+        this.targetState.energy = Math.max(0.35, this.targetState.energy * 0.92);
+    }
+
+    applyAudioEnergy(level, meta = {}) {
+        if (typeof level !== 'number') return;
+
+        const normalized = this.clamp(level, 0, 1);
+        const eased = Math.pow(normalized, 1.2);
+        const audioGain = this.layerProfile ? this.layerProfile.audioGain || 1 : 1;
+
+        this.audioEnergy = Math.max(this.audioEnergy, eased * audioGain);
+        if (meta.peak) {
+            this.audioPeak = Math.max(this.audioPeak, 0.85 * audioGain);
+        }
+
+        const swing = typeof meta.swing === 'number' ? meta.swing : 0;
+        const polarity = meta.polarity || (swing < 0 ? -1 : 1);
+
+        this.targetState.speed += eased * 0.55 * audioGain;
+        this.targetState.glitch += eased * 0.6 * audioGain;
+        this.targetState.energy += eased * 0.8 * audioGain;
+        this.targetState.moire += eased * (polarity >= 0 ? 0.4 : 0.22) * audioGain;
+        this.targetState.density -= eased * 0.35 * audioGain;
+        this.targetState.hue += swing * 12;
+        this.targetState.accentHue += swing * 8;
+
+        if (meta.peak) {
+            this.interactionPulse = {
+                active: true,
+                start: performance.now(),
+                duration: 880 + eased * 520,
+                magnitude: Math.max(this.pulseStrength, (0.55 + eased * 0.6) * audioGain)
+            };
+        }
+    }
+
+    setCardState(state, options = {}) {
+        const inheritedTrait = options.inheritedTrait;
+
+        if (inheritedTrait) {
+            this.applyInheritedTrait(inheritedTrait);
+        }
+
+        switch (state) {
+            case 'far-depth':
+                this.targetState.speed = this.presets.baseSpeed * 0.6 * this.layerProfile.speedMultiplier;
+                this.targetState.glitch = this.presets.baseGlitch * 0.45 * this.layerProfile.glitchMultiplier;
+                this.targetState.density = this.presets.baseDensity * 1.25 * this.layerProfile.densityMultiplier;
+                this.targetState.moire = this.presets.baseMoire * 0.4 * this.layerProfile.moireMultiplier;
+                this.targetState.energy = 0.2 * this.layerProfile.energyMultiplier;
+                this.applyInteractionResponse({
+                    intensity: 0.28,
+                    polarity: -1,
+                    hueSpin: -0.35,
+                    densityBias: 0.55,
+                    duration: 1180
+                });
+                break;
+            case 'approaching':
+                this.targetState.speed = this.presets.baseSpeed * 1.1 * this.layerProfile.speedMultiplier;
+                this.targetState.glitch = this.presets.baseGlitch * 0.8 * this.layerProfile.glitchMultiplier;
+                this.targetState.density = this.presets.baseDensity * 0.85 * this.layerProfile.densityMultiplier;
+                this.targetState.moire = this.presets.baseMoire * 0.7 * this.layerProfile.moireMultiplier;
+                this.targetState.energy = 0.65 * this.layerProfile.energyMultiplier;
+                this.applyInteractionResponse({
+                    intensity: 0.62,
+                    polarity: 1,
+                    hueSpin: 0.9,
+                    densityBias: -0.95,
+                    geometryAdvance: 1,
+                    duration: 1320
+                });
+                break;
+            case 'focused':
+                this.targetState.speed = this.presets.baseSpeed * 1.75 * this.layerProfile.speedMultiplier;
+                this.targetState.glitch = (this.presets.baseGlitch * 1.4 + 0.2) * this.layerProfile.glitchMultiplier;
+                this.targetState.density = this.presets.baseDensity * 0.6 * this.layerProfile.densityMultiplier;
+                this.targetState.moire = (this.presets.baseMoire * 1.3 + 0.1) * this.layerProfile.moireMultiplier;
+                this.targetState.energy = 1.05 * this.layerProfile.energyMultiplier;
+
+                if (!inheritedTrait || !inheritedTrait.geometryVariant) {
+                    if (!this.hasBeenFocused) {
+                        this.hasBeenFocused = true;
+                        this.targetState.geometryVariant = this.presets.geometryCycle[this.variantIndex];
+                    } else {
+                        this.variantIndex = (this.variantIndex + 1) % this.presets.geometryCycle.length;
+                        this.targetState.geometryVariant = this.presets.geometryCycle[this.variantIndex];
+                    }
+                }
+
+                this.applyInteractionResponse({
+                    intensity: 0.88,
+                    polarity: 1,
+                    hueSpin: 1.25,
+                    densityBias: -1.15,
+                    geometryAdvance: 1,
+                    duration: 1480
+                });
+                break;
+            case 'exiting':
+                this.targetState.speed = this.presets.baseSpeed * 1.35 * this.layerProfile.speedMultiplier;
+                this.targetState.glitch = this.presets.baseGlitch * 1.1 * this.layerProfile.glitchMultiplier;
+                this.targetState.density = this.presets.baseDensity * 0.75 * this.layerProfile.densityMultiplier;
+                this.targetState.moire = this.presets.baseMoire * 0.9 * this.layerProfile.moireMultiplier;
+                this.targetState.energy = 0.5 * this.layerProfile.energyMultiplier;
+                this.applyInteractionResponse({
+                    intensity: 0.5,
+                    polarity: -1,
+                    hueSpin: -0.85,
+                    densityBias: 0.7,
+                    geometryAdvance: -1,
+                    duration: 1120
+                });
+                break;
+            case 'destroyed':
+                this.targetState.speed = this.presets.baseSpeed * 2.1 * this.layerProfile.speedMultiplier;
+                this.targetState.glitch = (this.presets.baseGlitch * 1.9 + 0.4) * this.layerProfile.glitchMultiplier;
+                this.targetState.density = this.presets.baseDensity * 0.35 * this.layerProfile.densityMultiplier;
+                this.targetState.moire = (this.presets.baseMoire * 1.6 + 0.2) * this.layerProfile.moireMultiplier;
+                this.targetState.energy = 1.2 * this.layerProfile.energyMultiplier;
+                this.applyInteractionResponse({
+                    intensity: 1.1,
+                    polarity: 1,
+                    hueSpin: 1.6,
+                    densityBias: -1.4,
+                    geometryAdvance: 1,
+                    duration: 1820
+                });
+                break;
+        }
+    }
+
+    applyInheritedTrait(trait, options = {}) {
+        if (!trait) return;
+
+        const immediate = options.immediate || false;
+
+        if (typeof trait.hueShift === 'number') {
+            this.targetState.hue = this.presets.baseHue + trait.hueShift;
+        }
+
+        if (typeof trait.accentShift === 'number') {
+            this.targetState.accentHue = this.presets.accentHue + trait.accentShift;
+        }
+
+        if (typeof trait.moireBoost === 'number') {
+            this.targetState.moire += trait.moireBoost;
+        }
+
+        if (typeof trait.glitchBoost === 'number') {
+            this.targetState.glitch += trait.glitchBoost;
+        }
+
+        if (typeof trait.energyBoost === 'number') {
+            this.targetState.energy += trait.energyBoost;
+        }
+
+        if (trait.geometryVariant) {
+            this.targetState.geometryVariant = trait.geometryVariant;
+            const index = this.presets.geometryCycle.indexOf(trait.geometryVariant);
+            if (index >= 0) {
+                this.variantIndex = index;
+            }
+        }
+
+        this.traitFlourish = {
+            active: true,
+            start: performance.now(),
+            duration: 1200,
+            trait
+        };
+
+        if (immediate) {
+            Object.keys(this.targetState).forEach((key) => {
+                this.state[key] = this.targetState[key];
+            });
+        }
+    }
+
+    generateDestructionTrait() {
+        const cycleLength = this.presets.geometryCycle.length;
+        const geometryVariant = this.presets.geometryCycle[(this.traitIndex + 1) % cycleLength];
+
+        const trait = {
+            geometryVariant,
+            hueShift: this.presets.trait.hueShiftStep * (this.traitIndex + 1),
+            accentShift: this.presets.trait.accentShiftStep * (this.traitIndex + 1),
+            moireBoost: this.presets.trait.moireBoost + 0.08 * this.traitIndex,
+            glitchBoost: this.presets.trait.glitchBoost + 0.07 * this.traitIndex,
+            energyBoost: this.presets.trait.energyBoost + 0.05 * this.traitIndex
+        };
+
+        this.traitIndex = (this.traitIndex + 1) % cycleLength;
+
+        return trait;
+    }
+
+    triggerDestructionSequence() {
+        const trait = this.generateDestructionTrait();
+
+        this.destruction = {
+            active: true,
+            start: performance.now(),
+            duration: 1400,
+            trait
+        };
+
+        this.targetState.hue = this.presets.baseHue + trait.hueShift;
+        this.targetState.accentHue = this.presets.accentHue + trait.accentShift;
+        this.targetState.glitch += trait.glitchBoost * 0.5;
+        this.targetState.moire += trait.moireBoost * 0.5;
+        this.targetState.energy += trait.energyBoost * 0.5;
+
+        return trait;
+    }
+
+    renderTiltResponsiveGeometry(ctx, width, height, time) {
         const centerX = width / 2;
         const centerY = height / 2;
-        const time = Date.now() * 0.001;
 
-        // Use 4D rotation for geometric transformation
         const rotX = this.rotation4D.rot4dXW;
         const rotY = this.rotation4D.rot4dYW;
         const rotZ = this.rotation4D.rot4dZW;
 
-        // Create geometric patterns based on system type and tilt
+        const hue = this.state.hue;
+        const accentHue = this.state.accentHue;
+        const energy = this.state.energy * (1 + this.pulseStrength * 0.55);
+        const glitch = this.state.glitch * (1 + this.pulseStrength * 0.35);
+        const density = this.state.density * (1 - this.pulseStrength * 0.22);
+        const moire = this.state.moire * (1 + this.pulseStrength * 0.4);
+
+        const state = {
+            hue,
+            accentHue,
+            energy,
+            glitch,
+            density,
+            variant: this.state.geometryVariant,
+            moire
+        };
+
         switch (this.systemType) {
             case 'quantum':
-                this.renderQuantumTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time);
+                this.renderQuantumTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state);
                 break;
             case 'holographic':
-                this.renderHolographicTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time);
+                this.renderHolographicTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state);
                 break;
             case 'faceted':
-                this.renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time);
-                break;
             default:
-                this.renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time);
+                this.renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state);
+                break;
         }
+
+        this.renderMoireOverlay(ctx, centerX, centerY, state.moire, state.hue, state.accentHue, state.energy, time);
+        this.renderAudioRipples(ctx, centerX, centerY, this.audioEnergy, this.audioPeak > 0.05, state.hue, time);
     }
 
-    renderQuantumTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time) {
-        const gridSize = 40 - this.parameters.gridDensity;
-        const intensity = this.parameters.intensity;
+    computeHyperSpatialW(x, y, time, energy = 0, variant = 'default', glitch = 0) {
+        const profile = this.layerProfile || {};
+        const radial = Math.sqrt(x * x + y * y);
+        const angle = Math.atan2(y, x);
+        const frequency = (profile.wFrequency || 1);
+        const amplitude = (profile.wAmplitude || 1);
+        const phase = profile.wPhase || 0.8;
+        const radialGain = profile.wRadialGain || 0.45;
+        const jitterGain = profile.jitterGain || 1;
 
-        ctx.strokeStyle = `hsla(${this.parameters.hue}, 70%, 60%, ${intensity * 0.6})`;
-        ctx.lineWidth = 1 + intensity;
+        let wave = Math.sin((x + y) * 0.01 * frequency + time * (0.85 + energy * 0.55) + phase);
+        let moire = Math.cos((x - y) * 0.012 * frequency - time * (1.4 + energy * 0.35) + angle * 1.4);
+        let lattice = 0;
 
-        for (let x = -200; x < 200; x += gridSize) {
-            for (let y = -200; y < 200; y += gridSize) {
-                const px = centerX + x * (1 + rotY * 0.5);
-                const py = centerY + y * (1 + rotX * 0.5);
+        if (variant === 'wave') {
+            wave += Math.sin(radial * 0.02 + time * 2.4) * 0.6;
+        } else if (variant === 'crystal' || variant === 'polytope') {
+            lattice += Math.cos(angle * 4 + time * 1.8) * 0.6;
+        } else if (variant === 'lattice') {
+            lattice += Math.sin((x * 0.015 + y * 0.015) + time * 1.3) * 0.8;
+        } else if (variant === 'klein') {
+            lattice += Math.sin(angle * 3 + time * 1.6) * 0.7;
+        }
 
-                const distance = Math.hypot(px - centerX, py - centerY);
-                const wave = Math.sin(distance * 0.02 + time + rotZ * 2) * 0.5 + 0.5;
-                const alpha = (1 - distance / 300) * wave * intensity;
+        const base = (wave + moire * 0.65 + lattice * 0.5) * 160 * amplitude * (1 + energy * 0.35);
+        const radialOffset = radial * radialGain * Math.sin(angle * 2 + time * 0.8);
+        const glitchInfluence = glitch * 35 * jitterGain;
 
-                if (alpha > 0.1) {
-                    ctx.globalAlpha = alpha;
+        return base + radialOffset + glitchInfluence;
+    }
+
+    projectPortalPoint(x, y, options = {}) {
+        const {
+            time = 0,
+            rotX = 0,
+            rotY = 0,
+            rotZ = 0,
+            energy = 0,
+            glitch = 0,
+            variant = 'default',
+            density = 1,
+            z = 0
+        } = options;
+
+        const profile = this.layerProfile || {};
+        const tiltAmplification = profile.tiltAmplification || 1;
+        const swirlStrength = profile.swirlStrength || 10;
+
+        let px = x * (1 + rotY * 0.35 * tiltAmplification);
+        let py = y * (1 + rotX * 0.35 * tiltAmplification);
+
+        const swirl = Math.sin((px + py) * 0.005 * (profile.wFrequency || 1) + time * 0.8) * swirlStrength;
+        px += swirl * 0.6;
+        py += swirl * -0.4;
+
+        if (variant === 'wave') {
+            px += Math.sin(time * 2 + y * 0.02) * 12 * (energy + glitch * 0.5);
+        } else if (variant === 'ribbon') {
+            py += Math.cos(time * 2.2 + x * 0.02) * 16 * (energy + glitch * 0.4);
+        } else if (variant === 'shell') {
+            px += Math.sin(time * 1.6 + density * 0.5) * 8;
+            py += Math.cos(time * 1.4 + density * 0.4) * 8;
+        }
+
+        const w = this.computeHyperSpatialW(px, py, time, energy, variant, glitch);
+        const depthBias = profile.depthBias || 0;
+        const zBase = (z || 0) + depthBias;
+        const rotXW = rotX + (profile.rotationalBiasX || 0);
+        const rotYW = rotY + (profile.rotationalBiasY || 0);
+        const rotZW = rotZ + (profile.rotationalBiasZ || 0);
+
+        const sinX = Math.sin(rotXW);
+        const cosX = Math.cos(rotXW);
+        let x1 = px * cosX - w * sinX;
+        let w1 = px * sinX + w * cosX;
+
+        const sinY = Math.sin(rotYW);
+        const cosY = Math.cos(rotYW);
+        let y1 = py * cosY - w1 * sinY;
+        let w2 = py * sinY + w1 * cosY;
+
+        const sinZ = Math.sin(rotZW);
+        const cosZ = Math.cos(rotZW);
+        let z1 = zBase * cosZ - w2 * sinZ;
+        let w3 = zBase * sinZ + w2 * cosZ;
+
+        const planarSpin = rotZ * 0.6;
+        const sinP = Math.sin(planarSpin);
+        const cosP = Math.cos(planarSpin);
+        const x2 = x1 * cosP - y1 * sinP;
+        const y2 = x1 * sinP + y1 * cosP;
+
+        const attenuation = profile.depthAttenuation || 0;
+        const depthFactor = 1 / (1 + Math.abs(w3) * 0.0028 * (1 + attenuation));
+        const scale = depthFactor * (1 + (profile.scaleGain || 0) * Math.sign(w3));
+        const parallax = w3 * 0.0012 * (1 + (profile.parallaxGain || 0));
+
+        const finalX = x2 * scale + parallax * 120;
+        const finalY = y2 * scale - parallax * 90;
+
+        return {
+            x: finalX,
+            y: finalY,
+            depth: w3,
+            alpha: depthFactor,
+            scale,
+            parallax
+        };
+    }
+
+    renderQuantumTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state) {
+        const baseSpacing = 38;
+        const density = this.clamp(state.density, 0.2, 1.8);
+        const densityFactor = this.layerProfile ? this.layerProfile.densityMultiplier || 1 : 1;
+        const spacing = (baseSpacing * (1 + (1 - density) * 2.6)) / densityFactor;
+        const extent = 220 + state.energy * 140;
+        const hue = this.normalizeHue(state.hue);
+        const accentHue = this.normalizeHue(state.accentHue);
+        const glitch = state.glitch;
+        const energy = state.energy;
+        const variant = state.variant;
+        const alphaMultiplier = this.layerProfile ? this.layerProfile.alphaMultiplier || 1 : 1;
+        const lineWidthGain = this.layerProfile ? this.layerProfile.lineWidthGain || 1 : 1;
+        const jitterGain = this.layerProfile ? this.layerProfile.jitterGain || 1 : 1;
+
+        ctx.lineWidth = (1.2 + energy * 0.5) * lineWidthGain;
+
+        for (let x = -extent; x <= extent; x += spacing) {
+            for (let y = -extent; y <= extent; y += spacing) {
+                let jitterX = Math.sin(time * 4 + y * 0.06) * glitch * 8 * jitterGain;
+                let jitterY = Math.cos(time * 4 + x * 0.06) * glitch * 8 * jitterGain;
+
+                if (variant === 'wave') {
+                    jitterX += Math.sin(time * 3 + y * 0.09) * 12 * energy;
+                } else if (variant === 'crystal') {
+                    jitterY += Math.cos(time * 3 + x * 0.09) * 12 * energy;
+                } else if (variant === 'lattice') {
+                    jitterX += Math.sin((x + time * 30) * 0.02) * 6;
+                    jitterY += Math.cos((y - time * 30) * 0.02) * 6;
+                }
+
+                const projected = this.projectPortalPoint(x + jitterX, y + jitterY, {
+                    time,
+                    rotX,
+                    rotY,
+                    rotZ,
+                    energy,
+                    glitch,
+                    variant,
+                    density
+                });
+
+                const px = centerX + projected.x;
+                const py = centerY + projected.y;
+
+                const distance = Math.hypot(projected.x, projected.y);
+                const normalized = Math.max(0, 1 - distance / (extent * 1.15));
+                if (normalized <= 0.01) continue;
+
+                const wave = (Math.sin(distance * 0.016 + time * 3 + rotZ * 2 + projected.depth * 0.0015) + 1) * 0.5;
+                const depthAlpha = projected.alpha * alphaMultiplier;
+                const alpha = Math.pow(normalized, 1.35) * (0.25 + energy * 0.5) * (0.6 + wave * 0.5) * depthAlpha;
+
+                const radius = (2 + wave * 4 + glitch * 1.2) * (0.6 + projected.scale * 0.4);
+                ctx.strokeStyle = `hsla(${hue}, 72%, ${55 + wave * 18 + projected.parallax * 30}%, ${alpha})`;
+                ctx.beginPath();
+                ctx.arc(px, py, radius, 0, Math.PI * 2);
+                ctx.stroke();
+
+                if (variant === 'crystal' && wave > 0.65) {
+                    const anchor = this.projectPortalPoint(x * 0.6, y * 0.6, {
+                        time,
+                        rotX,
+                        rotY,
+                        rotZ,
+                        energy: energy * 0.8,
+                        glitch,
+                        variant,
+                        density
+                    });
+                    ctx.strokeStyle = `hsla(${accentHue}, 88%, 70%, ${alpha * 0.65})`;
                     ctx.beginPath();
-                    ctx.arc(px, py, 2 + wave * 3, 0, Math.PI * 2);
+                    ctx.moveTo(px, py);
+                    ctx.lineTo(centerX + anchor.x, centerY + anchor.y);
                     ctx.stroke();
                 }
             }
         }
 
-        ctx.globalAlpha = 1;
     }
 
-    renderHolographicTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time) {
-        const layers = 5;
-        const intensity = this.parameters.intensity;
+    renderHolographicTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state) {
+        const layers = 6 + Math.floor(state.energy * 3.2);
+        const hue = this.normalizeHue(state.hue);
+        const accentHue = this.normalizeHue(state.accentHue);
+        const glitch = state.glitch;
+        const energy = state.energy;
+        const density = state.density;
+        const variant = state.variant;
+        const alphaMultiplier = this.layerProfile ? this.layerProfile.alphaMultiplier || 1 : 1;
+        const lineWidthGain = this.layerProfile ? this.layerProfile.lineWidthGain || 1 : 1;
 
         for (let i = 0; i < layers; i++) {
-            const radius = 50 + i * 30;
-            const alpha = intensity * (1 - i / layers);
+            const progress = i / layers;
+            let radius = 55 + i * 32 * (1 + (1 - density) * 0.4);
+            let rotation = time * (0.45 + progress * 0.5) + rotZ * 1.2;
+            let offsetX = Math.sin(time * 1.2 + progress * 6) * 18 * glitch;
+            let offsetY = Math.cos(time * 1.1 + progress * 5) * 18 * glitch;
 
-            ctx.strokeStyle = `hsla(${this.parameters.hue + i * 20}, 80%, 70%, ${alpha})`;
-            ctx.lineWidth = 2;
+            if (variant === 'klein') {
+                rotation += Math.sin(time + progress * 2) * 0.8;
+            } else if (variant === 'ribbon') {
+                offsetX += Math.sin(time * 2 + progress * 8) * 36 * energy;
+                offsetY += Math.cos(time * 2 + progress * 8) * 30 * energy;
+            } else if (variant === 'shell') {
+                radius *= 1 + progress * 0.5;
+            } else if (variant === 'torus') {
+                radius *= 1 + Math.sin(time + progress * 3) * 0.12;
+            }
 
-            const offsetX = Math.sin(rotY + time) * 20;
-            const offsetY = Math.cos(rotX + time) * 20;
+            const anchor = this.projectPortalPoint(offsetX, offsetY, {
+                time,
+                rotX,
+                rotY,
+                rotZ,
+                energy,
+                glitch,
+                variant,
+                density
+            });
+
+            const px = centerX + anchor.x;
+            const py = centerY + anchor.y;
+            const scaleFactor = 0.8 + anchor.scale * 0.6;
+            const radiusX = Math.max(8, radius * (1 + rotX * 0.25 + energy * 0.1) * scaleFactor);
+            const radiusY = Math.max(8, radius * (1 + rotY * 0.25 + energy * 0.1) * scaleFactor);
+
+            const lineAlpha = (0.55 * (1 - progress) + energy * 0.1) * anchor.alpha * alphaMultiplier;
+            ctx.strokeStyle = `hsla(${(hue + progress * 25) % 360}, 88%, ${70 - progress * 18 + anchor.parallax * 20}%, ${lineAlpha})`;
+            ctx.lineWidth = (1.2 + energy * 0.4) * lineWidthGain;
 
             ctx.beginPath();
             ctx.ellipse(
-                centerX + offsetX,
-                centerY + offsetY,
-                radius * (1 + rotX * 0.2),
-                radius * (1 + rotY * 0.2),
-                rotZ + time,
+                px,
+                py,
+                radiusX,
+                radiusY,
+                rotation + anchor.parallax * 2,
                 0,
                 Math.PI * 2
             );
             ctx.stroke();
+
+            const shimmer = (0.2 * (1 - progress) + energy * 0.05) * anchor.alpha * alphaMultiplier;
+            ctx.setLineDash([6, 10]);
+            ctx.strokeStyle = `hsla(${accentHue + progress * 30}, 95%, 75%, ${shimmer})`;
+            ctx.beginPath();
+            ctx.ellipse(
+                px + anchor.parallax * 30,
+                py - anchor.parallax * 22,
+                Math.max(6, radiusX * 0.7),
+                Math.max(6, radiusY * 0.7 * (variant === 'ribbon' ? 0.75 : 1)),
+                rotation - anchor.parallax * 1.5,
+                0,
+                Math.PI * 2
+            );
+            ctx.stroke();
+            ctx.setLineDash([]);
+        }
+
+    }
+
+    renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time, state) {
+        const hue = this.normalizeHue(state.hue);
+        const accentHue = this.normalizeHue(state.accentHue);
+        const glitch = state.glitch;
+        const energy = state.energy;
+        const variant = state.variant;
+        const density = state.density;
+        const alphaMultiplier = this.layerProfile ? this.layerProfile.alphaMultiplier || 1 : 1;
+        const lineWidthGain = this.layerProfile ? this.layerProfile.lineWidthGain || 1 : 1;
+
+        let sides = 6;
+        if (variant === 'polytope') {
+            sides = 8;
+        } else if (variant === 'lattice') {
+            sides = 12;
+        }
+
+        const radius = 70 + energy * 40;
+        const rotation = time * 0.6 + rotZ;
+        const scaleX = 1 + rotY * 0.35 + energy * 0.12;
+        const scaleY = 1 + rotX * 0.35 + energy * 0.12;
+
+        const points = [];
+        for (let i = 0; i < sides; i++) {
+            const angle = (i / sides) * Math.PI * 2 + rotation;
+            let r = radius;
+
+            if (variant === 'lattice') {
+                r += Math.sin(time * 3 + angle * 4) * 14 * glitch;
+            } else if (variant === 'polytope') {
+                r += Math.cos(time * 2 + angle * 3) * 18 * energy;
+            }
+
+            const baseX = Math.cos(angle) * r * scaleX;
+            const baseY = Math.sin(angle) * r * scaleY;
+
+            const projected = this.projectPortalPoint(baseX, baseY, {
+                time,
+                rotX,
+                rotY,
+                rotZ,
+                energy,
+                glitch,
+                variant,
+                density
+            });
+
+            points.push({
+                x: centerX + projected.x,
+                y: centerY + projected.y,
+                alpha: projected.alpha,
+                scale: projected.scale
+            });
+        }
+
+        if (!points.length) return;
+
+        const avgAlpha = points.reduce((sum, p) => sum + p.alpha, 0) / points.length;
+        const fillAlpha = (0.2 + energy * 0.25) * avgAlpha * alphaMultiplier;
+        const strokeAlpha = (0.75 + energy * 0.18) * avgAlpha * alphaMultiplier;
+
+        ctx.beginPath();
+        ctx.moveTo(points[0].x, points[0].y);
+        for (let i = 1; i < points.length; i++) {
+            ctx.lineTo(points[i].x, points[i].y);
+        }
+        ctx.closePath();
+
+        ctx.fillStyle = `hsla(${hue}, 65%, ${45 + energy * 18}%, ${fillAlpha})`;
+        ctx.strokeStyle = `hsla(${hue}, 72%, 60%, ${strokeAlpha})`;
+        ctx.lineWidth = (2 + glitch * 0.8) * lineWidthGain;
+        ctx.fill();
+        ctx.stroke();
+
+        const centerAnchor = this.projectPortalPoint(0, 0, {
+            time,
+            rotX,
+            rotY,
+            rotZ,
+            energy: energy * 0.6,
+            glitch,
+            variant,
+            density
+        });
+        const centerXProjected = centerX + centerAnchor.x;
+        const centerYProjected = centerY + centerAnchor.y;
+
+        ctx.strokeStyle = `hsla(${accentHue}, 95%, 72%, ${(0.35 + glitch * 0.1) * avgAlpha * alphaMultiplier})`;
+        for (let i = 0; i < points.length; i++) {
+            ctx.beginPath();
+            ctx.moveTo(centerXProjected, centerYProjected);
+            ctx.lineTo(points[i].x, points[i].y);
+            ctx.stroke();
+        }
+
+    }
+
+    renderMoireOverlay(ctx, centerX, centerY, moire, hue, accentHue, energy, time) {
+        const intensity = Math.max(0, moire - 0.05);
+        if (intensity <= 0.01) return;
+
+        const layers = 3 + Math.floor(intensity * 2.5);
+
+        const anchor = this.projectPortalPoint(0, 0, {
+            time,
+            rotX: this.rotation4D.rot4dXW,
+            rotY: this.rotation4D.rot4dYW,
+            rotZ: this.rotation4D.rot4dZW,
+            energy,
+            glitch: this.state.glitch,
+            variant: this.state.geometryVariant,
+            density: this.state.density || 1
+        });
+
+        const px = centerX + anchor.x;
+        const py = centerY + anchor.y;
+        const alphaMultiplier = this.layerProfile ? this.layerProfile.alphaMultiplier || 1 : 1;
+        const moireLayerGain = this.layerProfile ? this.layerProfile.moireLayerGain || 1 : 1;
+
+        for (let i = 0; i < layers; i++) {
+            const radius = (i + 1) * 30 * (1 + energy * 0.35) * (0.8 + anchor.scale * 0.6);
+            const alpha = (0.08 + intensity * 0.12) * (1 - i / layers) * anchor.alpha * alphaMultiplier * moireLayerGain;
+            const angle = time * (0.5 + intensity * 0.4) + i * 0.6 + anchor.parallax * 3;
+
+            ctx.save();
+            ctx.translate(px, py);
+            ctx.rotate(angle);
+
+            ctx.strokeStyle = `hsla(${(accentHue + i * 14) % 360}, 92%, 68%, ${alpha})`;
+            ctx.lineWidth = (1 + intensity * 0.4) * (this.layerProfile ? this.layerProfile.lineWidthGain || 1 : 1);
+
+            ctx.beginPath();
+            ctx.ellipse(
+                0,
+                0,
+                radius * (1 + Math.sin(time + i) * 0.12 * energy),
+                radius * (1 + Math.cos(time + i * 0.8) * 0.12 * energy),
+                0,
+                0,
+                Math.PI * 2
+            );
+            ctx.stroke();
+
+            ctx.restore();
         }
     }
 
-    renderFacetedTiltPattern(ctx, centerX, centerY, rotX, rotY, rotZ, time) {
-        const sides = 6;
-        const radius = 80;
-        const intensity = this.parameters.intensity;
+    renderTraitFlourish(ctx, width, height) {
+        if (!this.traitFlourish) return;
 
-        ctx.strokeStyle = `hsla(${this.parameters.hue}, 70%, 60%, ${intensity})`;
-        ctx.fillStyle = `hsla(${this.parameters.hue}, 70%, 60%, ${intensity * 0.3})`;
-        ctx.lineWidth = 2;
+        const now = performance.now();
+        const progress = (now - this.traitFlourish.start) / this.traitFlourish.duration;
+        if (progress >= 1) {
+            this.traitFlourish.active = false;
+            return;
+        }
 
-        const angle = rotZ + time * 0.5;
-        const scaleX = 1 + rotY * 0.3;
-        const scaleY = 1 + rotX * 0.3;
+        const intensity = Math.sin(progress * Math.PI);
+        const hue = this.normalizeHue(this.targetState.accentHue + 24);
 
         ctx.save();
-        ctx.translate(centerX, centerY);
-        ctx.scale(scaleX, scaleY);
-        ctx.rotate(angle);
+        ctx.translate(width / 2, height / 2);
+        ctx.rotate(progress * Math.PI * 2);
 
+        const radius = (width + height) * 0.12 * (0.6 + intensity);
+
+        ctx.lineWidth = 2 + intensity * 3;
+        ctx.strokeStyle = `hsla(${hue}, 96%, 75%, ${0.55 * (1 - progress)})`;
         ctx.beginPath();
-        for (let i = 0; i <= sides; i++) {
-            const a = (i / sides) * Math.PI * 2;
-            const x = Math.cos(a) * radius;
-            const y = Math.sin(a) * radius;
-
-            if (i === 0) {
-                ctx.moveTo(x, y);
-            } else {
-                ctx.lineTo(x, y);
-            }
-        }
-        ctx.fill();
+        ctx.arc(0, 0, radius, 0, Math.PI * 2);
         ctx.stroke();
+
+        ctx.setLineDash([4, 10]);
+        ctx.strokeStyle = `hsla(${(hue + 40) % 360}, 98%, 72%, ${0.35 * (1 - progress)})`;
+        ctx.beginPath();
+        ctx.arc(0, 0, radius * 1.35, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
 
         ctx.restore();
     }
 
+    renderDestructionChoreography(ctx, width, height) {
+        if (!this.destruction) return;
+
+        const now = performance.now();
+        const progress = (now - this.destruction.start) / this.destruction.duration;
+        if (progress >= 1) {
+            this.destruction.active = false;
+            return;
+        }
+
+        const fade = 1 - progress;
+        const hue = this.normalizeHue(this.targetState.hue + 18);
+        const accentHue = this.normalizeHue(this.targetState.accentHue);
+        const radiusBase = Math.max(width, height) * 0.18;
+        const radius = radiusBase + progress * Math.max(width, height) * 0.35;
+
+        ctx.save();
+        ctx.translate(width / 2, height / 2);
+        ctx.globalCompositeOperation = 'screen';
+
+        const gradient = ctx.createRadialGradient(0, 0, radius * 0.1, 0, 0, radius);
+        gradient.addColorStop(0, `hsla(${accentHue}, 100%, 76%, ${0.45 * fade})`);
+        gradient.addColorStop(0.5, `hsla(${hue}, 100%, 66%, ${0.35 * fade})`);
+        gradient.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = gradient;
+        ctx.beginPath();
+        ctx.arc(0, 0, radius, 0, Math.PI * 2);
+        ctx.fill();
+
+        const shards = 18;
+        for (let i = 0; i < shards; i++) {
+            const angle = (i / shards) * Math.PI * 2 + progress * Math.PI * 1.5;
+            const shardLength = radius * (0.55 + 0.3 * Math.sin(progress * 6 + i));
+            ctx.strokeStyle = `hsla(${(hue + i * 12) % 360}, 100%, 70%, ${0.6 * fade})`;
+            ctx.lineWidth = 1.5 + this.state.glitch * 0.4;
+            ctx.beginPath();
+            ctx.moveTo(Math.cos(angle) * radius * 0.35, Math.sin(angle) * radius * 0.35);
+            ctx.lineTo(Math.cos(angle) * shardLength, Math.sin(angle) * shardLength);
+            ctx.stroke();
+        }
+
+        ctx.restore();
+    }
+
+    renderAudioRipples(ctx, centerX, centerY, energy, peak, hue, time) {
+        if (!energy || energy <= 0.01) return;
+
+        const layers = 3;
+        const anchor = this.projectPortalPoint(0, 0, {
+            time,
+            rotX: this.rotation4D.rot4dXW,
+            rotY: this.rotation4D.rot4dYW,
+            rotZ: this.rotation4D.rot4dZW,
+            energy,
+            glitch: this.state.glitch,
+            variant: this.state.geometryVariant,
+            density: this.state.density || 1
+        });
+
+        const px = centerX + anchor.x;
+        const py = centerY + anchor.y;
+        const rippleGain = this.layerProfile ? this.layerProfile.rippleGain || 1 : 1;
+        const baseRadius = (40 + energy * 160) * (0.8 + anchor.scale * 0.5);
+        const brightness = peak ? 82 : 68;
+        const accentHue = this.normalizeHue(hue + 24);
+
+        ctx.save();
+        ctx.translate(px, py);
+        ctx.globalCompositeOperation = 'screen';
+
+        for (let i = 0; i < layers; i++) {
+            const progress = i / layers;
+            const radius = baseRadius * (1 + progress * 0.8 + Math.sin(time * 2 + progress * 5) * energy * 0.25) * rippleGain;
+            const alpha = (0.18 + energy * 0.32) * (1 - progress * 0.3) * anchor.alpha;
+
+            ctx.lineWidth = 2 + energy * 3 - progress * 1.2;
+            ctx.strokeStyle = `hsla(${(accentHue + progress * 36) % 360}, 100%, ${brightness - progress * 14}%, ${alpha})`;
+            ctx.beginPath();
+            ctx.arc(0, 0, radius, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+
+        ctx.restore();
+    }
+
+    clamp(value, min, max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    normalizeHue(value) {
+        return ((value % 360) + 360) % 360;
+    }
+
     destroy() {
-        // Clean up resources
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
         this.context = null;
     }
 }
-
 // Export for global use
 window.VIB34DGeometricTiltSystem = VIB34DGeometricTiltSystem;
 window.VIB34DTiltVisualizer = VIB34DTiltVisualizer;


### PR DESCRIPTION
## Summary
- Layer each progression card with a primary, echo, and fracture visualizer canvas plus relational metadata so cards can pair, split, and merge with bespoke copy.
- Rework the VIB34D tilt renderer to project X/Y into W-depth for all layers, adjust dynamics per layer profile, and synchronize moiré and audio ripples with the new hyper-spatial projection.
- Expand the progression engine and orchestrator with card relationship metadata, multi-visualizer coordination, and dual-entity reactions so partner and triad cards choreograph together.

## Testing
- node --check scripts/vib34d-geometric-tilt-system.js
- node --check scripts/orthogonal-depth-progression.js

------
https://chatgpt.com/codex/tasks/task_e_68d71581991883298eff97480598f0ca