### PR TITLE
Refine layout-aware tilt orchestration

### DIFF
--- a/25-orthogonal-depth-progression.html
+++ b/25-orthogonal-depth-progression.html
@@ -10,11 +10,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 
-    <!-- VIB34D GEOMETRIC TILT SYSTEM -->
-    <script src="scripts/vib34d-geometric-tilt-system.js" defer></script>
-
     <!-- ORTHOGONAL DEPTH PROGRESSION ENGINE -->
-    <script src="scripts/orthogonal-depth-progression.js" defer></script>
+    <script type="module" src="scripts/orthogonal-depth-progression.js"></script>
 
     <style>
         * {
@@ -31,16 +28,46 @@
             --holographic-pink: #ff1493;
             --void-black: #0a0a0a;
             --depth-perspective: 1200px;
+            --visualizer-bg-primary: #020617;
+            --visualizer-bg-secondary: #0b193c;
+            --visualizer-bg-glow: rgba(0, 255, 255, 0.12);
+            --visualizer-grid-color: rgba(0, 255, 255, 0.1);
+            --visualizer-pulse-color: rgba(255, 0, 255, 0.18);
+            --section-title-from: var(--clear-seas-primary);
+            --section-title-to: var(--clear-seas-secondary);
+            --global-tilt-x: 0;
+            --global-tilt-y: 0;
+            --global-tilt-strength: 0;
+            --hypercube-fold-progress: 0;
         }
 
         body {
             font-family: 'Inter', sans-serif;
-            background: linear-gradient(180deg, #000 0%, #0a0a0a 50%, #000 100%);
             color: white;
             overflow: hidden; /* NO TRADITIONAL SCROLLING */
             height: 100vh;
             perspective: var(--depth-perspective);
             perspective-origin: center center;
+            background: radial-gradient(circle at 50% 50%, var(--visualizer-bg-glow), transparent 70%),
+                linear-gradient(180deg, var(--visualizer-bg-primary), var(--visualizer-bg-secondary));
+            transition: background 1.2s ease;
+        }
+
+        .holographic-backdrop {
+            position: fixed;
+            inset: 0;
+            overflow: hidden;
+            z-index: -2;
+        }
+
+        .holographic-backdrop canvas {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            display: block;
+            pointer-events: none;
+            mix-blend-mode: screen;
         }
 
         /* ORTHOGONAL PROGRESSION CONTAINER */
@@ -52,6 +79,26 @@
             height: 100vh;
             transform-style: preserve-3d;
             perspective: var(--depth-perspective);
+            transition: transform 1.3s cubic-bezier(0.35, 0, 0.25, 1);
+        }
+
+        .depth-progression-container.hypercube-folding {
+            animation: hypercubeFold 1.6s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        @keyframes hypercubeFold {
+            0% {
+                transform: scale(1) rotate3d(0, 0, 0, 0deg);
+            }
+            35% {
+                transform: scale(0.92) rotate3d(1, 1, 0, 12deg);
+            }
+            70% {
+                transform: scale(0.4) rotate3d(1, -1, 0, 120deg);
+            }
+            100% {
+                transform: scale(1) rotate3d(0, 0, 0, 0deg);
+            }
         }
 
         /* DEPTH PROGRESSION CARD SYSTEM */
@@ -65,47 +112,124 @@
             transform-origin: center center;
             transform-style: preserve-3d;
             border-radius: 20px;
-            background: linear-gradient(135deg, rgba(0, 255, 255, 0.1), rgba(255, 0, 255, 0.05));
+            background: linear-gradient(135deg, rgba(0, 255, 255, 0.08), rgba(255, 0, 255, 0.05));
             border: 2px solid rgba(0, 255, 255, 0.2);
-            backdrop-filter: blur(10px);
+            backdrop-filter: blur(12px);
             transition: all 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
             cursor: pointer;
+            --card-depth: -800px;
+            --card-scale: 0.3;
+            --card-opacity: 0.2;
+            --card-blur: 3px;
+            --card-glow: rgba(0, 255, 255, 0.16);
+            --card-glow-radius: 30px;
+            --layout-tilt-x: 0;
+            --layout-tilt-y: 0;
+            --layout-tilt-strength: 0;
+            --card-tilt-scale: 1;
+            --card-tilt-x: calc(var(--layout-tilt-x) + (var(--global-tilt-x) * var(--card-tilt-scale)));
+            --card-tilt-y: calc(var(--layout-tilt-y) + (var(--global-tilt-y) * var(--card-tilt-scale)));
+            transform: translate(-50%, -50%)
+                translateZ(var(--card-depth))
+                scale(var(--card-scale))
+                rotateX(calc(var(--card-tilt-y) * 12deg))
+                rotateY(calc(var(--card-tilt-x) * 14deg));
+            opacity: var(--card-opacity);
+            filter: blur(var(--card-blur));
+            box-shadow: 0 0 var(--card-glow-radius) var(--card-glow);
+        }
+
+        .progression-card:not(.focused) {
+            --card-tilt-scale: 0.34;
         }
 
         /* DEPTH PROGRESSION STATES */
         .progression-card.far-depth {
-            transform: translate(-50%, -50%) translateZ(-800px) scale(0.3);
-            opacity: 0.1;
-            filter: blur(3px);
+            --card-depth: -820px;
+            --card-scale: 0.28;
+            --card-opacity: 0.1;
+            --card-blur: 4px;
+            --card-tilt-scale: 0.22;
         }
 
         .progression-card.approaching {
-            transform: translate(-50%, -50%) translateZ(-400px) scale(0.6);
-            opacity: 0.4;
-            filter: blur(1px);
+            --card-depth: -420px;
+            --card-scale: 0.6;
+            --card-opacity: 0.45;
+            --card-blur: 1.2px;
+            --card-tilt-scale: 0.58;
         }
 
         .progression-card.focused {
-            transform: translate(-50%, -50%) translateZ(0px) scale(1.0);
-            opacity: 1.0;
-            filter: blur(0px);
-            border-color: var(--clear-seas-primary);
+            --card-depth: 0px;
+            --card-scale: 1;
+            --card-opacity: 1;
+            --card-blur: 0px;
+            --card-glow-radius: clamp(40px, 8vw, 80px);
+            --card-tilt-scale: 1;
+            border-color: rgba(0, 255, 255, 0.4);
             box-shadow:
-                0 0 30px rgba(0, 255, 255, 0.3),
-                0 0 60px rgba(0, 255, 255, 0.1);
+                0 0 clamp(30px, 6vw, 60px) rgba(0, 255, 255, 0.35),
+                0 0 clamp(60px, 10vw, 120px) rgba(255, 0, 255, 0.15);
+        }
+
+        .progression-card[data-section="quantum"].focused {
+            --card-glow: rgba(96, 255, 255, 0.36);
+        }
+
+        .progression-card[data-section="holographic"].focused {
+            --card-glow: rgba(255, 110, 255, 0.28);
+        }
+
+        .progression-card[data-section="faceted"].focused {
+            --card-glow: rgba(120, 255, 180, 0.32);
+        }
+
+        .progression-card[data-section="neural"].focused {
+            --card-glow: rgba(176, 129, 255, 0.32);
         }
 
         .progression-card.exiting {
-            transform: translate(-50%, -50%) translateZ(400px) scale(1.5);
-            opacity: 0.2;
-            filter: blur(2px);
+            --card-depth: 420px;
+            --card-scale: 1.45;
+            --card-opacity: 0.28;
+            --card-blur: 2px;
+            --card-tilt-scale: 0.78;
         }
 
         .progression-card.destroyed {
-            transform: translate(-50%, -50%) translateZ(800px) scale(2.0) rotateX(45deg) rotateY(45deg);
-            opacity: 0;
-            filter: blur(5px);
             pointer-events: none;
+            --card-tilt-scale: 0.12;
+        }
+
+        .progression-card::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            border-radius: inherit;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            opacity: calc(var(--layout-tilt-strength) * 0.2);
+            transform: translateZ(2px);
+            transition: opacity 0.6s ease, filter 0.6s ease, border-color 0.6s ease;
+            mix-blend-mode: screen;
+            pointer-events: none;
+        }
+
+        .progression-card.focused::after {
+            opacity: min(1, calc(0.5 + var(--global-tilt-strength) * 0.45));
+            border-color: rgba(255, 255, 255, 0.25);
+            filter: drop-shadow(0 0 35px rgba(0, 255, 255, 0.4));
+        }
+
+        .progression-card[data-visualizer-state="ascend"].focused::after {
+            filter: drop-shadow(0 0 25px rgba(255, 140, 255, 0.45));
+        }
+
+        .progression-card.tilt-extreme::after {
+            opacity: 0.9;
+            border-color: rgba(255, 255, 255, 0.4);
+            filter: drop-shadow(0 0 25px rgba(255, 255, 255, 0.35))
+                drop-shadow(0 0 45px rgba(0, 255, 255, 0.25));
         }
 
         /* CARD CONTENT SYSTEM */
@@ -117,9 +241,9 @@
         }
 
         .card-title {
-            font-size: 2.5rem;
+            font-size: clamp(1.8rem, 2.6vw, 2.8rem);
             font-weight: 700;
-            background: linear-gradient(135deg, var(--clear-seas-primary), var(--clear-seas-secondary));
+            background: linear-gradient(135deg, var(--section-title-from, var(--clear-seas-primary)), var(--section-title-to, var(--clear-seas-secondary)));
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -132,6 +256,17 @@
             color: rgba(255, 255, 255, 0.8);
             line-height: 1.6;
             margin-bottom: 30px;
+            transition: color 0.6s ease, filter 0.6s ease;
+        }
+
+        .progression-card.focused .card-title {
+            text-shadow: 0 0 20px var(--clear-seas-primary);
+            transform: scale(1.05) translateZ(16px);
+        }
+
+        .progression-card.focused .card-description {
+            color: rgba(255, 255, 255, 0.92);
+            filter: drop-shadow(0 0 18px rgba(0, 255, 255, 0.18));
         }
 
         /* PORTAL-STYLE TEXT VISUALIZERS */
@@ -148,12 +283,7 @@
         }
 
         .progression-card.focused .portal-text-visualizer {
-            opacity: 0.8;
-        }
-
-        .progression-card.focused .card-title {
-            text-shadow: 0 0 20px var(--clear-seas-primary);
-            transform: scale(1.05);
+            opacity: 0.85;
         }
 
         /* VIB34D TILT CANVAS SYSTEM */
@@ -174,12 +304,35 @@
             top: 20px;
             right: 20px;
             padding: 10px 15px;
-            background: rgba(0, 255, 255, 0.1);
+            background: rgba(2, 24, 36, 0.65);
             border: 1px solid rgba(0, 255, 255, 0.3);
             border-radius: 10px;
             font-family: 'JetBrains Mono', monospace;
             font-size: 0.9rem;
             z-index: 1000;
+            color: rgba(171, 244, 255, 0.95);
+            box-shadow: 0 0 18px rgba(0, 255, 255, 0.18);
+            transition: border-color 0.4s ease, box-shadow 0.4s ease, color 0.4s ease;
+        }
+
+        .tilt-indicator[data-mode="pointer"] {
+            border-color: rgba(255, 255, 255, 0.35);
+            color: rgba(255, 255, 255, 0.85);
+        }
+
+        .tilt-indicator[data-mode="dramatic"] {
+            border-color: rgba(255, 94, 188, 0.8);
+            color: rgba(255, 182, 255, 0.95);
+            box-shadow: 0 0 22px rgba(255, 94, 188, 0.55);
+        }
+
+        .tilt-indicator.extreme {
+            animation: tiltIndicatorPulse 1.4s ease-in-out infinite;
+        }
+
+        @keyframes tiltIndicatorPulse {
+            0%, 100% { box-shadow: 0 0 18px rgba(255, 94, 188, 0.45); }
+            50% { box-shadow: 0 0 32px rgba(255, 189, 94, 0.65); }
         }
 
         /* PROGRESSION CONTROLS */
@@ -297,18 +450,32 @@
 </head>
 <body>
 
+    <div class="holographic-backdrop">
+        <canvas id="holo-background-canvas" class="holo-layer"></canvas>
+        <canvas id="holo-shadow-canvas" class="holo-layer"></canvas>
+        <canvas id="holo-content-canvas" class="holo-layer"></canvas>
+        <canvas id="holo-highlight-canvas" class="holo-layer"></canvas>
+        <canvas id="holo-accent-canvas" class="holo-layer"></canvas>
+    </div>
+
     <!-- GEOMETRIC TILT INDICATOR -->
     <div class="tilt-indicator">
         <div>Tilt X: <span id="tilt-x">0</span>°</div>
         <div>Tilt Y: <span id="tilt-y">0</span>°</div>
-        <div>4D Rotation: <span id="rot4d">Active</span></div>
+        <div>4D Rotation: <span id="rot4d">Device</span></div>
     </div>
 
     <!-- ORTHOGONAL DEPTH PROGRESSION CONTAINER -->
     <div class="depth-progression-container" id="progressionContainer">
 
         <!-- CARD 1: QUANTUM SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum">
+        <div class="progression-card far-depth" data-section="quantum"
+            data-vib34d="quantum" data-destruction="quantum"
+            data-title-from="#6ff9ff" data-title-to="#5f6fff"
+            data-bg-primary="#030d1f" data-bg-secondary="#001a33"
+            data-bg-glow="rgba(0, 255, 255, 0.16)"
+            data-visualizer-density="0.75" data-visualizer-speed="0.6"
+            data-visualizer-geometry="lattice" data-visualizer-state="emerge">
             <canvas class="vib34d-tilt-canvas" id="quantum-tilt-canvas"></canvas>
             <div class="portal-text-visualizer" id="quantum-portal"></div>
             <div class="card-header">
@@ -321,7 +488,13 @@
         </div>
 
         <!-- CARD 2: HOLOGRAPHIC SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="holographic" data-destruction="holographic">
+        <div class="progression-card far-depth" data-section="holographic"
+            data-vib34d="holographic" data-destruction="holographic"
+            data-title-from="#ff7bf9" data-title-to="#7fdbff"
+            data-bg-primary="#140022" data-bg-secondary="#32004f"
+            data-bg-glow="rgba(255, 0, 255, 0.2)"
+            data-visualizer-density="0.65" data-visualizer-speed="0.8"
+            data-visualizer-geometry="hologram" data-visualizer-state="ripple">
             <canvas class="vib34d-tilt-canvas" id="holographic-tilt-canvas"></canvas>
             <div class="portal-text-visualizer" id="holographic-portal"></div>
             <div class="card-header">
@@ -334,7 +507,13 @@
         </div>
 
         <!-- CARD 3: FACETED SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="faceted" data-destruction="faceted">
+        <div class="progression-card far-depth" data-section="faceted"
+            data-vib34d="faceted" data-destruction="faceted"
+            data-title-from="#f6ff8a" data-title-to="#00ffd5"
+            data-bg-primary="#061400" data-bg-secondary="#033b1a"
+            data-bg-glow="rgba(102, 255, 204, 0.18)"
+            data-visualizer-density="0.85" data-visualizer-speed="0.5"
+            data-visualizer-geometry="facets" data-visualizer-state="ascend">
             <canvas class="vib34d-tilt-canvas" id="faceted-tilt-canvas"></canvas>
             <div class="portal-text-visualizer" id="faceted-portal"></div>
             <div class="card-header">
@@ -347,7 +526,13 @@
         </div>
 
         <!-- CARD 4: NEURAL SYSTEMS -->
-        <div class="progression-card far-depth" data-vib34d="quantum" data-destruction="quantum">
+        <div class="progression-card far-depth" data-section="neural"
+            data-vib34d="quantum" data-destruction="quantum"
+            data-title-from="#a0fffb" data-title-to="#ff87f3"
+            data-bg-primary="#040013" data-bg-secondary="#130044"
+            data-bg-glow="rgba(160, 255, 251, 0.2)"
+            data-visualizer-density="0.6" data-visualizer-speed="1.1"
+            data-visualizer-geometry="neural" data-visualizer-state="eclipse">
             <canvas class="vib34d-tilt-canvas" id="neural-tilt-canvas"></canvas>
             <div class="portal-text-visualizer" id="neural-portal"></div>
             <div class="card-header">
@@ -369,23 +554,32 @@
     </div>
 
     <!-- INITIALIZATION SCRIPT -->
-    <script>
-        // Initialize VIB34D Geometric Tilt + Orthogonal Depth Progression System
-        document.addEventListener('DOMContentLoaded', () => {
-            console.log('🎯 Initializing VIB34D Orthogonal Depth Progression System...');
+    <script type="module">
+        import OrthogonalDepthProgression from './scripts/orthogonal-depth-progression.js';
 
-            // Initialize geometric tilt system
-            if (window.VIB34DGeometricTiltSystem) {
+        const boot = () => {
+            console.log('🎯 Initializing Orthogonal Depth Progression with holographic choreography...');
+
+            if (window.VIB34DGeometricTiltSystem && !window.geometricTiltSystem) {
                 window.geometricTiltSystem = new VIB34DGeometricTiltSystem();
             }
 
-            // Initialize orthogonal depth progression
-            if (window.OrthogonalDepthProgression) {
-                window.progressionSystem = new OrthogonalDepthProgression();
-            }
+            const progression = new OrthogonalDepthProgression({
+                container: document.getElementById('progressionContainer'),
+                backgroundCanvas: document.getElementById('section-background'),
+                tiltIndicator: document.querySelector('.tilt-indicator')
+            });
 
-            console.log('✅ VIB34D Systems initialized - Professional Avant-garde Mode Active');
-        });
+            window.progressionSystem = progression;
+
+            console.log('✅ VIB34D Orthogonal progression + holographic visualizers ready.');
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', boot);
+        } else {
+            boot();
+        }
     </script>
 
 

--- a/js/interactions/device-tilt.js
+++ b/js/interactions/device-tilt.js
@@ -1,6 +1,7 @@
 /**
- * VIB34D DEVICE TILT TO 4D ROTATION SYSTEM
- * Maps device orientation to 4D rotation parameters for immersive interaction
+ * VIB34D GEOMETRIC TILT WINDOW SYSTEM
+ * Creates "angled window" effect where device tilt matches visual grid rotation
+ * Plus 4D depth changes based on viewing angle through the tilted window
  */
 
 export class DeviceTiltHandler {
@@ -8,25 +9,20 @@ export class DeviceTiltHandler {
         this.isEnabled = false;
         this.isSupported = false;
         this.sensitivity = 1.0;
-        this.smoothing = 0.1; // Smoothing factor (0-1, lower = smoother)
-        this.dramaticMode = false; // 🚀 NEW: Dramatic tilting mode
+        this.smoothing = 0.15; // Slightly more smoothing for geometric effects
         
-        // Current device orientation (radians)
+        // Current device orientation (degrees for easier geometric calculations)
         this.currentTilt = {
             alpha: 0, // Z-axis rotation (compass heading)
             beta: 0,  // X-axis rotation (front-back tilt)  
             gamma: 0  // Y-axis rotation (left-right tilt)
         };
         
-        // 🚀 DRAMATIC TILTING: Track tilt intensity for extreme effects
-        this.tiltIntensity = 0;
-        this.extremeTilt = false;
-        
-        // Smoothed 4D rotation values
-        this.smoothedRotation = {
-            rot4dXW: 0,
-            rot4dYW: 0,
-            rot4dZW: 0
+        // Smoothed values for smooth visual transitions
+        this.smoothedTilt = {
+            alpha: 0,
+            beta: 0,
+            gamma: 0
         };
         
         // Base rotation values (from presets/manual control)
@@ -36,54 +32,176 @@ export class DeviceTiltHandler {
             rot4dZW: 0
         };
         
-        // Mapping configuration
-        this.mapping = {
-            // 🔷 NORMAL MODE: Conservative mapping (original behavior)
-            normal: {
-                // Device beta (front-back tilt) -> 4D XW rotation
-                betaToXW: {
-                    scale: 0.01, // Radians per degree of device tilt
-                    range: [-45, 45], // Degrees of device tilt to use
-                    clamp: [-1.5, 1.5] // 4D rotation limits (radians)
-                },
-                // Device gamma (left-right tilt) -> 4D YW rotation  
-                gammaToYW: {
-                    scale: 0.015,
-                    range: [-30, 30],
-                    clamp: [-1.5, 1.5]
-                },
-                // Device alpha (compass heading) -> 4D ZW rotation
-                alphaToZW: {
-                    scale: 0.008,
-                    range: [-180, 180],
-                    clamp: [-2.0, 2.0]
-                }
-            },
-            
-            // 🚀 DRAMATIC MODE: 8x more sensitive with extended range
-            dramatic: {
-                // Device beta (front-back tilt) -> 4D XW rotation
-                betaToXW: {
-                    scale: 0.08, // 8x more sensitive!
-                    range: [-120, 120], // Extended range for dramatic effects
-                    clamp: [-6.0, 6.0] // Much wider 4D rotation limits
-                },
-                // Device gamma (left-right tilt) -> 4D YW rotation  
-                gammaToYW: {
-                    scale: 0.12, // 8x more sensitive!
-                    range: [-120, 120], // Extended range
-                    clamp: [-6.0, 6.0]
-                },
-                // Device alpha (compass heading) -> 4D ZW rotation
-                alphaToZW: {
-                    scale: 0.064, // 8x more sensitive!
-                    range: [-180, 180],
-                    clamp: [-6.0, 6.0]
-                }
-            }
+        // Base parameters for restoration
+        this.baseParameters = {
+            dimension: 3.5,
+            morphFactor: 1.0,
+            chaos: 0.2,
+            intensity: 0.8,
+            gridDensity: 15
         };
         
         this.boundHandleDeviceOrientation = this.handleDeviceOrientation.bind(this);
+    }
+    
+    /**
+     * 🌐 GEOMETRIC TILT WINDOW SYSTEM
+     * Maps device tilt to visual rotation + 4D depth exploration
+     */
+    calculateGeometricWindow(alpha, beta, gamma) {
+        // Convert to degrees for easier geometric calculations
+        const alphaDeg = alpha;
+        const betaDeg = beta;  
+        const gammaDeg = gamma;
+        
+        // 1. CALCULATE TILT INTENSITY (how far from level)
+        const tiltIntensity = Math.sqrt(betaDeg*betaDeg + gammaDeg*gammaDeg) / 90; // 0-1+ range
+        const extremeTilt = tiltIntensity > 0.7;
+        
+        // 2. VISUAL ROTATION MATCHING (1:1 with device tilt)
+        const visualRotation = {
+            // Device tilts physically match visual grid rotation
+            rotateX: betaDeg * 0.8,  // Front-back tilt → X-axis visual rotation
+            rotateY: alphaDeg * 0.2, // Compass → slight Y-axis rotation  
+            rotateZ: gammaDeg * 0.8  // Left-right tilt → Z-axis visual rotation
+        };
+        
+        // 3. WINDOW DEPTH PROGRESSION (more tilt = deeper into 4D)
+        const windowDepth = {
+            // Tilt intensity determines how "deep" through window you're looking
+            depthMultiplier: 1 + tiltIntensity * 2.5, // 1x to 3.5x depth
+            
+            // 4D parameters based on window depth
+            dimension: this.baseParameters.dimension + tiltIntensity * 1.8, // 3.5 to 5.3
+            morphFactor: this.baseParameters.morphFactor + tiltIntensity * 1.2, // More morph when deeper
+            chaos: Math.min(0.9, this.baseParameters.chaos + (tiltIntensity * tiltIntensity) * 0.6), // Quadratic chaos increase
+            intensity: Math.min(1.0, this.baseParameters.intensity + tiltIntensity * 0.3), // Brighter when deeper
+            gridDensity: this.baseParameters.gridDensity * (1 + tiltIntensity * 0.8) // More detail when deeper
+        };
+        
+        // 4. 4D ROTATION BASED ON VIEWING ANGLE
+        const viewingAngle4D = {
+            // Combine base rotation with tilt-based 4D exploration
+            rot4dXW: this.baseRotation.rot4dXW + (betaDeg * Math.PI / 180) * 0.025 * windowDepth.depthMultiplier,
+            rot4dYW: this.baseRotation.rot4dYW + (gammaDeg * Math.PI / 180) * 0.035 * windowDepth.depthMultiplier,  
+            rot4dZW: this.baseRotation.rot4dZW + (alphaDeg * Math.PI / 180) * 0.015 * windowDepth.depthMultiplier
+        };
+        
+        // 5. PERSPECTIVE DISTORTION EFFECTS
+        const perspectiveEffects = {
+            // Grid scaling based on viewing angle (like looking through thick glass)
+            scaleX: 1 + Math.abs(gammaDeg) / 300, // Horizontal tilt → horizontal stretch
+            scaleY: 1 + Math.abs(betaDeg) / 300,  // Vertical tilt → vertical stretch
+            
+            // Edge complexity (extreme angles show more detail)
+            edgeComplexity: extremeTilt ? 0.4 : 0,
+            
+            // Visual filters for angled viewing
+            brightness: 1 + tiltIntensity * 0.15,
+            contrast: 1 + tiltIntensity * 0.1
+        };
+        
+        return {
+            tiltIntensity,
+            extremeTilt,
+            visualRotation,
+            windowDepth,
+            viewingAngle4D,
+            perspectiveEffects
+        };
+    }
+    
+    /**
+     * Apply geometric window effects to the visualization
+     */
+    applyGeometricWindow(windowData) {
+        const { visualRotation, windowDepth, viewingAngle4D, perspectiveEffects, tiltIntensity } = windowData;
+        
+        // 1. Calculate dynamic scaling to fill perspective view (prevents background showing)
+        const tiltScale = 1 + (tiltIntensity * 0.6); // 1.0x to 1.6x scaling based on tilt intensity
+        const maxTilt = Math.max(Math.abs(visualRotation.rotateX), Math.abs(visualRotation.rotateZ));
+        const clampedScale = Math.min(tiltScale, 1.8); // Cap at 1.8x to avoid too much zoom
+        
+        // 2. Apply visual CSS rotation with dynamic scaling to match device tilt
+        const canvases = document.querySelectorAll('canvas');
+        canvases.forEach(canvas => {
+            if (canvas) {
+                // Limit tilt angles to prevent edge-on view
+                const clampedRotateX = Math.max(-45, Math.min(45, visualRotation.rotateX));
+                const clampedRotateZ = Math.max(-45, Math.min(45, visualRotation.rotateZ));
+                
+                canvas.style.transform = `
+                    perspective(1500px)
+                    rotateX(${clampedRotateX}deg) 
+                    rotateY(${visualRotation.rotateY}deg) 
+                    rotateZ(${clampedRotateZ}deg)
+                    scale3d(${clampedScale * perspectiveEffects.scaleX}, ${clampedScale * perspectiveEffects.scaleY}, 1)
+                `;
+                canvas.style.filter = `
+                    brightness(${perspectiveEffects.brightness}) 
+                    contrast(${perspectiveEffects.contrast})
+                `;
+            }
+        });
+        
+        // 3. Add dark background overlay when tilting to hide any gaps
+        const portalWindow = document.getElementById('portalWindow');
+        if (portalWindow) {
+            if (tiltIntensity > 0.3) {
+                portalWindow.style.backgroundColor = 'rgba(0, 0, 0, 0.1)';
+            } else {
+                portalWindow.style.backgroundColor = 'transparent';
+            }
+        }
+        
+        // 2. Update 4D rotation parameters
+        if (window.updateParameter) {
+            window.updateParameter('rot4dXW', viewingAngle4D.rot4dXW);
+            window.updateParameter('rot4dYW', viewingAngle4D.rot4dYW);
+            window.updateParameter('rot4dZW', viewingAngle4D.rot4dZW);
+        }
+        
+        // 3. Update window depth parameters
+        if (window.updateParameter) {
+            window.updateParameter('dimension', windowDepth.dimension);
+            window.updateParameter('morphFactor', windowDepth.morphFactor);
+            window.updateParameter('chaos', windowDepth.chaos);
+            window.updateParameter('intensity', windowDepth.intensity);
+            window.updateParameter('gridDensity', windowDepth.gridDensity);
+        }
+        
+        // 4. Update body class for CSS effects
+        document.body.classList.toggle('extreme-tilt', windowData.extremeTilt);
+        document.body.classList.toggle('geometric-tilt-active', windowData.tiltIntensity > 0.1);
+    }
+    
+    /**
+     * Reset visual effects to normal
+     */
+    resetGeometricWindow() {
+        // Reset canvas transforms
+        const canvases = document.querySelectorAll('canvas');
+        canvases.forEach(canvas => {
+            if (canvas) {
+                canvas.style.transform = '';
+                canvas.style.filter = '';
+            }
+        });
+        
+        // Reset parameters to base values
+        if (window.updateParameter) {
+            window.updateParameter('rot4dXW', this.baseRotation.rot4dXW);
+            window.updateParameter('rot4dYW', this.baseRotation.rot4dYW);
+            window.updateParameter('rot4dZW', this.baseRotation.rot4dZW);
+            window.updateParameter('dimension', this.baseParameters.dimension);
+            window.updateParameter('morphFactor', this.baseParameters.morphFactor);
+            window.updateParameter('chaos', this.baseParameters.chaos);
+            window.updateParameter('intensity', this.baseParameters.intensity);
+            window.updateParameter('gridDensity', this.baseParameters.gridDensity);
+        }
+        
+        // Remove CSS classes
+        document.body.classList.remove('extreme-tilt', 'geometric-tilt-active');
     }
     
     /**
@@ -93,17 +211,17 @@ export class DeviceTiltHandler {
         this.isSupported = 'DeviceOrientationEvent' in window;
         
         if (!this.isSupported) {
-            console.warn('🎯 DEVICE TILT: Not supported on this device/browser');
+            console.warn('🌐 GEOMETRIC TILT WINDOW: Not supported on this device/browser');
             return false;
         }
         
         // Check for iOS 13+ permission requirement
         if (typeof DeviceOrientationEvent.requestPermission === 'function') {
-            console.log('🎯 DEVICE TILT: iOS device detected - permission required');
+            console.log('🌐 GEOMETRIC TILT WINDOW: iOS device detected - permission required');
             return 'permission-required';
         }
         
-        console.log('🎯 DEVICE TILT: Supported and ready');
+        console.log('🌐 GEOMETRIC TILT WINDOW: Supported and ready');
         return true;
     }
     
@@ -115,14 +233,14 @@ export class DeviceTiltHandler {
             try {
                 const permission = await DeviceOrientationEvent.requestPermission();
                 if (permission === 'granted') {
-                    console.log('🎯 DEVICE TILT: iOS permission granted');
+                    console.log('🌐 GEOMETRIC TILT WINDOW: iOS permission granted');
                     return true;
                 } else {
-                    console.warn('🎯 DEVICE TILT: iOS permission denied');
+                    console.warn('🌐 GEOMETRIC TILT WINDOW: iOS permission denied');
                     return false;
                 }
             } catch (error) {
-                console.error('🎯 DEVICE TILT: Permission request failed:', error);
+                console.error('🌐 GEOMETRIC TILT WINDOW: Permission request failed:', error);
                 return false;
             }
         }
@@ -130,7 +248,7 @@ export class DeviceTiltHandler {
     }
     
     /**
-     * Enable device tilt control
+     * Enable geometric tilt window system
      */
     async enable() {
         if (!this.checkSupport()) {
@@ -148,136 +266,71 @@ export class DeviceTiltHandler {
             this.baseRotation.rot4dXW = window.userParameterState.rot4dXW || 0;
             this.baseRotation.rot4dYW = window.userParameterState.rot4dYW || 0;
             this.baseRotation.rot4dZW = window.userParameterState.rot4dZW || 0;
+            this.baseParameters.dimension = window.userParameterState.dimension || 3.5;
+            this.baseParameters.morphFactor = window.userParameterState.morphFactor || 1.0;
+            this.baseParameters.chaos = window.userParameterState.chaos || 0.2;
+            this.baseParameters.intensity = window.userParameterState.intensity || 0.8;
+            this.baseParameters.gridDensity = window.userParameterState.gridDensity || 15;
         }
         
-        // Initialize smoothed values to current base
-        this.smoothedRotation = { ...this.baseRotation };
+        // Initialize smoothed values
+        this.smoothedTilt = { ...this.currentTilt };
         
         window.addEventListener('deviceorientation', this.boundHandleDeviceOrientation);
         this.isEnabled = true;
         
-        console.log('🎯 DEVICE TILT: Enabled - tilt your device to control 4D rotation!');
-        console.log('🎯 Base rotation values:', this.baseRotation);
-        
-        // Show tilt UI indicator
-        this.showTiltIndicator(true);
+        console.log('🌐 GEOMETRIC TILT WINDOW: Enabled - tilt device to change viewing angle!');
+        console.log('🌐 Physical tilt will match visual rotation + explore 4D depth');
         
         return true;
     }
     
     /**
-     * Disable device tilt control
+     * Disable geometric tilt window system
      */
     disable() {
         window.removeEventListener('deviceorientation', this.boundHandleDeviceOrientation);
         this.isEnabled = false;
         
-        // Reset to base rotation values
-        if (window.updateParameter) {
-            window.updateParameter('rot4dXW', this.baseRotation.rot4dXW);
-            window.updateParameter('rot4dYW', this.baseRotation.rot4dYW);
-            window.updateParameter('rot4dZW', this.baseRotation.rot4dZW);
-        }
+        // Reset all visual effects
+        this.resetGeometricWindow();
         
-        console.log('🎯 DEVICE TILT: Disabled - reset to base rotation');
-        
-        // Hide tilt UI indicator
-        this.showTiltIndicator(false);
+        console.log('🌐 GEOMETRIC TILT WINDOW: Disabled - reset to normal view');
     }
     
     /**
-     * Handle device orientation changes
+     * Handle device orientation changes with geometric window logic
      */
     handleDeviceOrientation(event) {
         if (!this.isEnabled) return;
         
-        // Get raw orientation values (convert to radians)
-        const alpha = (event.alpha || 0) * Math.PI / 180; // Z-axis (compass)
-        const beta = (event.beta || 0) * Math.PI / 180;   // X-axis (front-back)
-        const gamma = (event.gamma || 0) * Math.PI / 180; // Y-axis (left-right)
+        // Get raw orientation values (keep in degrees)
+        const alpha = event.alpha || 0; // Z-axis (compass)
+        const beta = event.beta || 0;   // X-axis (front-back)
+        const gamma = event.gamma || 0; // Y-axis (left-right)
         
         // Update current tilt values
         this.currentTilt = { alpha, beta, gamma };
         
-        // Map device orientation to 4D rotation values
-        const targetRotation = this.mapToRotation(event);
-        
         // Apply smoothing to prevent jittery movement
-        this.smoothedRotation.rot4dXW = this.lerp(
-            this.smoothedRotation.rot4dXW,
-            targetRotation.rot4dXW,
-            this.smoothing
+        this.smoothedTilt.alpha = this.lerp(this.smoothedTilt.alpha, alpha, this.smoothing);
+        this.smoothedTilt.beta = this.lerp(this.smoothedTilt.beta, beta, this.smoothing);
+        this.smoothedTilt.gamma = this.lerp(this.smoothedTilt.gamma, gamma, this.smoothing);
+        
+        // Calculate geometric window effects
+        const windowData = this.calculateGeometricWindow(
+            this.smoothedTilt.alpha,
+            this.smoothedTilt.beta, 
+            this.smoothedTilt.gamma
         );
         
-        this.smoothedRotation.rot4dYW = this.lerp(
-            this.smoothedRotation.rot4dYW,
-            targetRotation.rot4dYW,
-            this.smoothing
-        );
+        // Apply all effects to visualization
+        this.applyGeometricWindow(windowData);
         
-        this.smoothedRotation.rot4dZW = this.lerp(
-            this.smoothedRotation.rot4dZW,
-            targetRotation.rot4dZW,
-            this.smoothing
-        );
-        
-        // Apply to visualization system
-        if (window.updateParameter) {
-            window.updateParameter('rot4dXW', this.smoothedRotation.rot4dXW);
-            window.updateParameter('rot4dYW', this.smoothedRotation.rot4dYW);
-            window.updateParameter('rot4dZW', this.smoothedRotation.rot4dZW);
+        // Debug logging
+        if (Math.random() < 0.02) { // Log occasionally to avoid spam
+            console.log(`🌐 GEOMETRIC WINDOW: Tilt(${beta.toFixed(1)}°, ${gamma.toFixed(1)}°) → Visual(${windowData.visualRotation.rotateX.toFixed(1)}°, ${windowData.visualRotation.rotateZ.toFixed(1)}°) Depth:${windowData.windowDepth.depthMultiplier.toFixed(2)}x`);
         }
-        
-        // Update UI display if available
-        this.updateTiltDisplay();
-    }
-    
-    /**
-     * Map device orientation to 4D rotation parameters
-     */
-    mapToRotation(event) {
-        const betaDeg = event.beta || 0;  // Front-back tilt (-180 to 180)
-        const gammaDeg = event.gamma || 0; // Left-right tilt (-90 to 90)
-        const alphaDeg = event.alpha || 0; // Compass heading (0 to 360)
-        
-        // 🚀 DRAMATIC MODE: Choose mapping configuration
-        const activeMapping = this.dramaticMode ? this.mapping.dramatic : this.mapping.normal;
-        
-        // 🚀 CALCULATE TILT INTENSITY for dramatic effects
-        const betaNorm = Math.max(-120, Math.min(120, betaDeg));
-        const gammaNorm = Math.max(-120, Math.min(120, gammaDeg));
-        this.tiltIntensity = Math.sqrt(betaNorm*betaNorm + gammaNorm*gammaNorm) / 90;
-        this.extremeTilt = this.tiltIntensity > 1.0;
-        
-        // Map beta (front-back tilt) to XW rotation
-        const betaClamped = Math.max(activeMapping.betaToXW.range[0], 
-            Math.min(activeMapping.betaToXW.range[1], betaDeg));
-        const rot4dXW = this.baseRotation.rot4dXW + 
-            (betaClamped * activeMapping.betaToXW.scale * this.sensitivity);
-        
-        // Map gamma (left-right tilt) to YW rotation
-        const gammaClamped = Math.max(activeMapping.gammaToYW.range[0],
-            Math.min(activeMapping.gammaToYW.range[1], gammaDeg));
-        const rot4dYW = this.baseRotation.rot4dYW + 
-            (gammaClamped * activeMapping.gammaToYW.scale * this.sensitivity);
-        
-        // Map alpha (compass) to ZW rotation
-        let alphaNormalized = alphaDeg;
-        if (alphaNormalized > 180) alphaNormalized -= 360; // Normalize to -180 to 180
-        const alphaClamped = Math.max(activeMapping.alphaToZW.range[0],
-            Math.min(activeMapping.alphaToZW.range[1], alphaNormalized));
-        const rot4dZW = this.baseRotation.rot4dZW + 
-            (alphaClamped * activeMapping.alphaToZW.scale * this.sensitivity);
-        
-        // Apply final clamping to prevent extreme values
-        return {
-            rot4dXW: Math.max(activeMapping.betaToXW.clamp[0],
-                Math.min(activeMapping.betaToXW.clamp[1], rot4dXW)),
-            rot4dYW: Math.max(activeMapping.gammaToYW.clamp[0],
-                Math.min(activeMapping.gammaToYW.clamp[1], rot4dYW)),
-            rot4dZW: Math.max(activeMapping.alphaToZW.clamp[0],
-                Math.min(activeMapping.alphaToZW.clamp[1], rot4dZW))
-        };
     }
     
     /**
@@ -288,273 +341,21 @@ export class DeviceTiltHandler {
     }
     
     /**
-     * Update base rotation values (from preset loading or manual adjustment)
+     * Get current tilt status for UI display
      */
-    updateBaseRotation(rot4dXW, rot4dYW, rot4dZW) {
-        this.baseRotation.rot4dXW = rot4dXW || 0;
-        this.baseRotation.rot4dYW = rot4dYW || 0;
-        this.baseRotation.rot4dZW = rot4dZW || 0;
+    getTiltStatus() {
+        if (!this.isEnabled) return { enabled: false };
         
-        console.log('🎯 DEVICE TILT: Base rotation updated:', this.baseRotation);
-    }
-    
-    /**
-     * Set tilt sensitivity (0.1 to 3.0)
-     */
-    setSensitivity(value) {
-        this.sensitivity = Math.max(0.1, Math.min(3.0, value));
-        console.log(`🎯 DEVICE TILT: Sensitivity set to ${this.sensitivity}`);
-    }
-    
-    /**
-     * Set smoothing factor (0.01 to 1.0)
-     */
-    setSmoothing(value) {
-        this.smoothing = Math.max(0.01, Math.min(1.0, value));
-        console.log(`🎯 DEVICE TILT: Smoothing set to ${this.smoothing}`);
-    }
-    
-    /**
-     * 🚀 Enable/disable dramatic tilting mode
-     */
-    setDramaticMode(enabled) {
-        this.dramaticMode = enabled;
-        console.log(`🚀 DEVICE TILT: Dramatic mode ${enabled ? 'ENABLED - 8x more sensitive!' : 'disabled - normal sensitivity'}`);
+        const tiltIntensity = Math.sqrt(
+            this.currentTilt.beta * this.currentTilt.beta + 
+            this.currentTilt.gamma * this.currentTilt.gamma
+        ) / 90;
         
-        // Update UI indicator to show mode
-        this.updateTiltModeDisplay();
-        
-        // If dramatic mode is enabled and tilt is active, show warning about extreme effects
-        if (enabled && this.isEnabled) {
-            console.log('⚠️ DRAMATIC TILTING ACTIVE: Tilt your device carefully - effects are 8x more intense!');
-        }
-    }
-    
-    /**
-     * 🚀 Toggle dramatic tilting mode
-     */
-    toggleDramaticMode() {
-        this.setDramaticMode(!this.dramaticMode);
-        return this.dramaticMode;
-    }
-    
-    /**
-     * Show/hide tilt indicator UI
-     */
-    showTiltIndicator(show) {
-        let indicator = document.getElementById('tilt-indicator');
-        
-        if (show && !indicator) {
-            // Create tilt indicator
-            indicator = document.createElement('div');
-            indicator.id = 'tilt-indicator';
-            indicator.innerHTML = `
-                <div class="tilt-status">
-                    <div class="tilt-icon">📱</div>
-                    <div class="tilt-text">4D Tilt Active</div>
-                    <div class="tilt-mode" id="tilt-mode">NORMAL MODE</div>
-                    <div class="tilt-values">
-                        <span id="tilt-xw">XW: 0.00</span>
-                        <span id="tilt-yw">YW: 0.00</span>
-                        <span id="tilt-zw">ZW: 0.00</span>
-                        <span id="tilt-intensity">Intensity: 0.00</span>
-                    </div>
-                </div>
-            `;
-            
-            indicator.style.cssText = `
-                position: fixed;
-                top: 10px;
-                right: 10px;
-                background: rgba(0, 0, 0, 0.8);
-                color: #0ff;
-                padding: 8px 12px;
-                border-radius: 8px;
-                font-family: 'Orbitron', monospace;
-                font-size: 11px;
-                z-index: 10000;
-                backdrop-filter: blur(10px);
-                border: 1px solid rgba(0, 255, 255, 0.3);
-                box-shadow: 0 0 15px rgba(0, 255, 255, 0.2);
-            `;
-            
-            document.body.appendChild(indicator);
-        } else if (!show && indicator) {
-            // Remove tilt indicator
-            indicator.remove();
-        }
-    }
-    
-    /**
-     * Update tilt display values
-     */
-    updateTiltDisplay() {
-        const xwDisplay = document.getElementById('tilt-xw');
-        const ywDisplay = document.getElementById('tilt-yw');
-        const zwDisplay = document.getElementById('tilt-zw');
-        const intensityDisplay = document.getElementById('tilt-intensity');
-        
-        if (xwDisplay) xwDisplay.textContent = `XW: ${this.smoothedRotation.rot4dXW.toFixed(2)}`;
-        if (ywDisplay) ywDisplay.textContent = `YW: ${this.smoothedRotation.rot4dYW.toFixed(2)}`;
-        if (zwDisplay) zwDisplay.textContent = `ZW: ${this.smoothedRotation.rot4dZW.toFixed(2)}`;
-        if (intensityDisplay) {
-            intensityDisplay.textContent = `Intensity: ${this.tiltIntensity.toFixed(2)}`;
-            // 🚀 Color intensity display based on extreme tilt
-            intensityDisplay.style.color = this.extremeTilt ? '#ff4444' : '#0ff';
-        }
-    }
-    
-    /**
-     * 🚀 Update tilt mode display
-     */
-    updateTiltModeDisplay() {
-        const modeDisplay = document.getElementById('tilt-mode');
-        if (modeDisplay) {
-            modeDisplay.textContent = this.dramaticMode ? '🚀 DRAMATIC MODE' : 'NORMAL MODE';
-            modeDisplay.style.color = this.dramaticMode ? '#ff4444' : '#0ff';
-            modeDisplay.style.fontWeight = this.dramaticMode ? 'bold' : 'normal';
-        }
-    }
-    
-    /**
-     * Get current tilt status
-     */
-    getStatus() {
         return {
-            isSupported: this.isSupported,
-            isEnabled: this.isEnabled,
-            sensitivity: this.sensitivity,
-            smoothing: this.smoothing,
-            currentTilt: { ...this.currentTilt },
-            smoothedRotation: { ...this.smoothedRotation },
-            baseRotation: { ...this.baseRotation }
+            enabled: true,
+            tiltIntensity: tiltIntensity,
+            angles: { ...this.currentTilt },
+            extremeTilt: tiltIntensity > 0.7
         };
     }
 }
-
-// Create global instance with enhanced toggle function
-if (typeof window !== 'undefined') {
-    window.deviceTiltHandler = new DeviceTiltHandler();
-    
-    // Add to global functions for UI integration
-    window.enableDeviceTilt = async () => {
-        return await window.deviceTiltHandler.enable();
-    };
-    
-    window.disableDeviceTilt = () => {
-        window.deviceTiltHandler.disable();
-    };
-    
-    // Enhanced toggle function that forces interactivity to mouse movement mode
-    window.toggleDeviceTilt = async () => {
-        const tiltBtn = document.getElementById('tiltBtn');
-        
-        if (window.deviceTiltHandler.isEnabled) {
-            // Disable tilt
-            window.deviceTiltHandler.disable();
-            if (tiltBtn) {
-                tiltBtn.style.background = '';
-                tiltBtn.style.color = '';
-                tiltBtn.title = 'Device Tilt (4D Rotation)';
-            }
-            console.log('🎯 Device tilt disabled');
-            return false;
-        } else {
-            // Enable tilt AND force interactivity to mouse movement mode
-            const enabled = await window.deviceTiltHandler.enable();
-            if (enabled) {
-                // FORCE the interactivity system to mouse movement mode (same as device tilt behavior)
-                if (window.interactivityMenu && window.interactivityMenu.engine) {
-                    // Force to mouse/touch mode since tilt = mouse movement behavior
-                    window.interactivityMenu.engine.setActiveInputMode('mouse/touch');
-                    console.log('🎯 Forced interactivity to mouse/touch mode (matches tilt behavior)');
-                    
-                    // ✅ NEW: Update menu display to show the mode change
-                    setTimeout(() => {
-                        if (window.interactivityMenu.updateInputSources) {
-                            window.interactivityMenu.updateInputSources();
-                        }
-                    }, 100);
-                }
-                
-                // ✅ NEW: Ensure interactivity is enabled when tilt is enabled
-                if (window.interactivityEnabled !== undefined) {
-                    window.interactivityEnabled = true;
-                    const interactBtn = document.querySelector('[onclick="toggleInteractivity()"]');
-                    if (interactBtn) {
-                        interactBtn.style.background = 'rgba(0, 255, 0, 0.3)';
-                        interactBtn.style.borderColor = '#00ff00';
-                        interactBtn.title = 'Mouse/Touch Interactions: ON (Auto-enabled by tilt)';
-                    }
-                }
-                
-                if (tiltBtn) {
-                    tiltBtn.style.background = 'linear-gradient(45deg, #00ffff, #0099ff)';
-                    tiltBtn.style.color = '#000';
-                    tiltBtn.title = 'Device Tilt Active + Mouse Movement Mode - Both work together!';
-                }
-                console.log('🎯 Device tilt enabled');
-                console.log('🖱️ Interactivity forced to mouse movement mode (compatible with tilt)');
-                return true;
-            } else {
-                console.warn('🎯 Device tilt failed to enable - permission may be required');
-                if (tiltBtn) {
-                    tiltBtn.style.background = 'rgba(255, 0, 0, 0.3)';
-                    tiltBtn.title = 'Device Tilt (Permission Required - Click to try again)';
-                }
-                return false;
-            }
-        }
-    };
-    
-    window.setTiltSensitivity = (value) => {
-        window.deviceTiltHandler.setSensitivity(value);
-    };
-    
-    // 🚀 NEW: Dramatic tilting mode functions
-    window.setDramaticTilting = (enabled) => {
-        window.deviceTiltHandler.setDramaticMode(enabled);
-    };
-    
-    window.toggleDramaticTilting = () => {
-        return window.deviceTiltHandler.toggleDramaticMode();
-    };
-    
-    // 🚀 NEW: Enhanced toggle that can enable dramatic mode
-    window.toggleDeviceTiltDramatic = async () => {
-        if (!window.deviceTiltHandler.isEnabled) {
-            // First enable tilt
-            const enabled = await window.toggleDeviceTilt();
-            if (enabled) {
-                // Then enable dramatic mode
-                window.deviceTiltHandler.setDramaticMode(true);
-                console.log('🚀 DRAMATIC TILTING ENABLED: 8x more sensitive! Tilt carefully!');
-                
-                const tiltBtn = document.getElementById('tiltBtn');
-                if (tiltBtn) {
-                    tiltBtn.style.background = 'linear-gradient(45deg, #ff4444, #ff0080)';
-                    tiltBtn.title = '🚀 DRAMATIC 4D Tilt Active - 8x More Sensitive!';
-                }
-            }
-            return enabled;
-        } else {
-            // Toggle dramatic mode if tilt is already enabled
-            const dramatic = window.deviceTiltHandler.toggleDramaticMode();
-            const tiltBtn = document.getElementById('tiltBtn');
-            if (tiltBtn) {
-                if (dramatic) {
-                    tiltBtn.style.background = 'linear-gradient(45deg, #ff4444, #ff0080)';
-                    tiltBtn.title = '🚀 DRAMATIC 4D Tilt Active - 8x More Sensitive!';
-                } else {
-                    tiltBtn.style.background = 'linear-gradient(45deg, #00ffff, #0099ff)';
-                    tiltBtn.title = 'Device Tilt Active - Normal Sensitivity';
-                }
-            }
-            return dramatic;
-        }
-    };
-    
-    console.log('🎯 DEVICE TILT: System loaded with DRAMATIC MODE support! 🚀');
-}
-
-export default DeviceTiltHandler;

--- a/scripts/orthogonal-depth-progression.js
+++ b/scripts/orthogonal-depth-progression.js
@@ -1,589 +1,1380 @@
-/**
- * ORTHOGONAL DEPTH PROGRESSION SYSTEM
- * Professional avant-garde card progression through Z-axis depth
- * Cards emerge from screen depths with portal-style text visualizers
- * A Paul Phillips Manifestation - Paul@clearseassolutions.com
- */
+import { DeviceTiltHandler } from '../js/interactions/device-tilt.js';
+import { RealHolographicSystem } from '../src/holograms/RealHolographicSystem.js';
+import { HolographicVisualizer } from '../src/holograms/HolographicVisualizer.js';
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const SECTION_PRESETS = {
+  quantum: {
+    variant: 5,
+    parameters: {
+      gridDensity: 68,
+      morphFactor: 1.1,
+      chaos: 0.32,
+      intensity: 0.88,
+      speed: 0.82,
+      hue: 195,
+      saturation: 0.88
+    }
+  },
+  holographic: {
+    variant: 13,
+    parameters: {
+      gridDensity: 60,
+      morphFactor: 0.95,
+      chaos: 0.28,
+      intensity: 0.92,
+      speed: 0.9,
+      hue: 305,
+      saturation: 0.93
+    }
+  },
+  faceted: {
+    variant: 26,
+    parameters: {
+      gridDensity: 74,
+      morphFactor: 0.72,
+      chaos: 0.22,
+      intensity: 0.9,
+      speed: 0.65,
+      hue: 140,
+      saturation: 0.86
+    }
+  },
+  neural: {
+    variant: 21,
+    parameters: {
+      gridDensity: 66,
+      morphFactor: 1.25,
+      chaos: 0.38,
+      intensity: 0.94,
+      speed: 1.05,
+      hue: 255,
+      saturation: 0.91
+    }
+  }
+};
+
+const DEFAULT_PARAMETER_STATE = {
+  rot4dXW: 0,
+  rot4dYW: 0,
+  rot4dZW: 0,
+  dimension: 3.5,
+  morphFactor: 1.0,
+  chaos: 0.3,
+  intensity: 0.85,
+  gridDensity: 55,
+  hue: 210,
+  saturation: 0.85,
+  speed: 0.75
+};
+
+const gridDensityToVariant = (value = DEFAULT_PARAMETER_STATE.gridDensity) => 0.3 + ((value ?? DEFAULT_PARAMETER_STATE.gridDensity) - 5) / 95 * 2.2;
+
+class HolographicBackdrop {
+  constructor() {
+    this.system = null;
+    this.currentSection = null;
+    this.currentParams = new Map();
+    this.initialize();
+  }
+
+  initialize() {
+    try {
+      this.system = new RealHolographicSystem();
+      if (typeof this.system.setActive === 'function') {
+        this.system.setActive(true);
+      }
+      window.holographicSystem = this.system;
+      console.log('✅ Holographic backdrop initialized');
+    } catch (error) {
+      console.error('❌ Failed to initialize holographic system:', error);
+    }
+  }
+
+  applyParameter(param, value) {
+    if (!this.system || value === undefined || Number.isNaN(value)) {
+      return;
+    }
+    const prev = this.currentParams.get(param);
+    if (prev === undefined || Math.abs(prev - value) >= 0.001) {
+      this.currentParams.set(param, value);
+      this.system.updateParameter(param, value);
+      if (window.userParameterState) {
+        window.userParameterState[param] = value;
+      }
+    }
+  }
+
+  applyPreset(section) {
+    if (!this.system) {
+      return;
+    }
+    const preset = SECTION_PRESETS[section];
+    this.currentSection = section;
+    if (preset && typeof preset.variant === 'number' && typeof this.system.updateVariant === 'function') {
+      this.system.updateVariant(preset.variant);
+    }
+    if (preset?.parameters) {
+      Object.entries(preset.parameters).forEach(([param, value]) => {
+        this.applyParameter(param, value);
+      });
+    }
+  }
+
+  updateTilt({ tiltX = 0, tiltY = 0, intensity = 0, rotation } = {}) {
+    const rotationPayload = rotation || {
+      rot4dXW: clamp(tiltY * 2.1, -2.6, 2.6),
+      rot4dYW: clamp(tiltX * 2.1, -2.6, 2.6),
+      rot4dZW: clamp((tiltX - tiltY) * 1.5, -2.3, 2.3)
+    };
+    this.applyParameter('rot4dXW', rotationPayload.rot4dXW);
+    this.applyParameter('rot4dYW', rotationPayload.rot4dYW);
+    this.applyParameter('rot4dZW', rotationPayload.rot4dZW);
+
+    const base = SECTION_PRESETS[this.currentSection]?.parameters || {};
+    const baseSpeed = base.speed ?? DEFAULT_PARAMETER_STATE.speed;
+    this.applyParameter('speed', baseSpeed + intensity * 0.45);
+
+    if (!rotation) {
+      const baseChaos = base.chaos ?? DEFAULT_PARAMETER_STATE.chaos;
+      const baseMorph = base.morphFactor ?? DEFAULT_PARAMETER_STATE.morphFactor;
+      this.applyParameter('chaos', baseChaos + intensity * 0.3);
+      this.applyParameter('morphFactor', baseMorph + intensity * 0.25);
+    }
+  }
+
+  triggerHypercubeFold() {
+    const preset = SECTION_PRESETS[this.currentSection]?.parameters || {};
+    const baseChaos = preset.chaos ?? DEFAULT_PARAMETER_STATE.chaos;
+    const baseSpeed = preset.speed ?? DEFAULT_PARAMETER_STATE.speed;
+    this.applyParameter('chaos', baseChaos + 0.35);
+    this.applyParameter('speed', baseSpeed + 0.6);
+    setTimeout(() => {
+      if (this.currentSection) {
+        this.applyPreset(this.currentSection);
+      }
+    }, 900);
+  }
+}
+
+class CardVisualizer {
+  constructor(card) {
+    this.card = card;
+    this.section = card.dataset.section || 'quantum';
+    this.canvas = card.querySelector('canvas');
+    const variant = SECTION_PRESETS[this.section]?.variant ?? 0;
+    this.visualizer = this.canvas ? new HolographicVisualizer(this.canvas.id, 'content', 1.0, variant) : null;
+    this.currentParams = { ...(SECTION_PRESETS[this.section]?.parameters || {}) };
+    this.tiltState = { tiltX: 0, tiltY: 0, intensity: 0 };
+    this.transitionState = { phase: 'far-depth', startTime: performance.now() };
+
+    if (this.visualizer) {
+      this.applyPreset();
+      this.start();
+    }
+  }
+
+  applyPreset() {
+    if (!this.visualizer) return;
+    const preset = SECTION_PRESETS[this.section];
+    if (preset && typeof preset.variant === 'number') {
+      this.visualizer.variant = preset.variant;
+      this.visualizer.variantParams = this.visualizer.generateVariantParams(preset.variant);
+      this.visualizer.roleParams = this.visualizer.generateRoleParams(this.visualizer.role);
+    }
+    this.applyParameterSet(this.currentParams);
+  }
+
+  applyParameterSet(params = {}) {
+    Object.entries(params).forEach(([param, value]) => this.handleParameter(param, value));
+  }
+
+  updateTilt(tiltX, tiltY, intensity) {
+    this.tiltState = { tiltX, tiltY, intensity };
+  }
+
+  setTransitionPhase(phase = 'far-depth') {
+    this.transitionState = { phase, startTime: performance.now() };
+  }
+
+  handleParameter(param, value) {
+    if (!this.visualizer || value === undefined || Number.isNaN(value)) return;
+    this.currentParams[param] = value;
+    switch (param) {
+      case 'gridDensity':
+        this.visualizer.variantParams.density = gridDensityToVariant(value);
+        break;
+      case 'morphFactor':
+        this.visualizer.variantParams.morph = value;
+        break;
+      case 'chaos':
+        this.visualizer.variantParams.chaos = value;
+        break;
+      case 'intensity':
+        this.visualizer.variantParams.intensity = value;
+        break;
+      case 'speed':
+        this.visualizer.variantParams.speed = value;
+        break;
+      case 'hue':
+        this.visualizer.variantParams.hue = value;
+        break;
+      case 'saturation':
+        this.visualizer.variantParams.saturation = value;
+        break;
+      case 'rot4dXW':
+        this.visualizer.variantParams.rot4dXW = value;
+        break;
+      case 'rot4dYW':
+        this.visualizer.variantParams.rot4dYW = value;
+        break;
+      case 'rot4dZW':
+        this.visualizer.variantParams.rot4dZW = value;
+        break;
+      default:
+        break;
+    }
+  }
+
+  applyDynamicModulation() {
+    if (!this.visualizer) return;
+    const { tiltX, tiltY, intensity } = this.tiltState;
+    const rotationScale = 2.2;
+    this.visualizer.variantParams.rot4dXW = clamp(tiltY * rotationScale, -2.7, 2.7);
+    this.visualizer.variantParams.rot4dYW = clamp(tiltX * rotationScale, -2.7, 2.7);
+    this.visualizer.variantParams.rot4dZW = clamp((tiltX - tiltY) * 1.6, -2.3, 2.3);
+
+    const preset = SECTION_PRESETS[this.section]?.parameters || {};
+    const baseSpeed = this.currentParams.speed ?? preset.speed ?? DEFAULT_PARAMETER_STATE.speed;
+    const baseChaos = this.currentParams.chaos ?? preset.chaos ?? DEFAULT_PARAMETER_STATE.chaos;
+    const baseIntensity = this.currentParams.intensity ?? preset.intensity ?? DEFAULT_PARAMETER_STATE.intensity;
+    const baseMorph = this.currentParams.morphFactor ?? preset.morphFactor ?? DEFAULT_PARAMETER_STATE.morphFactor;
+    const baseGrid = this.currentParams.gridDensity ?? preset.gridDensity ?? DEFAULT_PARAMETER_STATE.gridDensity;
+
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const { phase, startTime } = this.transitionState;
+    const elapsed = Math.max(0, now - startTime);
+
+    let speed;
+    let chaos;
+    let luminance;
+    let morph = baseMorph;
+    let densityVariant;
+
+    switch (phase) {
+      case 'approaching': {
+        const progress = clamp(elapsed / 700, 0, 1);
+        speed = baseSpeed + intensity * 0.35 + progress * 0.25;
+        chaos = baseChaos + intensity * 0.25 + progress * 0.2;
+        luminance = baseIntensity + intensity * 0.18 + progress * 0.12;
+        morph = baseMorph + intensity * 0.06 + progress * 0.1;
+        densityVariant = gridDensityToVariant(baseGrid) + progress * 0.12 - intensity * 0.05;
+        break;
+      }
+      case 'focused': {
+        const pulse = (Math.sin(now * 0.002) + 1) * 0.5;
+        speed = baseSpeed + intensity * 0.38 + pulse * 0.16;
+        chaos = baseChaos + intensity * 0.28 + pulse * 0.12;
+        luminance = baseIntensity + intensity * 0.22 + pulse * 0.1;
+        morph = baseMorph + intensity * 0.08 + pulse * 0.06;
+        densityVariant = gridDensityToVariant(baseGrid) - pulse * 0.05 - intensity * 0.03;
+        break;
+      }
+      case 'exiting':
+      case 'destroyed': {
+        const progress = clamp(elapsed / 900, 0, 1);
+        speed = baseSpeed + intensity * 0.45 + progress * 0.7;
+        chaos = baseChaos + intensity * 0.32 + progress * 0.55;
+        luminance = baseIntensity + intensity * 0.25 + progress * 0.34;
+        morph = baseMorph + intensity * 0.12 + progress * 0.35;
+        densityVariant = gridDensityToVariant(baseGrid) * (1 - progress * 0.55) - intensity * 0.08;
+        break;
+      }
+      case 'far-depth': {
+        const progress = clamp(elapsed / 800, 0, 1);
+        speed = baseSpeed * (0.55 + (1 - progress) * 0.25) + intensity * 0.18;
+        chaos = baseChaos * (0.6 + (1 - progress) * 0.25) + intensity * 0.14;
+        luminance = baseIntensity * (0.45 + (1 - progress) * 0.35) + intensity * 0.08;
+        morph = baseMorph * (0.8 + (1 - progress) * 0.15) + intensity * 0.04;
+        densityVariant = gridDensityToVariant(baseGrid) * (0.75 + (1 - progress) * 0.2) - intensity * 0.05;
+        break;
+      }
+      default: {
+        speed = baseSpeed + intensity * 0.35;
+        chaos = baseChaos + intensity * 0.25;
+        luminance = baseIntensity + intensity * 0.18;
+        morph = baseMorph + intensity * 0.06;
+        densityVariant = gridDensityToVariant(baseGrid) - intensity * 0.04;
+        break;
+      }
+    }
+
+    this.visualizer.variantParams.speed = clamp(speed, 0, 3.5);
+    this.visualizer.variantParams.chaos = clamp(chaos, 0, 2.6);
+    this.visualizer.variantParams.intensity = clamp(luminance, 0, 1.8);
+    this.visualizer.variantParams.morph = clamp(morph, 0, 3.5);
+    this.visualizer.variantParams.density = clamp(densityVariant, 0.08, 3.2);
+  }
+
+  start() {
+    if (!this.visualizer) return;
+    const render = () => {
+      this.visualizer.resize();
+      this.applyDynamicModulation();
+      this.visualizer.render();
+      this.frame = requestAnimationFrame(render);
+    };
+    render();
+  }
+}
+
+class TiltIndicator {
+  constructor(element) {
+    this.element = element || null;
+    this.xNode = this.element ? this.element.querySelector('#tilt-x') : null;
+    this.yNode = this.element ? this.element.querySelector('#tilt-y') : null;
+    this.modeNode = this.element ? this.element.querySelector('#rot4d') : null;
+    this.mode = 'pointer';
+  }
+
+  setMode(mode) {
+    this.mode = mode;
+    if (this.element) {
+      this.element.dataset.mode = mode;
+    }
+    if (this.modeNode) {
+      this.modeNode.textContent = mode === 'dramatic' ? 'Dramatic' : mode === 'device' ? 'Device' : 'Pointer';
+    }
+  }
+
+  update({ tiltX = 0, tiltY = 0, source = this.mode, extreme = false } = {}) {
+    if (source && source !== this.mode) {
+      this.setMode(source);
+    }
+    if (this.xNode) {
+      this.xNode.textContent = (tiltX * 45).toFixed(1);
+    }
+    if (this.yNode) {
+      this.yNode.textContent = (tiltY * 45).toFixed(1);
+    }
+    if (this.element) {
+      this.element.classList.toggle('extreme', !!extreme);
+    }
+  }
+}
+
+class SectionChoreographer {
+  constructor({ background, container } = {}) {
+    this.background = background || null;
+    this.container = container || null;
+    this.activeCard = null;
+    this.cardVisualizers = new Map();
+    this.layoutSamples = new Map();
+    this.pointerTilt = { tiltX: 0, tiltY: 0, intensity: 0, rotation: null, source: 'pointer', extreme: false };
+    this.pointerSource = 'pointer';
+    this.pendingRotation = null;
+    this.tiltTarget = { tiltX: 0, tiltY: 0, intensity: 0, rotation: null, source: 'layout', extreme: false };
+    this.smoothedTilt = { tiltX: 0, tiltY: 0, intensity: 0 };
+    this.layoutInfluence = 0.35;
+    this.pointerInfluence = 0.65;
+    this.animationFrame = null;
+    this.layoutObserver = null;
+    this.boundSampleLayout = () => this.sampleLayout();
+    window.addEventListener('resize', this.boundSampleLayout);
+  }
+
+  registerCards(cards = []) {
+    this.cardVisualizers.clear();
+    this.layoutSamples.clear();
+    cards.forEach((card) => {
+      if (!card) return;
+      if (card.dataset.titleFrom) {
+        card.style.setProperty('--section-title-from', card.dataset.titleFrom);
+      }
+      if (card.dataset.titleTo) {
+        card.style.setProperty('--section-title-to', card.dataset.titleTo);
+      }
+      const visualizer = new CardVisualizer(card);
+      if (card.classList.contains('focused')) {
+        visualizer.setTransitionPhase('focused');
+      }
+      this.cardVisualizers.set(card, visualizer);
+      this.updateLayoutForCard(card);
+    });
+    this.attachLayoutObserver();
+    this.sampleLayout();
+  }
+
+  attachLayoutObserver() {
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    if (this.layoutObserver) {
+      this.layoutObserver.disconnect();
+    }
+    this.layoutObserver = new ResizeObserver(() => {
+      this.sampleLayout();
+    });
+    this.cardVisualizers.forEach((_, card) => {
+      this.layoutObserver.observe(card);
+    });
+  }
+
+  sampleLayout() {
+    if (!this.cardVisualizers.size) {
+      return;
+    }
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 1;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 1;
+    this.cardVisualizers.forEach((_, card) => {
+      this.updateLayoutForCard(card, viewportWidth, viewportHeight);
+    });
+    this.recalculateTilt('layout');
+  }
+
+  updateLayoutForCard(card, viewportWidth = window.innerWidth || document.documentElement.clientWidth || 1, viewportHeight = window.innerHeight || document.documentElement.clientHeight || 1) {
+    if (!card) {
+      return;
+    }
+    const rect = card.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      this.layoutSamples.set(card, { x: 0, y: 0, intensity: 0 });
+      card.style.setProperty('--layout-tilt-x', '0');
+      card.style.setProperty('--layout-tilt-y', '0');
+      card.style.setProperty('--layout-tilt-strength', '0');
+      return;
+    }
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const normalizedX = ((centerX / viewportWidth) - 0.5) * 2;
+    const normalizedY = ((centerY / viewportHeight) - 0.5) * 2;
+    const tiltX = clamp(normalizedX * 0.45, -0.65, 0.65);
+    const tiltY = clamp(-normalizedY * 0.45, -0.65, 0.65);
+    const intensity = clamp(Math.sqrt(tiltX * tiltX + tiltY * tiltY), 0, 1.1);
+    this.layoutSamples.set(card, { x: tiltX, y: tiltY, intensity });
+    card.style.setProperty('--layout-tilt-x', tiltX.toFixed(4));
+    card.style.setProperty('--layout-tilt-y', tiltY.toFixed(4));
+    card.style.setProperty('--layout-tilt-strength', intensity.toFixed(3));
+  }
+
+  activate(card) {
+    if (!card) {
+      return;
+    }
+    if (this.activeCard && this.activeCard !== card) {
+      this.activeCard.classList.remove('tilt-extreme');
+    }
+    this.activeCard = card;
+    const root = document.documentElement;
+
+    if (card.dataset.titleFrom) {
+      root.style.setProperty('--section-title-from', card.dataset.titleFrom);
+    }
+    if (card.dataset.titleTo) {
+      root.style.setProperty('--section-title-to', card.dataset.titleTo);
+    }
+    if (card.dataset.bgPrimary) {
+      root.style.setProperty('--visualizer-bg-primary', card.dataset.bgPrimary);
+    }
+    if (card.dataset.bgSecondary) {
+      root.style.setProperty('--visualizer-bg-secondary', card.dataset.bgSecondary);
+    }
+    if (card.dataset.bgGlow) {
+      root.style.setProperty('--visualizer-bg-glow', card.dataset.bgGlow);
+      root.style.setProperty('--visualizer-pulse-color', card.dataset.bgGlow);
+      root.style.setProperty('--visualizer-grid-color', card.dataset.bgGlow);
+    }
+
+    card.dataset.visualizerActive = 'true';
+    card.style.removeProperty('--card-visibility');
+
+    const sectionKey = card.dataset.section || 'quantum';
+    this.background?.applyPreset(sectionKey);
+    const visualizer = this.cardVisualizers.get(card);
+    visualizer?.applyPreset();
+    visualizer?.setTransitionPhase('focused');
+
+    if (window.userParameterState) {
+      const presetParams = SECTION_PRESETS[sectionKey]?.parameters || {};
+      Object.entries(presetParams).forEach(([param, value]) => {
+        window.userParameterState[param] = value;
+      });
+    }
+
+    this.updateLayoutForCard(card);
+    this.recalculateTilt('layout');
+  }
+
+  deactivate(card) {
+    if (card) {
+      card.dataset.visualizerActive = 'false';
+      card.style.removeProperty('--card-visibility');
+      card.classList.remove('tilt-extreme');
+      const visualizer = this.cardVisualizers.get(card);
+      visualizer?.setTransitionPhase('far-depth');
+    }
+  }
+
+  updateTilt(payload = {}) {
+    const tiltX = clamp(payload.tiltX ?? 0, -1.2, 1.2);
+    const tiltY = clamp(payload.tiltY ?? 0, -1.2, 1.2);
+    const intensity = clamp(payload.intensity ?? 0, 0, 2);
+    this.pointerTilt = {
+      tiltX,
+      tiltY,
+      intensity,
+      rotation: payload.rotation || null,
+      source: payload.source || this.pointerSource || 'pointer',
+      extreme: !!payload.extreme
+    };
+    this.pointerSource = this.pointerTilt.source;
+    this.pendingRotation = this.pointerTilt.rotation;
+    this.recalculateTilt(this.pointerTilt.source, this.pointerTilt.extreme);
+  }
+
+  recalculateTilt(reason = 'pointer', externalExtreme = false) {
+    const layout = this.activeCard ? this.layoutSamples.get(this.activeCard) || { x: 0, y: 0, intensity: 0 } : { x: 0, y: 0, intensity: 0 };
+    const pointer = this.pointerTilt;
+    const finalTiltX = clamp(pointer.tiltX * this.pointerInfluence + layout.x * this.layoutInfluence, -1.25, 1.25);
+    const finalTiltY = clamp(pointer.tiltY * this.pointerInfluence + layout.y * this.layoutInfluence, -1.25, 1.25);
+    const finalIntensity = clamp(pointer.intensity * this.pointerInfluence + layout.intensity * this.layoutInfluence, 0, 1.6);
+    const extreme = externalExtreme || pointer.extreme || finalIntensity > 1.1;
+    this.setTiltTarget({
+      tiltX: finalTiltX,
+      tiltY: finalTiltY,
+      intensity: finalIntensity,
+      rotation: pointer.rotation || this.pendingRotation || null,
+      source: pointer.source || reason,
+      extreme
+    });
+  }
+
+  setTiltTarget(target = {}) {
+    this.tiltTarget = {
+      tiltX: clamp(target.tiltX ?? 0, -1.3, 1.3),
+      tiltY: clamp(target.tiltY ?? 0, -1.3, 1.3),
+      intensity: clamp(target.intensity ?? 0, 0, 1.8),
+      rotation: target.rotation || null,
+      source: target.source || 'layout',
+      extreme: !!target.extreme
+    };
+    if (!this.animationFrame) {
+      this.animationFrame = requestAnimationFrame(() => this.animateTilt());
+    }
+  }
+
+  animateTilt() {
+    const smoothing = 0.18;
+    this.smoothedTilt.tiltX += (this.tiltTarget.tiltX - this.smoothedTilt.tiltX) * smoothing;
+    this.smoothedTilt.tiltY += (this.tiltTarget.tiltY - this.smoothedTilt.tiltY) * smoothing;
+    this.smoothedTilt.intensity += (this.tiltTarget.intensity - this.smoothedTilt.intensity) * 0.2;
+
+    this.applySmoothedTilt({
+      tiltX: this.smoothedTilt.tiltX,
+      tiltY: this.smoothedTilt.tiltY,
+      intensity: this.smoothedTilt.intensity,
+      rotation: this.tiltTarget.rotation,
+      source: this.tiltTarget.source,
+      extreme: this.tiltTarget.extreme
+    });
+
+    const deltaX = Math.abs(this.smoothedTilt.tiltX - this.tiltTarget.tiltX);
+    const deltaY = Math.abs(this.smoothedTilt.tiltY - this.tiltTarget.tiltY);
+    const deltaI = Math.abs(this.smoothedTilt.intensity - this.tiltTarget.intensity);
+
+    if (deltaX > 0.0008 || deltaY > 0.0008 || deltaI > 0.0008) {
+      this.animationFrame = requestAnimationFrame(() => this.animateTilt());
+    } else {
+      this.animationFrame = null;
+    }
+  }
+
+  applySmoothedTilt({ tiltX, tiltY, intensity, rotation, extreme }) {
+    const root = document.documentElement;
+    root.style.setProperty('--global-tilt-x', tiltX.toFixed(4));
+    root.style.setProperty('--global-tilt-y', tiltY.toFixed(4));
+    root.style.setProperty('--global-tilt-strength', intensity.toFixed(3));
+
+    if (this.activeCard) {
+      this.activeCard.style.setProperty('--card-tilt-x', tiltX.toFixed(4));
+      this.activeCard.style.setProperty('--card-tilt-y', tiltY.toFixed(4));
+      this.activeCard.classList.toggle('tilt-extreme', !!extreme);
+      const visualizer = this.cardVisualizers.get(this.activeCard);
+      visualizer?.updateTilt(tiltX, tiltY, intensity);
+    }
+
+    this.cardVisualizers.forEach((visualizer, card) => {
+      if (!visualizer || card === this.activeCard) {
+        return;
+      }
+      const layout = this.layoutSamples.get(card) || { x: 0, y: 0, intensity: 0 };
+      const followerTiltX = clamp(tiltX * 0.25 + layout.x * 0.75, -1.1, 1.1);
+      const followerTiltY = clamp(tiltY * 0.25 + layout.y * 0.75, -1.1, 1.1);
+      const followerIntensity = clamp(intensity * 0.4 + layout.intensity * 0.8, 0, 1.2);
+      visualizer.updateTilt(followerTiltX, followerTiltY, followerIntensity);
+    });
+
+    this.background?.updateTilt({
+      tiltX,
+      tiltY,
+      intensity,
+      rotation: rotation || null
+    });
+  }
+
+  applyParameterToActiveCard(param, value) {
+    if (!this.activeCard) {
+      return;
+    }
+    const visualizer = this.cardVisualizers.get(this.activeCard);
+    visualizer?.handleParameter(param, value);
+  }
+
+  pulseExit(card) {
+    if (card) {
+      card.style.setProperty('--card-visibility', '0.45');
+    }
+  }
+
+  triggerHypercubeFold(nextCard, onComplete) {
+    if (this.container) {
+      this.container.classList.add('hypercube-folding');
+    }
+    this.background?.triggerHypercubeFold();
+    setTimeout(() => {
+      if (this.container) {
+        this.container.classList.remove('hypercube-folding');
+      }
+      if (typeof onComplete === 'function') {
+        onComplete();
+      }
+    }, 900);
+  }
+
+  destroy() {
+    if (this.layoutObserver) {
+      this.layoutObserver.disconnect();
+      this.layoutObserver = null;
+    }
+    window.removeEventListener('resize', this.boundSampleLayout);
+    if (this.animationFrame) {
+      cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = null;
+    }
+    this.cardVisualizers.clear();
+    this.layoutSamples.clear();
+    this.activeCard = null;
+  }
+}
+
+class PointerTiltController {
+  constructor({ onUpdate, indicator } = {}) {
+    this.onUpdate = typeof onUpdate === 'function' ? onUpdate : null;
+    this.indicator = indicator || null;
+    this.enabled = false;
+    this.handlePointerMove = this.handlePointerMove.bind(this);
+    this.handlePointerLeave = this.handlePointerLeave.bind(this);
+  }
+
+  enable() {
+    if (this.enabled) {
+      return;
+    }
+    this.enabled = true;
+    window.addEventListener('pointermove', this.handlePointerMove);
+    window.addEventListener('pointerleave', this.handlePointerLeave);
+    this.indicator?.setMode('pointer');
+  }
+
+  disable() {
+    if (!this.enabled) {
+      return;
+    }
+    this.enabled = false;
+    window.removeEventListener('pointermove', this.handlePointerMove);
+    window.removeEventListener('pointerleave', this.handlePointerLeave);
+  }
+
+  handlePointerMove(event) {
+    if (!this.enabled) {
+      return;
+    }
+    const { innerWidth, innerHeight } = window;
+    const x = (event.clientX / innerWidth - 0.5) * 1.4;
+    const y = (event.clientY / innerHeight - 0.5) * 1.4;
+    const tiltX = clamp(x, -0.9, 0.9);
+    const tiltY = clamp(-y, -0.9, 0.9);
+    const intensity = clamp(Math.sqrt(tiltX * tiltX + tiltY * tiltY) * 1.1, 0, 1.5);
+    const payload = { tiltX, tiltY, intensity, source: 'pointer', extreme: intensity > 1.05 };
+    this.indicator?.update(payload);
+    this.onUpdate?.(payload);
+  }
+
+  handlePointerLeave() {
+    if (!this.enabled) {
+      return;
+    }
+    const payload = { tiltX: 0, tiltY: 0, intensity: 0, source: 'pointer', extreme: false };
+    this.indicator?.update(payload);
+    this.onUpdate?.(payload);
+  }
+}
+
+class TiltVisualizerAdapter extends DeviceTiltHandler {
+  constructor({ onUpdate, indicator } = {}) {
+    super();
+    this.onUpdate = typeof onUpdate === 'function' ? onUpdate : null;
+    this.indicator = indicator || null;
+  }
+
+  applyGeometricWindow(windowData) {
+    super.applyGeometricWindow(windowData);
+    const tiltX = clamp(windowData.visualRotation.rotateZ / 60, -1, 1);
+    const tiltY = clamp(windowData.visualRotation.rotateX / 60, -1, 1);
+    const payload = {
+      tiltX,
+      tiltY,
+      intensity: windowData.tiltIntensity,
+      rotation: { ...windowData.viewingAngle4D },
+      source: 'device',
+      extreme: windowData.extremeTilt
+    };
+
+    if (this.indicator) {
+      this.indicator.update(payload);
+    }
+    if (this.onUpdate) {
+      this.onUpdate(payload);
+    }
+  }
+
+  resetGeometricWindow() {
+    super.resetGeometricWindow();
+    const payload = { tiltX: 0, tiltY: 0, intensity: 0, source: 'device', extreme: false };
+    if (this.indicator) {
+      this.indicator.update(payload);
+    }
+    if (this.onUpdate) {
+      this.onUpdate(payload);
+    }
+  }
+}
 
 class OrthogonalDepthProgression {
-    constructor() {
-        this.cards = [];
-        this.currentIndex = 0;
-        this.isAutoProgressing = false;
-        this.autoProgressInterval = null;
-        this.progressionStates = ['far-depth', 'approaching', 'focused', 'exiting', 'destroyed'];
+  constructor(options = {}) {
+    this.container = options.container || document.querySelector('.depth-progression-container');
+    this.cards = [];
+    this.currentIndex = 0;
+    this.isAutoProgressing = false;
+    this.autoProgressInterval = null;
+    this.progressionStates = ['far-depth', 'approaching', 'focused', 'exiting', 'destroyed'];
 
-        // Progression timing
-        this.timings = {
-            cardTransition: 800,
-            autoProgressDelay: 4000,
-            destructionDelay: 1200,
-            portalActivation: 300
-        };
+    this.timings = {
+      cardTransition: 800,
+      autoProgressDelay: 4200,
+      destructionDelay: 1300,
+      portalActivation: 320
+    };
 
-        // Scroll-to-progress system
-        this.scrollAccumulator = 0;
-        this.scrollThreshold = 100;
-        this.isScrollProgression = true;
+    this.scrollAccumulator = 0;
+    this.scrollThreshold = 100;
+    this.isScrollProgression = true;
 
-        this.init();
+    this.background = new HolographicBackdrop();
+    this.indicator = new TiltIndicator(options.tiltIndicator);
+    this.sectionChoreographer = new SectionChoreographer({
+      background: this.background,
+      container: this.container
+    });
+
+    this.parameterState = { ...DEFAULT_PARAMETER_STATE };
+    window.userParameterState = { ...this.parameterState };
+    window.updateParameter = (param, value) => this.handleParameterUpdate(param, value);
+
+    this.tiltAdapter = new TiltVisualizerAdapter({
+      onUpdate: (payload) => this.sectionChoreographer.updateTilt(payload),
+      indicator: this.indicator
+    });
+    this.pointerTilt = new PointerTiltController({
+      onUpdate: (payload) => this.sectionChoreographer.updateTilt(payload),
+      indicator: this.indicator
+    });
+
+    this.init();
+  }
+
+  init() {
+    console.log('🎯 Initializing Orthogonal Depth Progression System...');
+
+    this.findProgressionCards();
+    this.sectionChoreographer.registerCards(this.cards);
+    this.setupScrollProgression();
+    this.setupKeyboardControls();
+    this.initializePortalVisualizers();
+    this.setInitialPositions();
+    this.setupTiltControllers();
+
+    console.log('✅ Orthogonal Depth Progression initialized - immersive visualizer mode');
+  }
+
+  setupTiltControllers() {
+    this.pointerTilt.enable();
+    this.indicator?.setMode('pointer');
+
+    setTimeout(() => {
+      this.tiltAdapter.enable().then((enabled) => {
+        if (enabled) {
+          this.pointerTilt.disable();
+          this.indicator?.setMode('device');
+        }
+      }).catch(() => {
+        this.pointerTilt.enable();
+        this.indicator?.setMode('pointer');
+      });
+    }, 400);
+  }
+
+  handleParameterUpdate(param, value) {
+    const numeric = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(numeric)) {
+      return;
     }
+    this.parameterState[param] = numeric;
+    this.background?.applyParameter(param, numeric);
+    this.sectionChoreographer.applyParameterToActiveCard(param, numeric);
+  }
 
-    init() {
-        console.log('🎯 Initializing Orthogonal Depth Progression System...');
-
-        this.findProgressionCards();
-        this.setupScrollProgression();
-        this.setupKeyboardControls();
-        this.initializePortalVisualizers();
-        this.setInitialPositions();
-
-        console.log('✅ Orthogonal Depth Progression initialized - Professional Avant-garde Mode');
+  findProgressionCards() {
+    if (!this.container) {
+      this.cards = [];
+      return;
     }
+    this.cards = Array.from(this.container.querySelectorAll('.progression-card'));
+    console.log(`🎨 Found ${this.cards.length} progression cards`);
+  }
 
-    findProgressionCards() {
-        this.cards = Array.from(document.querySelectorAll('.progression-card'));
-        console.log(`🎨 Found ${this.cards.length} progression cards`);
-    }
+  setupScrollProgression() {
+    let scrollTimeout;
 
-    setupScrollProgression() {
-        // Intercept scroll events and convert to Z-axis progression
-        let scrollTimeout;
+    window.addEventListener('wheel', (event) => {
+      event.preventDefault();
+      this.scrollAccumulator += event.deltaY;
+      clearTimeout(scrollTimeout);
+      scrollTimeout = setTimeout(() => {
+        this.handleScrollProgression();
+      }, 60);
+    }, { passive: false });
 
-        window.addEventListener('wheel', (event) => {
-            event.preventDefault(); // Block traditional scrolling
+    this.setupTouchProgression();
+  }
 
-            this.scrollAccumulator += event.deltaY;
+  setupTouchProgression() {
+    let startY = 0;
+    let currentY = 0;
 
-            clearTimeout(scrollTimeout);
-            scrollTimeout = setTimeout(() => {
-                this.handleScrollProgression();
-            }, 50);
+    document.addEventListener('touchstart', (event) => {
+      startY = event.touches[0].clientY;
+    }, { passive: true });
 
-        }, { passive: false });
+    document.addEventListener('touchmove', (event) => {
+      event.preventDefault();
+      currentY = event.touches[0].clientY;
+      const deltaY = startY - currentY;
 
-        // Touch support for mobile
-        this.setupTouchProgression();
-    }
-
-    setupTouchProgression() {
-        let startY = 0;
-        let currentY = 0;
-
-        document.addEventListener('touchstart', (event) => {
-            startY = event.touches[0].clientY;
-        });
-
-        document.addEventListener('touchmove', (event) => {
-            event.preventDefault(); // Block traditional scrolling
-            currentY = event.touches[0].clientY;
-            const deltaY = startY - currentY;
-
-            if (Math.abs(deltaY) > 30) {
-                if (deltaY > 0) {
-                    this.nextCard();
-                } else {
-                    this.previousCard();
-                }
-                startY = currentY;
-            }
-        }, { passive: false });
-    }
-
-    handleScrollProgression() {
-        if (Math.abs(this.scrollAccumulator) > this.scrollThreshold) {
-            if (this.scrollAccumulator > 0) {
-                this.nextCard();
-            } else {
-                this.previousCard();
-            }
-            this.scrollAccumulator = 0;
+      if (Math.abs(deltaY) > 32) {
+        if (deltaY > 0) {
+          this.nextCard();
         } else {
-            // Decay scroll accumulator
-            this.scrollAccumulator *= 0.9;
+          this.previousCard();
         }
-    }
+        startY = currentY;
+      }
+    }, { passive: false });
+  }
 
-    setupKeyboardControls() {
-        document.addEventListener('keydown', (event) => {
-            switch (event.code) {
-                case 'ArrowDown':
-                case 'Space':
-                    event.preventDefault();
-                    this.nextCard();
-                    break;
-                case 'ArrowUp':
-                    event.preventDefault();
-                    this.previousCard();
-                    break;
-                case 'Home':
-                    event.preventDefault();
-                    this.goToCard(0);
-                    break;
-                case 'End':
-                    event.preventDefault();
-                    this.goToCard(this.cards.length - 1);
-                    break;
-            }
+  handleScrollProgression() {
+    if (Math.abs(this.scrollAccumulator) > this.scrollThreshold) {
+      if (this.scrollAccumulator > 0) {
+        this.nextCard();
+      } else {
+        this.previousCard();
+      }
+      this.scrollAccumulator = 0;
+    } else {
+      this.scrollAccumulator *= 0.9;
+    }
+  }
+
+  setupKeyboardControls() {
+    document.addEventListener('keydown', (event) => {
+      switch (event.code) {
+        case 'ArrowDown':
+        case 'Space':
+          event.preventDefault();
+          this.nextCard();
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          this.previousCard();
+          break;
+        case 'Home':
+          event.preventDefault();
+          this.goToCard(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          this.goToCard(this.cards.length - 1);
+          break;
+        default:
+          break;
+      }
+    });
+  }
+
+  initializePortalVisualizers() {
+    this.cards.forEach((card, index) => {
+      const portalElement = card.querySelector('.portal-text-visualizer');
+      if (portalElement) {
+        this.createPortalVisualizer(portalElement, card.dataset.vib34d, index);
+      }
+    });
+  }
+
+  createPortalVisualizer(portalElement, systemType, cardIndex) {
+    const canvas = document.createElement('canvas');
+    canvas.className = 'portal-canvas';
+    canvas.style.cssText = `
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      border-radius: inherit;
+      pointer-events: none;
+    `;
+
+    portalElement.appendChild(canvas);
+    const portalVisualizer = new PortalTextVisualizer(canvas, systemType, cardIndex);
+    portalElement.portalVisualizer = portalVisualizer;
+  }
+
+  setInitialPositions() {
+    this.cards.forEach((card, index) => {
+      card.style.zIndex = this.cards.length - index;
+      if (index === 0) {
+        this.setCardState(card, 'focused');
+      } else {
+        this.setCardState(card, 'far-depth');
+      }
+    });
+
+    if (this.cards[0]) {
+      this.activatePortalForCard(this.cards[0]);
+      this.sectionChoreographer.activate(this.cards[0]);
+    }
+  }
+
+  nextCard() {
+    if (this.currentIndex >= this.cards.length - 1) {
+      const currentCard = this.cards[this.currentIndex];
+      this.destroyCurrentCard(() => {
+        const nextCard = this.cards[0];
+        this.sectionChoreographer.triggerHypercubeFold(nextCard, () => {
+          this.currentIndex = 0;
+          this.progressToCurrentCard();
         });
+      }, currentCard);
+      return;
+    }
+    this.progressToCard(this.currentIndex + 1);
+  }
+
+  previousCard() {
+    if (this.currentIndex <= 0) {
+      this.currentIndex = this.cards.length - 1;
+    } else {
+      this.currentIndex -= 1;
+    }
+    this.progressToCurrentCard();
+  }
+
+  goToCard(index) {
+    if (index >= 0 && index < this.cards.length && index !== this.currentIndex) {
+      this.currentIndex = index;
+      this.progressToCurrentCard();
+    }
+  }
+
+  progressToCard(newIndex) {
+    const currentCard = this.cards[this.currentIndex];
+    const newCard = this.cards[newIndex];
+
+    if (!currentCard || !newCard) {
+      return;
     }
 
-    initializePortalVisualizers() {
-        this.cards.forEach((card, index) => {
-            const portalElement = card.querySelector('.portal-text-visualizer');
-            if (portalElement) {
-                this.createPortalVisualizer(portalElement, card.dataset.vib34d, index);
-            }
-        });
-    }
+    this.deactivatePortalForCard(currentCard);
+    this.sectionChoreographer.deactivate(currentCard);
+    this.sectionChoreographer.pulseExit(currentCard);
+    this.setCardState(currentCard, 'exiting');
 
-    createPortalVisualizer(portalElement, systemType, cardIndex) {
-        // Create canvas for portal visualization
-        const canvas = document.createElement('canvas');
-        canvas.className = 'portal-canvas';
-        canvas.style.cssText = `
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            border-radius: inherit;
-            pointer-events: none;
-        `;
-
-        portalElement.appendChild(canvas);
-
-        // Create portal visualizer instance
-        const portalVisualizer = new PortalTextVisualizer(canvas, systemType, cardIndex);
-
-        // Store reference on card
-        portalElement.portalVisualizer = portalVisualizer;
-    }
-
-    setInitialPositions() {
-        this.cards.forEach((card, index) => {
-            card.style.zIndex = this.cards.length - index;
-
-            if (index === 0) {
-                this.setCardState(card, 'focused');
-            } else {
-                this.setCardState(card, 'far-depth');
-            }
-        });
-
-        this.activatePortalForCard(this.cards[0]);
-    }
-
-    nextCard() {
-        if (this.currentIndex >= this.cards.length - 1) {
-            // Loop to beginning with destruction animation
-            this.destroyCurrentCard(() => {
-                this.currentIndex = 0;
-                this.progressToCurrentCard();
-            });
-            return;
-        }
-
-        this.progressToCard(this.currentIndex + 1);
-    }
-
-    previousCard() {
-        if (this.currentIndex <= 0) {
-            this.currentIndex = this.cards.length - 1;
-        } else {
-            this.currentIndex--;
-        }
-        this.progressToCurrentCard();
-    }
-
-    goToCard(index) {
-        if (index >= 0 && index < this.cards.length && index !== this.currentIndex) {
-            this.currentIndex = index;
-            this.progressToCurrentCard();
-        }
-    }
-
-    progressToCard(newIndex) {
-        const currentCard = this.cards[this.currentIndex];
-        const newCard = this.cards[newIndex];
-
-        // Deactivate current card portal
-        this.deactivatePortalForCard(currentCard);
-
-        // Exit current card
-        this.setCardState(currentCard, 'exiting');
-
-        // Bring new card forward through progression states
+    setTimeout(() => {
+      this.setCardState(newCard, 'approaching');
+      setTimeout(() => {
+        this.setCardState(newCard, 'focused');
+        this.currentIndex = newIndex;
+        this.activatePortalForCard(newCard);
+        this.sectionChoreographer.activate(newCard);
         setTimeout(() => {
-            this.setCardState(newCard, 'approaching');
+          this.setCardState(currentCard, 'far-depth');
+        }, this.timings.cardTransition);
+      }, this.timings.cardTransition / 2);
+    }, this.timings.cardTransition / 4);
+  }
 
-            setTimeout(() => {
-                this.setCardState(newCard, 'focused');
-                this.currentIndex = newIndex;
-                this.activatePortalForCard(newCard);
+  progressToCurrentCard() {
+    this.cards.forEach((card, index) => {
+      if (index === this.currentIndex) {
+        this.setCardState(card, 'focused');
+        this.activatePortalForCard(card);
+        this.sectionChoreographer.activate(card);
+      } else {
+        this.setCardState(card, 'far-depth');
+        this.deactivatePortalForCard(card);
+        this.sectionChoreographer.deactivate(card);
+      }
+    });
+  }
 
-                // Move old card to far depth
-                setTimeout(() => {
-                    this.setCardState(currentCard, 'far-depth');
-                }, this.timings.cardTransition);
+  setCardState(card, state) {
+    if (!card) {
+      return;
+    }
+    this.progressionStates.forEach((s) => card.classList.remove(s));
+    card.classList.add(state);
+    card.dataset.progressionState = state;
 
-            }, this.timings.cardTransition / 2);
-
-        }, this.timings.cardTransition / 4);
+    switch (state) {
+      case 'focused':
+        card.style.zIndex = 1000;
+        break;
+      case 'approaching':
+        card.style.zIndex = 900;
+        break;
+      case 'exiting':
+        card.style.zIndex = 800;
+        break;
+      case 'far-depth':
+        card.style.zIndex = 100;
+        break;
+      case 'destroyed':
+        card.style.zIndex = 50;
+        break;
+      default:
+        break;
     }
 
-    progressToCurrentCard() {
-        this.cards.forEach((card, index) => {
-            if (index === this.currentIndex) {
-                this.setCardState(card, 'focused');
-                this.activatePortalForCard(card);
-            } else if (index < this.currentIndex) {
-                this.setCardState(card, 'far-depth');
-                this.deactivatePortalForCard(card);
-            } else {
-                this.setCardState(card, 'far-depth');
-                this.deactivatePortalForCard(card);
-            }
-        });
+    const visualizer = this.sectionChoreographer.cardVisualizers.get(card);
+    visualizer?.setTransitionPhase(state);
+    this.sectionChoreographer.updateLayoutForCard(card);
+    if (card === this.sectionChoreographer.activeCard) {
+      this.sectionChoreographer.recalculateTilt('layout');
+    }
+  }
+
+  activatePortalForCard(card) {
+    const portal = card?.querySelector('.portal-text-visualizer');
+    if (portal && portal.portalVisualizer) {
+      portal.portalVisualizer.activate();
+    }
+  }
+
+  deactivatePortalForCard(card) {
+    const portal = card?.querySelector('.portal-text-visualizer');
+    if (portal && portal.portalVisualizer) {
+      portal.portalVisualizer.deactivate();
+    }
+  }
+
+  destroyCurrentCard(callback, currentCard) {
+    const card = currentCard || this.cards[this.currentIndex];
+    if (!card) {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return;
     }
 
-    setCardState(card, state) {
-        // Remove all progression state classes
-        this.progressionStates.forEach(s => card.classList.remove(s));
+    const destructionType = card.dataset.destruction || 'quantum';
+    this.setCardState(card, 'destroyed');
+    card.classList.add(`destruction-${destructionType}`);
+    this.deactivatePortalForCard(card);
 
-        // Add new state
-        card.classList.add(state);
+    setTimeout(() => {
+      card.classList.remove(`destruction-${destructionType}`);
+      this.setCardState(card, 'far-depth');
+      if (typeof callback === 'function') {
+        callback();
+      }
+    }, this.timings.destructionDelay);
+  }
 
-        // Update card z-index based on state
-        switch (state) {
-            case 'focused':
-                card.style.zIndex = 1000;
-                break;
-            case 'approaching':
-                card.style.zIndex = 900;
-                break;
-            case 'exiting':
-                card.style.zIndex = 800;
-                break;
-            case 'far-depth':
-                card.style.zIndex = 100;
-                break;
-            case 'destroyed':
-                card.style.zIndex = 50;
-                break;
-        }
+  toggleAutoProgress() {
+    if (this.isAutoProgressing) {
+      this.stopAutoProgress();
+    } else {
+      this.startAutoProgress();
     }
+  }
 
-    activatePortalForCard(card) {
-        const portal = card.querySelector('.portal-text-visualizer');
-        if (portal && portal.portalVisualizer) {
-            portal.portalVisualizer.activate();
-        }
+  startAutoProgress() {
+    this.isAutoProgressing = true;
+    this.autoProgressInterval = setInterval(() => {
+      this.nextCard();
+    }, this.timings.autoProgressDelay);
+    console.log('▶️ Auto progression started');
+  }
 
-        // Add glow effect to card title
-        const title = card.querySelector('.card-title');
-        if (title) {
-            title.style.textShadow = '0 0 20px var(--clear-seas-primary), 0 0 40px var(--clear-seas-primary)';
-            title.style.transform = 'scale(1.05)';
-        }
+  stopAutoProgress() {
+    this.isAutoProgressing = false;
+    if (this.autoProgressInterval) {
+      clearInterval(this.autoProgressInterval);
+      this.autoProgressInterval = null;
     }
+    console.log('⏸️ Auto progression stopped');
+  }
 
-    deactivatePortalForCard(card) {
-        const portal = card.querySelector('.portal-text-visualizer');
-        if (portal && portal.portalVisualizer) {
-            portal.portalVisualizer.deactivate();
-        }
+  destroy() {
+    this.stopAutoProgress();
+    this.pointerTilt.disable();
+    this.tiltAdapter.disable();
+    this.sectionChoreographer.destroy();
 
-        // Remove glow effect from card title
-        const title = card.querySelector('.card-title');
-        if (title) {
-            title.style.textShadow = '';
-            title.style.transform = '';
-        }
-    }
+    this.cards.forEach((card) => {
+      const portal = card.querySelector('.portal-text-visualizer');
+      if (portal && portal.portalVisualizer) {
+        portal.portalVisualizer.destroy();
+      }
+    });
 
-    destroyCurrentCard(callback) {
-        const currentCard = this.cards[this.currentIndex];
-        const destructionType = currentCard.dataset.destruction || 'quantum';
-
-        // Apply unique destruction animation
-        this.setCardState(currentCard, 'destroyed');
-        currentCard.classList.add(`destruction-${destructionType}`);
-
-        // Deactivate portal
-        this.deactivatePortalForCard(currentCard);
-
-        // Reset card after destruction animation
-        setTimeout(() => {
-            currentCard.classList.remove(`destruction-${destructionType}`);
-            this.setCardState(currentCard, 'far-depth');
-            if (callback) callback();
-        }, this.timings.destructionDelay);
-    }
-
-    toggleAutoProgress() {
-        if (this.isAutoProgressing) {
-            this.stopAutoProgress();
-        } else {
-            this.startAutoProgress();
-        }
-    }
-
-    startAutoProgress() {
-        this.isAutoProgressing = true;
-        this.autoProgressInterval = setInterval(() => {
-            this.nextCard();
-        }, this.timings.autoProgressDelay);
-
-        console.log('▶️ Auto progression started');
-    }
-
-    stopAutoProgress() {
-        this.isAutoProgressing = false;
-        if (this.autoProgressInterval) {
-            clearInterval(this.autoProgressInterval);
-            this.autoProgressInterval = null;
-        }
-
-        console.log('⏸️ Auto progression stopped');
-    }
-
-    destroy() {
-        this.stopAutoProgress();
-
-        this.cards.forEach(card => {
-            const portal = card.querySelector('.portal-text-visualizer');
-            if (portal && portal.portalVisualizer) {
-                portal.portalVisualizer.destroy();
-            }
-        });
-
-        console.log('🗑️ Orthogonal Depth Progression destroyed');
-    }
+    console.log('🗑️ Orthogonal Depth Progression destroyed');
+  }
 }
 
-/**
- * PORTAL TEXT VISUALIZER
- * Creates portal-style visualizations within focused card text
- */
 class PortalTextVisualizer {
-    constructor(canvas, systemType, cardIndex) {
-        this.canvas = canvas;
-        this.context = canvas.getContext('2d');
-        this.systemType = systemType;
-        this.cardIndex = cardIndex;
-        this.isActive = false;
-        this.animationFrame = null;
+  constructor(canvas, systemType, cardIndex) {
+    this.canvas = canvas;
+    this.context = canvas.getContext('2d');
+    this.systemType = systemType;
+    this.cardIndex = cardIndex;
+    this.isActive = false;
+    this.animationFrame = null;
 
-        // Portal parameters
-        this.portalDepth = 0;
-        this.targetDepth = 0;
-        this.portalRotation = 0;
-        this.portalPulse = 0;
+    this.portalDepth = 0;
+    this.targetDepth = 0;
+    this.portalRotation = 0;
+    this.portalPulse = 0;
 
-        this.init();
-    }
+    this.init();
+  }
 
-    init() {
-        this.setupCanvas();
-    }
+  init() {
+    this.setupCanvas();
+  }
 
-    setupCanvas() {
-        const resizeCanvas = () => {
-            const rect = this.canvas.getBoundingClientRect();
-            const dpr = window.devicePixelRatio || 1;
+  setupCanvas() {
+    const resizeCanvas = () => {
+      const rect = this.canvas.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
 
-            this.canvas.width = rect.width * dpr;
-            this.canvas.height = rect.height * dpr;
-            this.context.scale(dpr, dpr);
-        };
+      this.canvas.width = rect.width * dpr;
+      this.canvas.height = rect.height * dpr;
+      this.context.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
 
-        resizeCanvas();
+    resizeCanvas();
 
-        const resizeObserver = new ResizeObserver(resizeCanvas);
-        resizeObserver.observe(this.canvas);
-    }
+    const resizeObserver = new ResizeObserver(resizeCanvas);
+    resizeObserver.observe(this.canvas);
+  }
 
-    activate() {
-        this.isActive = true;
-        this.targetDepth = 1.0;
-        this.startRenderLoop();
-        console.log(`🌀 Portal activated for ${this.systemType} system`);
-    }
+  activate() {
+    this.isActive = true;
+    this.targetDepth = 1.0;
+    this.startRenderLoop();
+  }
 
-    deactivate() {
-        this.isActive = false;
-        this.targetDepth = 0;
-        setTimeout(() => {
-            this.stopRenderLoop();
-        }, 500);
-    }
+  deactivate() {
+    this.isActive = false;
+    this.targetDepth = 0;
+    setTimeout(() => {
+      this.stopRenderLoop();
+    }, 500);
+  }
 
-    startRenderLoop() {
-        if (this.animationFrame) return;
+  startRenderLoop() {
+    if (this.animationFrame) return;
 
-        const render = () => {
-            this.update();
-            this.renderPortal();
+    const render = () => {
+      this.update();
+      this.renderPortal();
 
-            if (this.isActive || this.portalDepth > 0.01) {
-                this.animationFrame = requestAnimationFrame(render);
-            } else {
-                this.animationFrame = null;
-            }
-        };
-
+      if (this.isActive || this.portalDepth > 0.01) {
         this.animationFrame = requestAnimationFrame(render);
+      } else {
+        this.animationFrame = null;
+      }
+    };
+
+    this.animationFrame = requestAnimationFrame(render);
+  }
+
+  stopRenderLoop() {
+    if (this.animationFrame) {
+      cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = null;
+    }
+  }
+
+  update() {
+    this.portalDepth += (this.targetDepth - this.portalDepth) * 0.08;
+    this.portalRotation += 0.02;
+    this.portalPulse = Math.sin(Date.now() * 0.003) * 0.5 + 0.5;
+  }
+
+  renderPortal() {
+    const ctx = this.context;
+    const width = this.canvas.width / (window.devicePixelRatio || 1);
+    const height = this.canvas.height / (window.devicePixelRatio || 1);
+
+    ctx.clearRect(0, 0, width, height);
+
+    if (this.portalDepth < 0.01) return;
+
+    const centerX = width / 2;
+    const centerY = height / 2;
+    const intensity = this.portalDepth;
+
+    switch (this.systemType) {
+      case 'holographic':
+        this.renderHolographicPortal(ctx, centerX, centerY, intensity);
+        break;
+      case 'faceted':
+        this.renderFacetedPortal(ctx, centerX, centerY, intensity);
+        break;
+      case 'quantum':
+      default:
+        this.renderQuantumPortal(ctx, centerX, centerY, intensity);
+        break;
+    }
+  }
+
+  renderQuantumPortal(ctx, centerX, centerY, intensity) {
+    const rings = 8;
+    const maxRadius = Math.min(centerX, centerY) * 0.8;
+
+    for (let i = 0; i < rings; i += 1) {
+      const progress = i / rings;
+      const radius = maxRadius * (1 - progress) * intensity;
+      const alpha = intensity * (1 - progress) * this.portalPulse;
+
+      if (alpha > 0.05) {
+        ctx.strokeStyle = `hsla(280, 70%, ${60 + progress * 20}%, ${alpha})`;
+        ctx.lineWidth = 2 + progress * 3;
+
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+        ctx.stroke();
+      }
     }
 
-    stopRenderLoop() {
-        if (this.animationFrame) {
-            cancelAnimationFrame(this.animationFrame);
-            this.animationFrame = null;
+    const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, 50 * intensity);
+    gradient.addColorStop(0, `rgba(138, 43, 226, ${intensity * 0.5})`);
+    gradient.addColorStop(1, 'transparent');
+
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, centerX * 2, centerY * 2);
+  }
+
+  renderHolographicPortal(ctx, centerX, centerY, intensity) {
+    const layers = 6;
+    const maxRadius = Math.min(centerX, centerY) * 0.9;
+
+    ctx.save();
+    ctx.translate(centerX, centerY);
+    ctx.rotate(this.portalRotation);
+
+    for (let i = 0; i < layers; i += 1) {
+      const progress = i / layers;
+      const radius = maxRadius * (1 - progress * 0.8) * intensity;
+      const alpha = intensity * (1 - progress) * 0.6;
+
+      ctx.strokeStyle = `hsla(${330 + i * 15}, 80%, 70%, ${alpha})`;
+      ctx.lineWidth = 1 + progress * 2;
+
+      const sides = 8 + i * 2;
+      ctx.beginPath();
+      for (let j = 0; j <= sides; j += 1) {
+        const angle = (j / sides) * Math.PI * 2;
+        const x = Math.cos(angle) * radius * (1 + Math.sin(angle * 3) * 0.1);
+        const y = Math.sin(angle) * radius * (1 + Math.cos(angle * 3) * 0.1);
+
+        if (j === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
         }
+      }
+      ctx.stroke();
     }
 
-    update() {
-        // Smooth portal depth transition
-        this.portalDepth += (this.targetDepth - this.portalDepth) * 0.08;
+    ctx.restore();
+  }
 
-        // Portal animation
-        this.portalRotation += 0.02;
-        this.portalPulse = Math.sin(Date.now() * 0.003) * 0.5 + 0.5;
+  renderFacetedPortal(ctx, centerX, centerY, intensity) {
+    const facets = 12;
+    const maxRadius = Math.min(centerX, centerY) * 0.7;
+
+    ctx.save();
+    ctx.translate(centerX, centerY);
+
+    for (let i = 0; i < facets; i += 1) {
+      const angle = (i / facets) * Math.PI * 2 + this.portalRotation;
+      const radius = maxRadius * intensity * (0.5 + this.portalPulse * 0.3);
+
+      ctx.strokeStyle = `hsla(200, 70%, 60%, ${intensity * 0.8})`;
+      ctx.fillStyle = `hsla(200, 70%, 60%, ${intensity * 0.2})`;
+      ctx.lineWidth = 2;
+
+      ctx.beginPath();
+      ctx.moveTo(0, 0);
+      ctx.lineTo(
+        Math.cos(angle) * radius,
+        Math.sin(angle) * radius
+      );
+      ctx.lineTo(
+        Math.cos(angle + Math.PI / facets) * radius,
+        Math.sin(angle + Math.PI / facets) * radius
+      );
+      ctx.closePath();
+
+      ctx.fill();
+      ctx.stroke();
     }
 
-    renderPortal() {
-        const ctx = this.context;
-        const width = this.canvas.width / (window.devicePixelRatio || 1);
-        const height = this.canvas.height / (window.devicePixelRatio || 1);
+    ctx.restore();
+  }
 
-        // Clear canvas
-        ctx.clearRect(0, 0, width, height);
-
-        if (this.portalDepth < 0.01) return;
-
-        const centerX = width / 2;
-        const centerY = height / 2;
-        const intensity = this.portalDepth;
-
-        // Render portal based on system type
-        switch (this.systemType) {
-            case 'quantum':
-                this.renderQuantumPortal(ctx, centerX, centerY, intensity);
-                break;
-            case 'holographic':
-                this.renderHolographicPortal(ctx, centerX, centerY, intensity);
-                break;
-            case 'faceted':
-                this.renderFacetedPortal(ctx, centerX, centerY, intensity);
-                break;
-        }
-    }
-
-    renderQuantumPortal(ctx, centerX, centerY, intensity) {
-        const rings = 8;
-        const maxRadius = Math.min(centerX, centerY) * 0.8;
-
-        for (let i = 0; i < rings; i++) {
-            const progress = i / rings;
-            const radius = maxRadius * (1 - progress) * intensity;
-            const alpha = intensity * (1 - progress) * this.portalPulse;
-
-            if (alpha > 0.05) {
-                ctx.strokeStyle = `hsla(280, 70%, ${60 + progress * 20}%, ${alpha})`;
-                ctx.lineWidth = 2 + progress * 3;
-
-                ctx.beginPath();
-                ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
-                ctx.stroke();
-            }
-        }
-
-        // Central quantum glow
-        const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, 50 * intensity);
-        gradient.addColorStop(0, `rgba(138, 43, 226, ${intensity * 0.5})`);
-        gradient.addColorStop(1, 'transparent');
-
-        ctx.fillStyle = gradient;
-        ctx.fillRect(0, 0, centerX * 2, centerY * 2);
-    }
-
-    renderHolographicPortal(ctx, centerX, centerY, intensity) {
-        const layers = 6;
-        const maxRadius = Math.min(centerX, centerY) * 0.9;
-
-        ctx.save();
-        ctx.translate(centerX, centerY);
-        ctx.rotate(this.portalRotation);
-
-        for (let i = 0; i < layers; i++) {
-            const progress = i / layers;
-            const radius = maxRadius * (1 - progress * 0.8) * intensity;
-            const alpha = intensity * (1 - progress) * 0.6;
-
-            ctx.strokeStyle = `hsla(${330 + i * 15}, 80%, 70%, ${alpha})`;
-            ctx.lineWidth = 1 + progress * 2;
-
-            // Create holographic interference pattern
-            const sides = 8 + i * 2;
-            ctx.beginPath();
-            for (let j = 0; j <= sides; j++) {
-                const angle = (j / sides) * Math.PI * 2;
-                const x = Math.cos(angle) * radius * (1 + Math.sin(angle * 3) * 0.1);
-                const y = Math.sin(angle) * radius * (1 + Math.cos(angle * 3) * 0.1);
-
-                if (j === 0) {
-                    ctx.moveTo(x, y);
-                } else {
-                    ctx.lineTo(x, y);
-                }
-            }
-            ctx.stroke();
-        }
-
-        ctx.restore();
-    }
-
-    renderFacetedPortal(ctx, centerX, centerY, intensity) {
-        const facets = 12;
-        const maxRadius = Math.min(centerX, centerY) * 0.7;
-
-        ctx.save();
-        ctx.translate(centerX, centerY);
-
-        for (let i = 0; i < facets; i++) {
-            const angle = (i / facets) * Math.PI * 2 + this.portalRotation;
-            const radius = maxRadius * intensity * (0.5 + this.portalPulse * 0.3);
-
-            ctx.strokeStyle = `hsla(200, 70%, 60%, ${intensity * 0.8})`;
-            ctx.fillStyle = `hsla(200, 70%, 60%, ${intensity * 0.2})`;
-            ctx.lineWidth = 2;
-
-            ctx.beginPath();
-            ctx.moveTo(0, 0);
-            ctx.lineTo(
-                Math.cos(angle) * radius,
-                Math.sin(angle) * radius
-            );
-            ctx.lineTo(
-                Math.cos(angle + Math.PI / facets) * radius,
-                Math.sin(angle + Math.PI / facets) * radius
-            );
-            ctx.closePath();
-
-            ctx.fill();
-            ctx.stroke();
-        }
-
-        ctx.restore();
-    }
-
-    destroy() {
-        this.stopRenderLoop();
-        this.context = null;
-    }
+  destroy() {
+    this.stopRenderLoop();
+    this.context = null;
+  }
 }
 
-// Export for global use
-window.OrthogonalDepthProgression = OrthogonalDepthProgression;
-window.PortalTextVisualizer = PortalTextVisualizer;
+export default OrthogonalDepthProgression;
+
+if (typeof window !== 'undefined') {
+  window.OrthogonalDepthProgression = OrthogonalDepthProgression;
+  window.PortalTextVisualizer = PortalTextVisualizer;
+}

--- a/src/holograms/RealHolographicSystem.js
+++ b/src/holograms/RealHolographicSystem.js
@@ -13,7 +13,8 @@ export class RealHolographicSystem {
         this.totalVariants = 30;
         this.isActive = false;
         
-        // REMOVED: Built-in reactivity - ReactivityManager handles all interactions now
+        // Conditional reactivity: Use built-in only if ReactivityManager not active
+        this.useBuiltInReactivity = !window.reactivityManager;
         
         // Audio reactivity system
         this.audioEnabled = false;
@@ -48,7 +49,7 @@ export class RealHolographicSystem {
     initialize() {
         console.log('🎨 Initializing REAL Holographic System for Active Holograms tab...');
         this.createVisualizers();
-        // REMOVED: Built-in reactivity - ReactivityManager handles all interactions
+        this.setupCenterDistanceReactivity(); // NEW: Center-distance grid density changes
         this.updateVariantDisplay();
         this.startRenderLoop();
     }
@@ -462,9 +463,8 @@ export class RealHolographicSystem {
         });
     }
     
-    // REMOVED: setupCenterDistanceReactivity - ReactivityManager handles all interactions
-    removedSetupCenterDistanceReactivity() {
-        if (true) { // Disabled
+    setupCenterDistanceReactivity() {
+        if (!this.useBuiltInReactivity) {
             console.log('✨ Holographic built-in reactivity DISABLED - ReactivityManager active');
             return;
         }

--- a/styles/global-card-synergy.css
+++ b/styles/global-card-synergy.css
@@ -11,6 +11,8 @@
   --global-tilt-strength: 0;
   --global-warp: 0;
   --global-tilt-skew: 0;
+  --global-layout-x: 0.5;
+  --global-layout-y: 0.5;
   --global-focus-trend: 0;
   --global-scroll-speed: 0;
   --global-scroll-direction: 0;
@@ -159,8 +161,16 @@ html[data-global-page-family="labs"] {
   --card-focus-strength: 0;
   --card-support-intensity: 0;
   --card-scroll-momentum: 0;
+  --card-layout-offset-x: 0;
+  --card-layout-offset-y: 0;
+  --card-parallax-x: 0;
+  --card-parallax-y: 0;
+  --card-viewport-x: 0.5;
+  --card-viewport-y: 0.5;
+  --card-viewport-coverage: 0;
   --card-twist: 0deg;
   --card-pulse: 0;
+  --card-rotation-phase: 0;
   --card-overlay-shift: 0px;
   --card-visibility-factor: var(--card-visibility, 1);
   --support-distance-z: 0px;
@@ -236,11 +246,12 @@ html[data-global-page-family="labs"] {
   transform: perspective(1600px)
     rotateX(calc(
       (0.5 - var(--card-focus-y)) * 22deg +
-      var(--card-scroll-momentum) * 4deg +
+      var(--card-layout-offset-y) * 20deg +
       var(--shared-tilt-y-signal) * 16deg
     ))
     rotateY(calc(
-      (var(--card-focus-x) - 0.5) * 20deg +
+      (var(--card-focus-x) - 0.5) * 20deg -
+      var(--card-layout-offset-x) * 22deg +
       var(--shared-tilt-x-signal) * 18deg
     ))
     rotateZ(calc(
@@ -258,10 +269,12 @@ html[data-global-page-family="labs"] {
     ))
     translateX(calc(
       (var(--card-focus-x) - 0.5) * 22px +
+      var(--card-layout-offset-x) * -26px +
       var(--shared-scroll-direction-signal) * var(--shared-scroll-speed-signal) * 16px
     ))
     translateY(calc(
       (var(--card-focus-y) - 0.5) * -18px +
+      var(--card-layout-offset-y) * -22px +
       var(--shared-focus-trend-signal) * -16px
     ))
     scale(calc(
@@ -278,11 +291,12 @@ html[data-global-page-family="labs"] {
   transform: perspective(1500px)
     rotateX(calc(
       (0.5 - var(--card-focus-y)) * 18deg +
-      var(--card-scroll-momentum) * 2deg +
+      var(--card-layout-offset-y) * 16deg +
       var(--shared-tilt-y-signal) * 14deg
     ))
     rotateY(calc(
-      (var(--card-focus-x) - 0.5) * 18deg +
+      (var(--card-focus-x) - 0.5) * 18deg -
+      var(--card-layout-offset-x) * 18deg +
       var(--shared-tilt-x-signal) * 14deg
     ))
     rotateZ(calc(
@@ -295,6 +309,8 @@ html[data-global-page-family="labs"] {
       var(--shared-bend-signal) * 16px +
       var(--shared-focus-signal) * 12px
     ))
+    translateX(calc((var(--card-layout-offset-x) * -18px) + (var(--card-focus-x) - 0.5) * 12px))
+    translateY(calc((var(--card-layout-offset-y) * -18px) + (var(--card-focus-y) - 0.5) * -10px))
     scale(calc(0.98 + var(--card-support-intensity) * 0.02 + var(--shared-synergy-signal) * 0.03));
 }
 
@@ -305,11 +321,12 @@ html[data-global-page-family="labs"] {
   transform: perspective(1550px)
     rotateX(calc(
       (0.5 - var(--card-focus-y)) * 20deg +
-      var(--card-scroll-momentum) * 3deg +
+      var(--card-layout-offset-y) * 18deg +
       var(--shared-tilt-y-signal) * 15deg
     ))
     rotateY(calc(
-      (var(--card-focus-x) - 0.5) * 19deg +
+      (var(--card-focus-x) - 0.5) * 19deg -
+      var(--card-layout-offset-x) * 20deg +
       var(--shared-tilt-x-signal) * 16deg
     ))
     rotateZ(calc(
@@ -322,6 +339,8 @@ html[data-global-page-family="labs"] {
       var(--shared-bend-signal) * 18px +
       var(--shared-focus-signal) * 16px
     ))
+    translateX(calc((var(--card-focus-x) - 0.5) * 18px + var(--card-layout-offset-x) * -20px))
+    translateY(calc((var(--card-focus-y) - 0.5) * -14px + var(--card-layout-offset-y) * -20px))
     scale(calc(1 + var(--card-support-intensity) * 0.015 + var(--shared-synergy-signal) * 0.035));
 }
 
@@ -368,15 +387,20 @@ html[data-global-page-family="labs"] {
     perspective(calc(1600px - var(--global-bend-intensity) * 320px))
     rotateX(calc(
       (0.5 - var(--card-focus-y)) * 26deg +
-      var(--card-scroll-momentum) * 6deg +
+      var(--card-layout-offset-y) * 24deg +
       var(--global-tilt-y) * 24deg
     ))
     rotateY(calc(
-      (var(--card-focus-x) - 0.5) * 28deg +
+      (var(--card-focus-x) - 0.5) * 28deg -
+      var(--card-layout-offset-x) * 26deg +
       var(--global-tilt-x) * 26deg
     ))
-    rotateZ(calc(var(--card-twist) + var(--global-warp) * 8deg))
-    translateZ(calc(var(--card-focus-strength) * 48px + var(--support-distance-z) + var(--global-bend-intensity) * 24px))
+    rotateZ(calc(var(--card-twist) + var(--global-warp) * 6deg))
+    translate3d(
+      calc(var(--card-layout-offset-x) * -28px),
+      calc(var(--card-layout-offset-y) * -24px),
+      calc(var(--card-focus-strength) * 48px + var(--support-distance-z) + var(--global-bend-intensity) * 24px)
+    )
     scale(calc(1 + var(--card-focus-strength) * 0.06 + var(--card-support-intensity) * 0.03 + var(--global-bend-intensity) * 0.02));
   box-shadow:
     0 30px 70px rgba(8, 12, 32, calc((0.25 + var(--card-focus-strength) * 0.35) * (0.5 + var(--card-visibility-factor) * 0.5))),
@@ -404,10 +428,14 @@ html[data-global-page-family="labs"] {
     blur(calc((0.4 - var(--card-focus-strength) * 0.3 - var(--group-synergy, 0) * 0.1 - var(--global-tilt-strength) * 0.08 + (1 - var(--card-visibility-factor)) * 0.2) * 18px))
     var(--brand-overlay-filter, brightness(1));
   transform:
-    translateZ(calc(18px + var(--card-focus-strength) * 36px + var(--group-synergy, 0) * 24px + var(--support-distance-z) * 0.4 + var(--brand-overlay-depth, 0px) + var(--global-bend-intensity) * 32px))
-    rotateX(calc(var(--card-scroll-momentum) * -1.8deg + var(--group-synergy, 0) * -1.2deg + var(--global-tilt-y) * -18deg))
-    rotateY(calc(var(--card-scroll-momentum) * 1.6deg + var(--group-synergy, 0) * 1.1deg + var(--global-tilt-x) * 18deg))
-    rotateZ(calc(var(--brand-overlay-rotate, 0deg) + var(--global-warp) * 10deg));
+    translate3d(
+      calc(var(--card-layout-offset-x) * -22px + var(--card-parallax-x, 0) * -18px),
+      calc(var(--card-layout-offset-y) * -20px + var(--card-parallax-y, 0) * -16px),
+      calc(18px + var(--card-focus-strength) * 36px + var(--group-synergy, 0) * 24px + var(--support-distance-z) * 0.4 + var(--brand-overlay-depth, 0px) + var(--global-bend-intensity) * 32px)
+    )
+    rotateX(calc(var(--card-layout-offset-y) * -22deg + var(--group-synergy, 0) * -1.2deg + var(--global-tilt-y) * -18deg))
+    rotateY(calc(var(--card-layout-offset-x) * 22deg + var(--group-synergy, 0) * 1.1deg + var(--global-tilt-x) * 18deg))
+    rotateZ(calc(var(--brand-overlay-rotate, 0deg) + var(--global-warp) * 8deg));
   transition: opacity 0.5s ease, filter 0.6s ease, transform 0.6s ease;
 }
 
@@ -447,10 +475,14 @@ html[data-global-page-family="labs"] {
   width: calc(136% + var(--global-bend-intensity) * 18%);
   height: calc(136% + var(--global-bend-intensity) * 18%);
   transform:
-    translateZ(calc(-36px + var(--card-focus-strength) * -18px - var(--group-synergy, 0) * 16px + var(--support-distance-z) * -0.6 + var(--card-canvas-depth, 0px) - var(--global-bend-intensity) * 28px))
-    rotateX(calc((0.5 - var(--card-focus-y)) * 18deg + var(--card-scroll-momentum) * 4deg + var(--group-synergy, 0) * 2deg + var(--global-tilt-y) * 20deg))
-    rotateY(calc((var(--card-focus-x) - 0.5) * 18deg + var(--group-synergy, 0) * -2deg + var(--global-tilt-x) * 20deg))
-    rotateZ(calc(var(--card-rotation-phase, 0) * 18deg + var(--global-warp) * 12deg))
+    translate3d(
+      calc(var(--card-parallax-x, 0) * -40px + var(--card-rotation-phase, 0) * -12px),
+      calc(var(--card-parallax-y, 0) * -34px + var(--card-rotation-phase, 0) * 10px),
+      calc(-36px + var(--card-focus-strength) * -18px - var(--group-synergy, 0) * 16px + var(--support-distance-z) * -0.6 + var(--card-canvas-depth, 0px) - var(--global-bend-intensity) * 28px)
+    )
+    rotateX(calc((0.5 - var(--card-focus-y)) * 18deg + var(--card-layout-offset-y, 0) * 20deg + var(--group-synergy, 0) * 2deg + var(--global-tilt-y) * 20deg))
+    rotateY(calc((var(--card-focus-x) - 0.5) * 18deg - var(--card-layout-offset-x, 0) * 22deg + var(--group-synergy, 0) * -2deg + var(--global-tilt-x) * 20deg))
+    rotateZ(calc(var(--global-warp) * 8deg))
     scale3d(
       calc(1 + var(--card-canvas-scale, 0) + var(--global-bend-intensity) * 0.04),
       calc(1 + var(--card-canvas-scale, 0) + var(--global-bend-intensity) * 0.04),


### PR DESCRIPTION
## Summary
- mix layout-derived tilt offsets into the orthogonal card CSS so each progression state scales tilt while exposing a tilt-extreme glow channel
- rebuild the section choreographer to sample card placement, blend pointer/device tilt with layout bias, and smooth updates across the background and non-focused cards
- extend card visualizers with transition phases that remap density, speed, chaos, and morph targets during approach, focus, exit, and far-depth states for coordinated choreography

## Testing
- node --check scripts/orthogonal-depth-progression.js

------
https://chatgpt.com/codex/tasks/task_e_68d70445076483299e0cd63f9d404e68